### PR TITLE
Small fixes to make DBFS work

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/client/ConfigLoader.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/client/ConfigLoader.java
@@ -95,8 +95,8 @@ public class ConfigLoader {
 
     private static Ini parseDatabricksCfg(DatabricksConfig cfg) {
         String configFile = cfg.getConfigFile();
-        configFile = configFile.replaceFirst("^~", System.getProperty("user.home"));
         boolean isDefaultConfig = configFile.equals(DatabricksConfig.DEFAULT_CONFIG_FILE);
+        configFile = configFile.replaceFirst("^~", System.getProperty("user.home"));
         Ini ini = new Ini();
         try {
             ini.load(new File(configFile));

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dbfs/DbfsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dbfs/DbfsAPI.java
@@ -2,7 +2,6 @@
 package com.databricks.sdk.service.dbfs;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.http.client.methods.*;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dbfs/DbfsService.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dbfs/DbfsService.java
@@ -1,7 +1,6 @@
 // Code generated from OpenAPI specs by Databricks SDK Generator. DO NOT EDIT.
 package com.databricks.sdk.service.dbfs;
 
-import java.util.List;
 import java.util.Map;
 
 /**


### PR DESCRIPTION
Fix incorrect order in ConfigLoader. This forces a user always to have a dbconfig ini file.
Fix incorrect usage of List in Dbfs API. This was using java.util.List instead of the local List class.