### PR TITLE
Added overloaded method signatures

### DIFF
--- a/.codegen/api.java.tmpl
+++ b/.codegen/api.java.tmpl
@@ -26,6 +26,15 @@ public class {{.PascalName}}API {
     impl = mock;
   }
 	{{range .Methods}}
+	{{if and .Request .Request.RequiredFields}}
+  public {{if .Response -}}{{template "type" .Response}}{{else}}void{{end}} {{.CamelName}}{{if .IsNameReserved}}Content{{end}}({{range $i, $p := .Request.RequiredFields -}}
+    {{if $i}}, {{end}}{{template "type" .Entity }} {{.CamelName}}{{if .IsNameReserved}}Value{{end}}
+  {{- end}}) {
+    {{if .Response -}}return {{end}}{{.CamelName}}{{if .IsNameReserved}}Content{{end}}(new {{.Request.PascalName}}(){{range .Request.RequiredFields}}
+      .set{{.PascalName}}({{.CamelName}}){{end}});
+  }
+  {{end}}
+
 	{{if .Description}}/**
    {{.Comment "   * " 80}}
    */{{end}}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BillableUsageAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BillableUsageAPI.java
@@ -21,6 +21,10 @@ public class BillableUsageAPI {
     impl = mock;
   }
 
+  public void download(String startMonth, String endMonth) {
+    download(new DownloadRequest().setStartMonth(startMonth).setEndMonth(endMonth));
+  }
+
   /**
    * Return billable usage logs.
    *

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BudgetsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BudgetsAPI.java
@@ -21,6 +21,10 @@ public class BudgetsAPI {
     impl = mock;
   }
 
+  public WrappedBudgetWithStatus create(Budget budget, String budgetId) {
+    return create(new WrappedBudget().setBudget(budget).setBudgetId(budgetId));
+  }
+
   /**
    * Create a new budget.
    *
@@ -30,6 +34,10 @@ public class BudgetsAPI {
     return impl.create(request);
   }
 
+  public void delete(String budgetId) {
+    delete(new DeleteBudgetRequest().setBudgetId(budgetId));
+  }
+
   /**
    * Delete budget.
    *
@@ -37,6 +45,10 @@ public class BudgetsAPI {
    */
   public void delete(DeleteBudgetRequest request) {
     impl.delete(request);
+  }
+
+  public WrappedBudgetWithStatus get(String budgetId) {
+    return get(new GetBudgetRequest().setBudgetId(budgetId));
   }
 
   /**
@@ -57,6 +69,10 @@ public class BudgetsAPI {
    */
   public BudgetList list() {
     return impl.list();
+  }
+
+  public void update(Budget budget, String budgetId) {
+    update(new WrappedBudget().setBudget(budget).setBudgetId(budgetId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/LogDeliveryAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/LogDeliveryAPI.java
@@ -105,6 +105,11 @@ public class LogDeliveryAPI {
     return impl.create(request);
   }
 
+  public WrappedLogDeliveryConfiguration get(String logDeliveryConfigurationId) {
+    return get(
+        new GetLogDeliveryRequest().setLogDeliveryConfigurationId(logDeliveryConfigurationId));
+  }
+
   /**
    * Get log delivery configuration.
    *
@@ -121,6 +126,13 @@ public class LogDeliveryAPI {
    */
   public WrappedLogDeliveryConfigurations list(ListLogDeliveryRequest request) {
     return impl.list(request);
+  }
+
+  public void patchStatus(LogDeliveryConfigStatus status, String logDeliveryConfigurationId) {
+    patchStatus(
+        new UpdateLogDeliveryConfigurationStatusRequest()
+            .setStatus(status)
+            .setLogDeliveryConfigurationId(logDeliveryConfigurationId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusterpolicies/ClusterPoliciesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusterpolicies/ClusterPoliciesAPI.java
@@ -40,6 +40,10 @@ public class ClusterPoliciesAPI {
     impl = mock;
   }
 
+  public CreatePolicyResponse create(String name) {
+    return create(new CreatePolicy().setName(name));
+  }
+
   /**
    * Create a new policy.
    *
@@ -47,6 +51,10 @@ public class ClusterPoliciesAPI {
    */
   public CreatePolicyResponse create(CreatePolicy request) {
     return impl.create(request);
+  }
+
+  public void delete(String policyId) {
+    delete(new DeletePolicy().setPolicyId(policyId));
   }
 
   /**
@@ -59,6 +67,10 @@ public class ClusterPoliciesAPI {
     impl.delete(request);
   }
 
+  public void edit(String policyId, String name) {
+    edit(new EditPolicy().setPolicyId(policyId).setName(name));
+  }
+
   /**
    * Update a cluster policy.
    *
@@ -67,6 +79,10 @@ public class ClusterPoliciesAPI {
    */
   public void edit(EditPolicy request) {
     impl.edit(request);
+  }
+
+  public Policy get(String policyId) {
+    return get(new Get().setPolicyId(policyId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusterpolicies/PolicyFamiliesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusterpolicies/PolicyFamiliesAPI.java
@@ -28,6 +28,10 @@ public class PolicyFamiliesAPI {
     impl = mock;
   }
 
+  public PolicyFamily get(String policyFamilyId) {
+    return get(new GetPolicyFamilyRequest().setPolicyFamilyId(policyFamilyId));
+  }
+
   public PolicyFamily get(GetPolicyFamilyRequest request) {
     return impl.get(request);
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusters/ClustersAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusters/ClustersAPI.java
@@ -42,6 +42,10 @@ public class ClustersAPI {
     impl = mock;
   }
 
+  public void changeOwner(String clusterId, String ownerUsername) {
+    changeOwner(new ChangeClusterOwner().setClusterId(clusterId).setOwnerUsername(ownerUsername));
+  }
+
   /**
    * Change cluster owner.
    *
@@ -49,6 +53,10 @@ public class ClustersAPI {
    */
   public void changeOwner(ChangeClusterOwner request) {
     impl.changeOwner(request);
+  }
+
+  public CreateClusterResponse create(String sparkVersion) {
+    return create(new CreateCluster().setSparkVersion(sparkVersion));
   }
 
   /**
@@ -69,6 +77,10 @@ public class ClustersAPI {
     return impl.create(request);
   }
 
+  public void delete(String clusterId) {
+    delete(new DeleteCluster().setClusterId(clusterId));
+  }
+
   /**
    * Terminate cluster.
    *
@@ -78,6 +90,10 @@ public class ClustersAPI {
    */
   public void delete(DeleteCluster request) {
     impl.delete(request);
+  }
+
+  public void edit(String clusterId, String sparkVersion) {
+    edit(new EditCluster().setClusterId(clusterId).setSparkVersion(sparkVersion));
   }
 
   /**
@@ -100,6 +116,10 @@ public class ClustersAPI {
     impl.edit(request);
   }
 
+  public GetEventsResponse events(String clusterId) {
+    return events(new GetEvents().setClusterId(clusterId));
+  }
+
   /**
    * List cluster activity events.
    *
@@ -109,6 +129,10 @@ public class ClustersAPI {
    */
   public GetEventsResponse events(GetEvents request) {
     return impl.events(request);
+  }
+
+  public ClusterInfo get(String clusterId) {
+    return get(new Get().setClusterId(clusterId));
   }
 
   /**
@@ -157,6 +181,10 @@ public class ClustersAPI {
     return impl.listZones();
   }
 
+  public void permanentDelete(String clusterId) {
+    permanentDelete(new PermanentDeleteCluster().setClusterId(clusterId));
+  }
+
   /**
    * Permanently delete cluster.
    *
@@ -170,6 +198,10 @@ public class ClustersAPI {
     impl.permanentDelete(request);
   }
 
+  public void pin(String clusterId) {
+    pin(new PinCluster().setClusterId(clusterId));
+  }
+
   /**
    * Pin cluster.
    *
@@ -181,6 +213,10 @@ public class ClustersAPI {
     impl.pin(request);
   }
 
+  public void resize(String clusterId) {
+    resize(new ResizeCluster().setClusterId(clusterId));
+  }
+
   /**
    * Resize cluster.
    *
@@ -189,6 +225,10 @@ public class ClustersAPI {
    */
   public void resize(ResizeCluster request) {
     impl.resize(request);
+  }
+
+  public void restart(String clusterId) {
+    restart(new RestartCluster().setClusterId(clusterId));
   }
 
   /**
@@ -211,6 +251,10 @@ public class ClustersAPI {
     return impl.sparkVersions();
   }
 
+  public void start(String clusterId) {
+    start(new StartCluster().setClusterId(clusterId));
+  }
+
   /**
    * Start terminated cluster.
    *
@@ -224,6 +268,10 @@ public class ClustersAPI {
    */
   public void start(StartCluster request) {
     impl.start(request);
+  }
+
+  public void unpin(String clusterId) {
+    unpin(new UnpinCluster().setClusterId(clusterId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusters/InstanceProfilesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusters/InstanceProfilesAPI.java
@@ -25,6 +25,10 @@ public class InstanceProfilesAPI {
     impl = mock;
   }
 
+  public void add(String instanceProfileArn) {
+    add(new AddInstanceProfile().setInstanceProfileArn(instanceProfileArn));
+  }
+
   /**
    * Register an instance profile.
    *
@@ -33,6 +37,10 @@ public class InstanceProfilesAPI {
    */
   public void add(AddInstanceProfile request) {
     impl.add(request);
+  }
+
+  public void edit(String instanceProfileArn) {
+    edit(new InstanceProfile().setInstanceProfileArn(instanceProfileArn));
   }
 
   /**
@@ -65,6 +73,10 @@ public class InstanceProfilesAPI {
    */
   public ListInstanceProfilesResponse list() {
     return impl.list();
+  }
+
+  public void remove(String instanceProfileArn) {
+    remove(new RemoveInstanceProfile().setInstanceProfileArn(instanceProfileArn));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/commands/CommandExecutionAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/commands/CommandExecutionAPI.java
@@ -31,6 +31,14 @@ public class CommandExecutionAPI {
     impl.cancel(request);
   }
 
+  public CommandStatusResponse commandStatus(String clusterId, String contextId, String commandId) {
+    return commandStatus(
+        new CommandStatusRequest()
+            .setClusterId(clusterId)
+            .setContextId(contextId)
+            .setCommandId(commandId));
+  }
+
   /**
    * Get command info.
    *
@@ -40,6 +48,11 @@ public class CommandExecutionAPI {
    */
   public CommandStatusResponse commandStatus(CommandStatusRequest request) {
     return impl.commandStatus(request);
+  }
+
+  public ContextStatusResponse contextStatus(String clusterId, String contextId) {
+    return contextStatus(
+        new ContextStatusRequest().setClusterId(clusterId).setContextId(contextId));
   }
 
   /**
@@ -60,6 +73,10 @@ public class CommandExecutionAPI {
    */
   public Created create(CreateContext request) {
     return impl.create(request);
+  }
+
+  public void destroy(String clusterId, String contextId) {
+    destroy(new DestroyContext().setClusterId(clusterId).setContextId(contextId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dbfs/DbfsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dbfs/DbfsAPI.java
@@ -22,6 +22,10 @@ public class DbfsAPI {
     impl = mock;
   }
 
+  public void addBlock(long handle, String data) {
+    addBlock(new AddBlock().setHandle(handle).setData(data));
+  }
+
   /**
    * Append data block.
    *
@@ -35,6 +39,10 @@ public class DbfsAPI {
     impl.addBlock(request);
   }
 
+  public void close(long handle) {
+    close(new Close().setHandle(handle));
+  }
+
   /**
    * Close the stream.
    *
@@ -43,6 +51,10 @@ public class DbfsAPI {
    */
   public void close(Close request) {
     impl.close(request);
+  }
+
+  public CreateResponse create(String path) {
+    return create(new Create().setPath(path));
   }
 
   /**
@@ -59,6 +71,10 @@ public class DbfsAPI {
    */
   public CreateResponse create(Create request) {
     return impl.create(request);
+  }
+
+  public void delete(String path) {
+    delete(new Delete().setPath(path));
   }
 
   /**
@@ -84,6 +100,10 @@ public class DbfsAPI {
     impl.delete(request);
   }
 
+  public FileInfo getStatus(String path) {
+    return getStatus(new GetStatus().setPath(path));
+  }
+
   /**
    * Get the information of a file or directory.
    *
@@ -92,6 +112,10 @@ public class DbfsAPI {
    */
   public FileInfo getStatus(GetStatus request) {
     return impl.getStatus(request);
+  }
+
+  public ListStatusResponse list(String path) {
+    return list(new List().setPath(path));
   }
 
   /**
@@ -111,6 +135,10 @@ public class DbfsAPI {
     return impl.list(request);
   }
 
+  public void mkdirs(String path) {
+    mkdirs(new MkDirs().setPath(path));
+  }
+
   /**
    * Create a directory.
    *
@@ -123,6 +151,10 @@ public class DbfsAPI {
     impl.mkdirs(request);
   }
 
+  public void move(String sourcePath, String destinationPath) {
+    move(new Move().setSourcePath(sourcePath).setDestinationPath(destinationPath));
+  }
+
   /**
    * Move a file.
    *
@@ -133,6 +165,10 @@ public class DbfsAPI {
    */
   public void move(Move request) {
     impl.move(request);
+  }
+
+  public void put(String path) {
+    put(new Put().setPath(path));
   }
 
   /**
@@ -151,6 +187,10 @@ public class DbfsAPI {
    */
   public void put(Put request) {
     impl.put(request);
+  }
+
+  public ReadResponse read(String path) {
+    return read(new Read().setPath(path));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/CredentialsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/CredentialsAPI.java
@@ -24,6 +24,13 @@ public class CredentialsAPI {
     impl = mock;
   }
 
+  public Credential create(String credentialsName, CreateCredentialAwsCredentials awsCredentials) {
+    return create(
+        new CreateCredentialRequest()
+            .setCredentialsName(credentialsName)
+            .setAwsCredentials(awsCredentials));
+  }
+
   /**
    * Create credential configuration.
    *
@@ -46,6 +53,10 @@ public class CredentialsAPI {
     return impl.create(request);
   }
 
+  public void delete(String credentialsId) {
+    delete(new DeleteCredentialRequest().setCredentialsId(credentialsId));
+  }
+
   /**
    * Delete credential configuration.
    *
@@ -54,6 +65,10 @@ public class CredentialsAPI {
    */
   public void delete(DeleteCredentialRequest request) {
     impl.delete(request);
+  }
+
+  public Credential get(String credentialsId) {
+    return get(new GetCredentialRequest().setCredentialsId(credentialsId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/EncryptionKeysAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/EncryptionKeysAPI.java
@@ -33,6 +33,11 @@ public class EncryptionKeysAPI {
     impl = mock;
   }
 
+  public CustomerManagedKey create(CreateAwsKeyInfo awsKeyInfo, List<KeyUseCase> useCases) {
+    return create(
+        new CreateCustomerManagedKeyRequest().setAwsKeyInfo(awsKeyInfo).setUseCases(useCases));
+  }
+
   /**
    * Create encryption key configuration.
    *
@@ -54,6 +59,10 @@ public class EncryptionKeysAPI {
     return impl.create(request);
   }
 
+  public void delete(String customerManagedKeyId) {
+    delete(new DeleteEncryptionKeyRequest().setCustomerManagedKeyId(customerManagedKeyId));
+  }
+
   /**
    * Delete encryption key configuration.
    *
@@ -62,6 +71,10 @@ public class EncryptionKeysAPI {
    */
   public void delete(DeleteEncryptionKeyRequest request) {
     impl.delete(request);
+  }
+
+  public CustomerManagedKey get(String customerManagedKeyId) {
+    return get(new GetEncryptionKeyRequest().setCustomerManagedKeyId(customerManagedKeyId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/NetworksAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/NetworksAPI.java
@@ -22,6 +22,10 @@ public class NetworksAPI {
     impl = mock;
   }
 
+  public Network create(String networkName) {
+    return create(new CreateNetworkRequest().setNetworkName(networkName));
+  }
+
   /**
    * Create network configuration.
    *
@@ -30,6 +34,10 @@ public class NetworksAPI {
    */
   public Network create(CreateNetworkRequest request) {
     return impl.create(request);
+  }
+
+  public void delete(String networkId) {
+    delete(new DeleteNetworkRequest().setNetworkId(networkId));
   }
 
   /**
@@ -42,6 +50,10 @@ public class NetworksAPI {
    */
   public void delete(DeleteNetworkRequest request) {
     impl.delete(request);
+  }
+
+  public Network get(String networkId) {
+    return get(new GetNetworkRequest().setNetworkId(networkId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/PrivateAccessAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/PrivateAccessAPI.java
@@ -29,6 +29,15 @@ public class PrivateAccessAPI {
     impl = mock;
   }
 
+  public PrivateAccessSettings create(
+      String privateAccessSettingsName, String region, String privateAccessSettingsId) {
+    return create(
+        new UpsertPrivateAccessSettingsRequest()
+            .setPrivateAccessSettingsName(privateAccessSettingsName)
+            .setRegion(region)
+            .setPrivateAccessSettingsId(privateAccessSettingsId));
+  }
+
   /**
    * Create private access settings.
    *
@@ -50,6 +59,10 @@ public class PrivateAccessAPI {
     return impl.create(request);
   }
 
+  public void delete(String privateAccessSettingsId) {
+    delete(new DeletePrivateAccesRequest().setPrivateAccessSettingsId(privateAccessSettingsId));
+  }
+
   /**
    * Delete a private access settings object.
    *
@@ -64,6 +77,10 @@ public class PrivateAccessAPI {
    */
   public void delete(DeletePrivateAccesRequest request) {
     impl.delete(request);
+  }
+
+  public PrivateAccessSettings get(String privateAccessSettingsId) {
+    return get(new GetPrivateAccesRequest().setPrivateAccessSettingsId(privateAccessSettingsId));
   }
 
   /**
@@ -89,6 +106,15 @@ public class PrivateAccessAPI {
    */
   public List<PrivateAccessSettings> list() {
     return impl.list();
+  }
+
+  public void replace(
+      String privateAccessSettingsName, String region, String privateAccessSettingsId) {
+    replace(
+        new UpsertPrivateAccessSettingsRequest()
+            .setPrivateAccessSettingsName(privateAccessSettingsName)
+            .setRegion(region)
+            .setPrivateAccessSettingsId(privateAccessSettingsId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/StorageAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/StorageAPI.java
@@ -25,6 +25,14 @@ public class StorageAPI {
     impl = mock;
   }
 
+  public StorageConfiguration create(
+      String storageConfigurationName, RootBucketInfo rootBucketInfo) {
+    return create(
+        new CreateStorageConfigurationRequest()
+            .setStorageConfigurationName(storageConfigurationName)
+            .setRootBucketInfo(rootBucketInfo));
+  }
+
   /**
    * Create new storage configuration.
    *
@@ -43,6 +51,10 @@ public class StorageAPI {
     return impl.create(request);
   }
 
+  public void delete(String storageConfigurationId) {
+    delete(new DeleteStorageRequest().setStorageConfigurationId(storageConfigurationId));
+  }
+
   /**
    * Delete storage configuration.
    *
@@ -51,6 +63,10 @@ public class StorageAPI {
    */
   public void delete(DeleteStorageRequest request) {
     impl.delete(request);
+  }
+
+  public StorageConfiguration get(String storageConfigurationId) {
+    return get(new GetStorageRequest().setStorageConfigurationId(storageConfigurationId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/VpcEndpointsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/VpcEndpointsAPI.java
@@ -30,6 +30,14 @@ public class VpcEndpointsAPI {
     impl = mock;
   }
 
+  public VpcEndpoint create(String vpcEndpointName, String awsVpcEndpointId, String region) {
+    return create(
+        new CreateVpcEndpointRequest()
+            .setVpcEndpointName(vpcEndpointName)
+            .setAwsVpcEndpointId(awsVpcEndpointId)
+            .setRegion(region));
+  }
+
   /**
    * Create VPC endpoint configuration.
    *
@@ -52,6 +60,10 @@ public class VpcEndpointsAPI {
     return impl.create(request);
   }
 
+  public void delete(String vpcEndpointId) {
+    delete(new DeleteVpcEndpointRequest().setVpcEndpointId(vpcEndpointId));
+  }
+
   /**
    * Delete VPC endpoint configuration.
    *
@@ -70,6 +82,10 @@ public class VpcEndpointsAPI {
    */
   public void delete(DeleteVpcEndpointRequest request) {
     impl.delete(request);
+  }
+
+  public VpcEndpoint get(String vpcEndpointId) {
+    return get(new GetVpcEndpointRequest().setVpcEndpointId(vpcEndpointId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/WorkspacesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/WorkspacesAPI.java
@@ -27,6 +27,10 @@ public class WorkspacesAPI {
     impl = mock;
   }
 
+  public Workspace create(String workspaceName) {
+    return create(new CreateWorkspaceRequest().setWorkspaceName(workspaceName));
+  }
+
   /**
    * Create a new workspace.
    *
@@ -43,6 +47,10 @@ public class WorkspacesAPI {
     return impl.create(request);
   }
 
+  public void delete(long workspaceId) {
+    delete(new DeleteWorkspaceRequest().setWorkspaceId(workspaceId));
+  }
+
   /**
    * Delete a workspace.
    *
@@ -55,6 +63,10 @@ public class WorkspacesAPI {
    */
   public void delete(DeleteWorkspaceRequest request) {
     impl.delete(request);
+  }
+
+  public Workspace get(long workspaceId) {
+    return get(new GetWorkspaceRequest().setWorkspaceId(workspaceId));
   }
 
   /**
@@ -88,6 +100,10 @@ public class WorkspacesAPI {
    */
   public List<Workspace> list() {
     return impl.list();
+  }
+
+  public void update(long workspaceId) {
+    update(new UpdateWorkspaceRequest().setWorkspaceId(workspaceId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/endpoints/ServingEndpointsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/endpoints/ServingEndpointsAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.endpoints;
 
 import com.databricks.sdk.client.ApiClient;
+import java.util.List;
 import org.apache.http.client.methods.*;
 
 /**
@@ -29,6 +30,10 @@ public class ServingEndpointsAPI {
     impl = mock;
   }
 
+  public BuildLogsResponse buildLogs(String name, String servedModelName) {
+    return buildLogs(new BuildLogsRequest().setName(name).setServedModelName(servedModelName));
+  }
+
   /**
    * Retrieve the logs associated with building the model's environment for a given serving
    * endpoint's served model.
@@ -39,14 +44,26 @@ public class ServingEndpointsAPI {
     return impl.buildLogs(request);
   }
 
+  public ServingEndpointDetailed create(String name, EndpointCoreConfigInput config) {
+    return create(new CreateServingEndpoint().setName(name).setConfig(config));
+  }
+
   /** Create a new serving endpoint. */
   public ServingEndpointDetailed create(CreateServingEndpoint request) {
     return impl.create(request);
   }
 
+  public void delete(String name) {
+    delete(new DeleteServingEndpointRequest().setName(name));
+  }
+
   /** Delete a serving endpoint. */
   public void delete(DeleteServingEndpointRequest request) {
     impl.delete(request);
+  }
+
+  public void exportMetrics(String name) {
+    exportMetrics(new ExportMetricsRequest().setName(name));
   }
 
   /**
@@ -58,6 +75,10 @@ public class ServingEndpointsAPI {
    */
   public void exportMetrics(ExportMetricsRequest request) {
     impl.exportMetrics(request);
+  }
+
+  public ServingEndpointDetailed get(String name) {
+    return get(new GetServingEndpointRequest().setName(name));
   }
 
   /**
@@ -74,6 +95,10 @@ public class ServingEndpointsAPI {
     return impl.list();
   }
 
+  public ServerLogsResponse logs(String name, String servedModelName) {
+    return logs(new LogsRequest().setName(name).setServedModelName(servedModelName));
+  }
+
   /**
    * Retrieve the most recent log lines associated with a given serving endpoint's served model.
    *
@@ -83,9 +108,17 @@ public class ServingEndpointsAPI {
     return impl.logs(request);
   }
 
+  public QueryEndpointResponse query(String name) {
+    return query(new QueryRequest().setName(name));
+  }
+
   /** Query a serving endpoint with provided model input. */
   public QueryEndpointResponse query(QueryRequest request) {
     return impl.query(request);
+  }
+
+  public ServingEndpointDetailed updateConfig(List<ServedModelInput> servedModels, String name) {
+    return updateConfig(new EndpointCoreConfigInput().setServedModels(servedModels).setName(name));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/gitcredentials/GitCredentialsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/gitcredentials/GitCredentialsAPI.java
@@ -24,6 +24,10 @@ public class GitCredentialsAPI {
     impl = mock;
   }
 
+  public CreateCredentialsResponse create(String gitProvider) {
+    return create(new CreateCredentials().setGitProvider(gitProvider));
+  }
+
   /**
    * Create a credential entry.
    *
@@ -35,6 +39,10 @@ public class GitCredentialsAPI {
     return impl.create(request);
   }
 
+  public void delete(long credentialId) {
+    delete(new Delete().setCredentialId(credentialId));
+  }
+
   /**
    * Delete a credential.
    *
@@ -42,6 +50,10 @@ public class GitCredentialsAPI {
    */
   public void delete(Delete request) {
     impl.delete(request);
+  }
+
+  public CredentialInfo get(long credentialId) {
+    return get(new Get().setCredentialId(credentialId));
   }
 
   /**
@@ -60,6 +72,10 @@ public class GitCredentialsAPI {
    */
   public GetCredentialsResponse list() {
     return impl.list();
+  }
+
+  public void update(long credentialId) {
+    update(new UpdateCredentials().setCredentialId(credentialId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/globalinitscripts/GlobalInitScriptsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/globalinitscripts/GlobalInitScriptsAPI.java
@@ -26,6 +26,10 @@ public class GlobalInitScriptsAPI {
     impl = mock;
   }
 
+  public CreateResponse create(String name, String script) {
+    return create(new GlobalInitScriptCreateRequest().setName(name).setScript(script));
+  }
+
   /**
    * Create init script.
    *
@@ -35,6 +39,10 @@ public class GlobalInitScriptsAPI {
     return impl.create(request);
   }
 
+  public void delete(String scriptId) {
+    delete(new Delete().setScriptId(scriptId));
+  }
+
   /**
    * Delete init script.
    *
@@ -42,6 +50,10 @@ public class GlobalInitScriptsAPI {
    */
   public void delete(Delete request) {
     impl.delete(request);
+  }
+
+  public GlobalInitScriptDetailsWithContent get(String scriptId) {
+    return get(new Get().setScriptId(scriptId));
   }
 
   /**
@@ -62,6 +74,11 @@ public class GlobalInitScriptsAPI {
    */
   public ListGlobalInitScriptsResponse list() {
     return impl.list();
+  }
+
+  public void update(String name, String script, String scriptId) {
+    update(
+        new GlobalInitScriptUpdateRequest().setName(name).setScript(script).setScriptId(scriptId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/instancepools/InstancePoolsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/instancepools/InstancePoolsAPI.java
@@ -34,6 +34,11 @@ public class InstancePoolsAPI {
     impl = mock;
   }
 
+  public CreateInstancePoolResponse create(String instancePoolName, String nodeTypeId) {
+    return create(
+        new CreateInstancePool().setInstancePoolName(instancePoolName).setNodeTypeId(nodeTypeId));
+  }
+
   /**
    * Create a new instance pool.
    *
@@ -41,6 +46,10 @@ public class InstancePoolsAPI {
    */
   public CreateInstancePoolResponse create(CreateInstancePool request) {
     return impl.create(request);
+  }
+
+  public void delete(String instancePoolId) {
+    delete(new DeleteInstancePool().setInstancePoolId(instancePoolId));
   }
 
   /**
@@ -53,6 +62,14 @@ public class InstancePoolsAPI {
     impl.delete(request);
   }
 
+  public void edit(String instancePoolId, String instancePoolName, String nodeTypeId) {
+    edit(
+        new EditInstancePool()
+            .setInstancePoolId(instancePoolId)
+            .setInstancePoolName(instancePoolName)
+            .setNodeTypeId(nodeTypeId));
+  }
+
   /**
    * Edit an existing instance pool.
    *
@@ -60,6 +77,10 @@ public class InstancePoolsAPI {
    */
   public void edit(EditInstancePool request) {
     impl.edit(request);
+  }
+
+  public GetInstancePool get(String instancePoolId) {
+    return get(new Get().setInstancePoolId(instancePoolId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ipaccesslists/IpAccessListsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ipaccesslists/IpAccessListsAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.ipaccesslists;
 
 import com.databricks.sdk.client.ApiClient;
+import java.util.List;
 import org.apache.http.client.methods.*;
 
 /**
@@ -38,6 +39,12 @@ public class IpAccessListsAPI {
     impl = mock;
   }
 
+  public CreateIpAccessListResponse create(
+      String label, ListType listType, List<String> ipAddresses) {
+    return create(
+        new CreateIpAccessList().setLabel(label).setListType(listType).setIpAddresses(ipAddresses));
+  }
+
   /**
    * Create access list.
    *
@@ -60,6 +67,10 @@ public class IpAccessListsAPI {
     return impl.create(request);
   }
 
+  public void delete(String ipAccessListId) {
+    delete(new Delete().setIpAccessListId(ipAccessListId));
+  }
+
   /**
    * Delete access list.
    *
@@ -67,6 +78,10 @@ public class IpAccessListsAPI {
    */
   public void delete(Delete request) {
     impl.delete(request);
+  }
+
+  public FetchIpAccessListResponse get(String ipAccessListId) {
+    return get(new Get().setIpAccessListId(ipAccessListId));
   }
 
   /**
@@ -87,6 +102,21 @@ public class IpAccessListsAPI {
     return impl.list();
   }
 
+  public void replace(
+      String label,
+      ListType listType,
+      List<String> ipAddresses,
+      boolean enabled,
+      String ipAccessListId) {
+    replace(
+        new ReplaceIpAccessList()
+            .setLabel(label)
+            .setListType(listType)
+            .setIpAddresses(ipAddresses)
+            .setEnabled(enabled)
+            .setIpAccessListId(ipAccessListId));
+  }
+
   /**
    * Replace access list.
    *
@@ -103,6 +133,21 @@ public class IpAccessListsAPI {
    */
   public void replace(ReplaceIpAccessList request) {
     impl.replace(request);
+  }
+
+  public void update(
+      String label,
+      ListType listType,
+      List<String> ipAddresses,
+      boolean enabled,
+      String ipAccessListId) {
+    update(
+        new UpdateIpAccessList()
+            .setLabel(label)
+            .setListType(listType)
+            .setIpAddresses(ipAddresses)
+            .setEnabled(enabled)
+            .setIpAccessListId(ipAccessListId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/JobsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/JobsAPI.java
@@ -36,6 +36,10 @@ public class JobsAPI {
     impl = mock;
   }
 
+  public void cancelAllRuns(long jobId) {
+    cancelAllRuns(new CancelAllRuns().setJobId(jobId));
+  }
+
   /**
    * Cancel all runs of a job.
    *
@@ -44,6 +48,10 @@ public class JobsAPI {
    */
   public void cancelAllRuns(CancelAllRuns request) {
     impl.cancelAllRuns(request);
+  }
+
+  public void cancelRun(long runId) {
+    cancelRun(new CancelRun().setRunId(runId));
   }
 
   /**
@@ -65,6 +73,10 @@ public class JobsAPI {
     return impl.create(request);
   }
 
+  public void delete(long jobId) {
+    delete(new DeleteJob().setJobId(jobId));
+  }
+
   /**
    * Delete a job.
    *
@@ -72,6 +84,10 @@ public class JobsAPI {
    */
   public void delete(DeleteJob request) {
     impl.delete(request);
+  }
+
+  public void deleteRun(long runId) {
+    deleteRun(new DeleteRun().setRunId(runId));
   }
 
   /**
@@ -83,6 +99,10 @@ public class JobsAPI {
     impl.deleteRun(request);
   }
 
+  public ExportRunOutput exportRun(long runId) {
+    return exportRun(new ExportRun().setRunId(runId));
+  }
+
   /**
    * Export and retrieve a job run.
    *
@@ -90,6 +110,10 @@ public class JobsAPI {
    */
   public ExportRunOutput exportRun(ExportRun request) {
     return impl.exportRun(request);
+  }
+
+  public Job get(long jobId) {
+    return get(new Get().setJobId(jobId));
   }
 
   /**
@@ -101,6 +125,10 @@ public class JobsAPI {
     return impl.get(request);
   }
 
+  public Run getRun(long runId) {
+    return getRun(new GetRun().setRunId(runId));
+  }
+
   /**
    * Get a single job run.
    *
@@ -108,6 +136,10 @@ public class JobsAPI {
    */
   public Run getRun(GetRun request) {
     return impl.getRun(request);
+  }
+
+  public RunOutput getRunOutput(long runId) {
+    return getRunOutput(new GetRunOutput().setRunId(runId));
   }
 
   /**
@@ -145,6 +177,10 @@ public class JobsAPI {
     return impl.listRuns(request);
   }
 
+  public RepairRunResponse repairRun(long runId) {
+    return repairRun(new RepairRun().setRunId(runId));
+  }
+
   /**
    * Repair a job run.
    *
@@ -155,6 +191,10 @@ public class JobsAPI {
     return impl.repairRun(request);
   }
 
+  public void reset(long jobId, JobSettings newSettings) {
+    reset(new ResetJob().setJobId(jobId).setNewSettings(newSettings));
+  }
+
   /**
    * Overwrites all settings for a job.
    *
@@ -163,6 +203,10 @@ public class JobsAPI {
    */
   public void reset(ResetJob request) {
     impl.reset(request);
+  }
+
+  public RunNowResponse runNow(long jobId) {
+    return runNow(new RunNow().setJobId(jobId));
   }
 
   /**
@@ -183,6 +227,10 @@ public class JobsAPI {
    */
   public SubmitRunResponse submit(SubmitRun request) {
     return impl.submit(request);
+  }
+
+  public void update(long jobId) {
+    update(new UpdateJob().setJobId(jobId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/libraries/LibrariesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/libraries/LibrariesAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.libraries;
 
 import com.databricks.sdk.client.ApiClient;
+import java.util.List;
 import org.apache.http.client.methods.*;
 
 /**
@@ -49,6 +50,10 @@ public class LibrariesAPI {
     return impl.allClusterStatuses();
   }
 
+  public ClusterLibraryStatuses clusterStatus(String clusterId) {
+    return clusterStatus(new ClusterStatus().setClusterId(clusterId));
+  }
+
   /**
    * Get status.
    *
@@ -70,6 +75,10 @@ public class LibrariesAPI {
     return impl.clusterStatus(request);
   }
 
+  public void install(String clusterId, List<Library> libraries) {
+    install(new InstallLibraries().setClusterId(clusterId).setLibraries(libraries));
+  }
+
   /**
    * Add a library.
    *
@@ -82,6 +91,10 @@ public class LibrariesAPI {
    */
   public void install(InstallLibraries request) {
     impl.install(request);
+  }
+
+  public void uninstall(String clusterId, List<Library> libraries) {
+    uninstall(new UninstallLibraries().setClusterId(clusterId).setLibraries(libraries));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ExperimentsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ExperimentsAPI.java
@@ -17,6 +17,10 @@ public class ExperimentsAPI {
     impl = mock;
   }
 
+  public CreateExperimentResponse create(String name) {
+    return create(new CreateExperiment().setName(name));
+  }
+
   /**
    * Create experiment.
    *
@@ -30,6 +34,10 @@ public class ExperimentsAPI {
     return impl.create(request);
   }
 
+  public void delete(String experimentId) {
+    delete(new DeleteExperiment().setExperimentId(experimentId));
+  }
+
   /**
    * Delete an experiment.
    *
@@ -40,6 +48,10 @@ public class ExperimentsAPI {
     impl.delete(request);
   }
 
+  public Experiment get(String experimentId) {
+    return get(new GetExperimentRequest().setExperimentId(experimentId));
+  }
+
   /**
    * Get an experiment.
    *
@@ -47,6 +59,10 @@ public class ExperimentsAPI {
    */
   public Experiment get(GetExperimentRequest request) {
     return impl.get(request);
+  }
+
+  public GetExperimentByNameResponse getByName(String experimentName) {
+    return getByName(new GetByNameRequest().setExperimentName(experimentName));
   }
 
   /**
@@ -73,6 +89,10 @@ public class ExperimentsAPI {
     return impl.list(request);
   }
 
+  public void restore(String experimentId) {
+    restore(new RestoreExperiment().setExperimentId(experimentId));
+  }
+
   /**
    * Restores an experiment.
    *
@@ -96,6 +116,11 @@ public class ExperimentsAPI {
     return impl.search(request);
   }
 
+  public void setExperimentTag(String experimentId, String key, String value) {
+    setExperimentTag(
+        new SetExperimentTag().setExperimentId(experimentId).setKey(key).setValue(value));
+  }
+
   /**
    * Set a tag.
    *
@@ -103,6 +128,10 @@ public class ExperimentsAPI {
    */
   public void setExperimentTag(SetExperimentTag request) {
     impl.setExperimentTag(request);
+  }
+
+  public void update(String experimentId) {
+    update(new UpdateExperiment().setExperimentId(experimentId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowDatabricksAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowDatabricksAPI.java
@@ -21,6 +21,10 @@ public class MLflowDatabricksAPI {
     impl = mock;
   }
 
+  public GetResponse get(String name) {
+    return get(new GetMLflowDatabrickRequest().setName(name));
+  }
+
   /**
    * Get model.
    *
@@ -32,6 +36,16 @@ public class MLflowDatabricksAPI {
    */
   public GetResponse get(GetMLflowDatabrickRequest request) {
     return impl.get(request);
+  }
+
+  public TransitionStageResponse transitionStage(
+      String name, String version, Stage stage, boolean archiveExistingVersions) {
+    return transitionStage(
+        new TransitionModelVersionStageDatabricks()
+            .setName(name)
+            .setVersion(version)
+            .setStage(stage)
+            .setArchiveExistingVersions(archiveExistingVersions));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowMetricsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowMetricsAPI.java
@@ -17,6 +17,10 @@ public class MLflowMetricsAPI {
     impl = mock;
   }
 
+  public GetMetricHistoryResponse getHistory(String metricKey) {
+    return getHistory(new GetHistoryRequest().setMetricKey(metricKey));
+  }
+
   /**
    * Get history of a given metric within a run.
    *

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowRunsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowRunsAPI.java
@@ -28,6 +28,10 @@ public class MLflowRunsAPI {
     return impl.create(request);
   }
 
+  public void delete(String runId) {
+    delete(new DeleteRun().setRunId(runId));
+  }
+
   /**
    * Delete a run.
    *
@@ -35,6 +39,10 @@ public class MLflowRunsAPI {
    */
   public void delete(DeleteRun request) {
     impl.delete(request);
+  }
+
+  public void deleteTag(String runId, String key) {
+    deleteTag(new DeleteTag().setRunId(runId).setKey(key));
   }
 
   /**
@@ -45,6 +53,10 @@ public class MLflowRunsAPI {
    */
   public void deleteTag(DeleteTag request) {
     impl.deleteTag(request);
+  }
+
+  public GetRunResponse get(String runId) {
+    return get(new GetRunRequest().setRunId(runId));
   }
 
   /**
@@ -103,6 +115,10 @@ public class MLflowRunsAPI {
     impl.logBatch(request);
   }
 
+  public void logMetric(String key, float value, long timestamp) {
+    logMetric(new LogMetric().setKey(key).setValue(value).setTimestamp(timestamp));
+  }
+
   /**
    * Log a metric.
    *
@@ -124,6 +140,10 @@ public class MLflowRunsAPI {
     impl.logModel(request);
   }
 
+  public void logParameter(String key, String value) {
+    logParameter(new LogParam().setKey(key).setValue(value));
+  }
+
   /**
    * Log a param.
    *
@@ -133,6 +153,10 @@ public class MLflowRunsAPI {
    */
   public void logParameter(LogParam request) {
     impl.logParameter(request);
+  }
+
+  public void restore(String runId) {
+    restore(new RestoreRun().setRunId(runId));
   }
 
   /**
@@ -153,6 +177,10 @@ public class MLflowRunsAPI {
    */
   public SearchRunsResponse search(SearchRuns request) {
     return impl.search(request);
+  }
+
+  public void setTag(String key, String value) {
+    setTag(new SetTag().setKey(key).setValue(value));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ModelVersionCommentsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ModelVersionCommentsAPI.java
@@ -17,6 +17,10 @@ public class ModelVersionCommentsAPI {
     impl = mock;
   }
 
+  public CreateResponse create(String name, String version, String comment) {
+    return create(new CreateComment().setName(name).setVersion(version).setComment(comment));
+  }
+
   /**
    * Post a comment.
    *
@@ -28,6 +32,10 @@ public class ModelVersionCommentsAPI {
     return impl.create(request);
   }
 
+  public void delete(String id) {
+    delete(new DeleteModelVersionCommentRequest().setId(id));
+  }
+
   /**
    * Delete a comment.
    *
@@ -35,6 +43,10 @@ public class ModelVersionCommentsAPI {
    */
   public void delete(DeleteModelVersionCommentRequest request) {
     impl.delete(request);
+  }
+
+  public UpdateResponse update(String id, String comment) {
+    return update(new UpdateComment().setId(id).setComment(comment));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ModelVersionsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ModelVersionsAPI.java
@@ -17,6 +17,10 @@ public class ModelVersionsAPI {
     impl = mock;
   }
 
+  public CreateModelVersionResponse create(String name, String source) {
+    return create(new CreateModelVersionRequest().setName(name).setSource(source));
+  }
+
   /**
    * Create a model version.
    *
@@ -24,6 +28,10 @@ public class ModelVersionsAPI {
    */
   public CreateModelVersionResponse create(CreateModelVersionRequest request) {
     return impl.create(request);
+  }
+
+  public void delete(String name, String version) {
+    delete(new DeleteModelVersionRequest().setName(name).setVersion(version));
   }
 
   /**
@@ -35,6 +43,10 @@ public class ModelVersionsAPI {
     impl.delete(request);
   }
 
+  public void deleteTag(String name, String version, String key) {
+    deleteTag(new DeleteModelVersionTagRequest().setName(name).setVersion(version).setKey(key));
+  }
+
   /**
    * Delete a model version tag.
    *
@@ -44,6 +56,10 @@ public class ModelVersionsAPI {
     impl.deleteTag(request);
   }
 
+  public GetModelVersionResponse get(String name, String version) {
+    return get(new GetModelVersionRequest().setName(name).setVersion(version));
+  }
+
   /**
    * Get a model version.
    *
@@ -51,6 +67,11 @@ public class ModelVersionsAPI {
    */
   public GetModelVersionResponse get(GetModelVersionRequest request) {
     return impl.get(request);
+  }
+
+  public GetModelVersionDownloadUriResponse getDownloadUri(String name, String version) {
+    return getDownloadUri(
+        new GetModelVersionDownloadUriRequest().setName(name).setVersion(version));
   }
 
   /**
@@ -72,6 +93,15 @@ public class ModelVersionsAPI {
     return impl.search(request);
   }
 
+  public void setTag(String name, String version, String key, String value) {
+    setTag(
+        new SetModelVersionTagRequest()
+            .setName(name)
+            .setVersion(version)
+            .setKey(key)
+            .setValue(value));
+  }
+
   /**
    * Set a version tag.
    *
@@ -81,6 +111,16 @@ public class ModelVersionsAPI {
     impl.setTag(request);
   }
 
+  public TransitionModelVersionStageResponse transitionStage(
+      String name, String version, String stage, boolean archiveExistingVersions) {
+    return transitionStage(
+        new TransitionModelVersionStage()
+            .setName(name)
+            .setVersion(version)
+            .setStage(stage)
+            .setArchiveExistingVersions(archiveExistingVersions));
+  }
+
   /**
    * Transition a stage.
    *
@@ -88,6 +128,10 @@ public class ModelVersionsAPI {
    */
   public TransitionModelVersionStageResponse transitionStage(TransitionModelVersionStage request) {
     return impl.transitionStage(request);
+  }
+
+  public void update(String name, String version) {
+    update(new UpdateModelVersionRequest().setName(name).setVersion(version));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/RegisteredModelsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/RegisteredModelsAPI.java
@@ -17,6 +17,10 @@ public class RegisteredModelsAPI {
     impl = mock;
   }
 
+  public CreateRegisteredModelResponse create(String name) {
+    return create(new CreateRegisteredModelRequest().setName(name));
+  }
+
   /**
    * Create a model.
    *
@@ -28,6 +32,10 @@ public class RegisteredModelsAPI {
     return impl.create(request);
   }
 
+  public void delete(String name) {
+    delete(new DeleteRegisteredModelRequest().setName(name));
+  }
+
   /**
    * Delete a model.
    *
@@ -35,6 +43,10 @@ public class RegisteredModelsAPI {
    */
   public void delete(DeleteRegisteredModelRequest request) {
     impl.delete(request);
+  }
+
+  public void deleteTag(String name, String key) {
+    deleteTag(new DeleteRegisteredModelTagRequest().setName(name).setKey(key));
   }
 
   /**
@@ -46,6 +58,10 @@ public class RegisteredModelsAPI {
     impl.deleteTag(request);
   }
 
+  public GetRegisteredModelResponse get(String name) {
+    return get(new GetRegisteredModelRequest().setName(name));
+  }
+
   /**
    * Get a model.
    *
@@ -53,6 +69,10 @@ public class RegisteredModelsAPI {
    */
   public GetRegisteredModelResponse get(GetRegisteredModelRequest request) {
     return impl.get(request);
+  }
+
+  public GetLatestVersionsResponse getLatestVersions(String name) {
+    return getLatestVersions(new GetLatestVersionsRequest().setName(name));
   }
 
   /**
@@ -73,6 +93,10 @@ public class RegisteredModelsAPI {
     return impl.list(request);
   }
 
+  public RenameRegisteredModelResponse rename(String name) {
+    return rename(new RenameRegisteredModelRequest().setName(name));
+  }
+
   /**
    * Rename a model.
    *
@@ -91,6 +115,10 @@ public class RegisteredModelsAPI {
     return impl.search(request);
   }
 
+  public void setTag(String name, String key, String value) {
+    setTag(new SetRegisteredModelTagRequest().setName(name).setKey(key).setValue(value));
+  }
+
   /**
    * Set a tag.
    *
@@ -98,6 +126,10 @@ public class RegisteredModelsAPI {
    */
   public void setTag(SetRegisteredModelTagRequest request) {
     impl.setTag(request);
+  }
+
+  public void update(String name) {
+    update(new UpdateRegisteredModelRequest().setName(name));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/RegistryWebhooksAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/RegistryWebhooksAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.mlflow;
 
 import com.databricks.sdk.client.ApiClient;
+import java.util.List;
 import org.apache.http.client.methods.*;
 
 public class RegistryWebhooksAPI {
@@ -15,6 +16,10 @@ public class RegistryWebhooksAPI {
   /** Constructor for mocks */
   public RegistryWebhooksAPI(RegistryWebhooksService mock) {
     impl = mock;
+  }
+
+  public CreateResponse create(List<RegistryWebhookEvent> events) {
+    return create(new CreateRegistryWebhook().setEvents(events));
   }
 
   /**
@@ -50,6 +55,10 @@ public class RegistryWebhooksAPI {
     return impl.list(request);
   }
 
+  public TestRegistryWebhookResponse test(String id) {
+    return test(new TestRegistryWebhookRequest().setId(id));
+  }
+
   /**
    * Test a webhook.
    *
@@ -59,6 +68,10 @@ public class RegistryWebhooksAPI {
    */
   public TestRegistryWebhookResponse test(TestRegistryWebhookRequest request) {
     return impl.test(request);
+  }
+
+  public void update(String id) {
+    update(new UpdateRegistryWebhook().setId(id));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/TransitionRequestsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/TransitionRequestsAPI.java
@@ -17,6 +17,16 @@ public class TransitionRequestsAPI {
     impl = mock;
   }
 
+  public ApproveResponse approve(
+      String name, String version, Stage stage, boolean archiveExistingVersions) {
+    return approve(
+        new ApproveTransitionRequest()
+            .setName(name)
+            .setVersion(version)
+            .setStage(stage)
+            .setArchiveExistingVersions(archiveExistingVersions));
+  }
+
   /**
    * Approve transition requests.
    *
@@ -24,6 +34,10 @@ public class TransitionRequestsAPI {
    */
   public ApproveResponse approve(ApproveTransitionRequest request) {
     return impl.approve(request);
+  }
+
+  public CreateResponse create(String name, String version, Stage stage) {
+    return create(new CreateTransitionRequest().setName(name).setVersion(version).setStage(stage));
   }
 
   /**
@@ -35,6 +49,15 @@ public class TransitionRequestsAPI {
     return impl.create(request);
   }
 
+  public void delete(String name, String version, String stage, String creator) {
+    delete(
+        new DeleteTransitionRequestRequest()
+            .setName(name)
+            .setVersion(version)
+            .setStage(stage)
+            .setCreator(creator));
+  }
+
   /**
    * Delete a ransition request.
    *
@@ -44,6 +67,10 @@ public class TransitionRequestsAPI {
     impl.delete(request);
   }
 
+  public ListResponse list(String name, String version) {
+    return list(new ListTransitionRequestsRequest().setName(name).setVersion(version));
+  }
+
   /**
    * List transition requests.
    *
@@ -51,6 +78,10 @@ public class TransitionRequestsAPI {
    */
   public ListResponse list(ListTransitionRequestsRequest request) {
     return impl.list(request);
+  }
+
+  public RejectResponse reject(String name, String version, Stage stage) {
+    return reject(new RejectTransitionRequest().setName(name).setVersion(version).setStage(stage));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/CustomAppIntegrationAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/CustomAppIntegrationAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.client.ApiClient;
+import java.util.List;
 import org.apache.http.client.methods.*;
 
 /**
@@ -24,6 +25,10 @@ public class CustomAppIntegrationAPI {
     impl = mock;
   }
 
+  public CreateCustomAppIntegrationOutput create(String name, List<String> redirectUrls) {
+    return create(new CreateCustomAppIntegration().setName(name).setRedirectUrls(redirectUrls));
+  }
+
   /**
    * Create Custom OAuth App Integration.
    *
@@ -35,6 +40,10 @@ public class CustomAppIntegrationAPI {
     return impl.create(request);
   }
 
+  public void delete(String integrationId) {
+    delete(new DeleteCustomAppIntegrationRequest().setIntegrationId(integrationId));
+  }
+
   /**
    * Delete Custom OAuth App Integration.
    *
@@ -43,6 +52,10 @@ public class CustomAppIntegrationAPI {
    */
   public void delete(DeleteCustomAppIntegrationRequest request) {
     impl.delete(request);
+  }
+
+  public GetCustomAppIntegrationOutput get(String integrationId) {
+    return get(new GetCustomAppIntegrationRequest().setIntegrationId(integrationId));
   }
 
   /**
@@ -61,6 +74,10 @@ public class CustomAppIntegrationAPI {
    */
   public GetCustomAppIntegrationsOutput list() {
     return impl.list();
+  }
+
+  public void update(String integrationId) {
+    update(new UpdateCustomAppIntegration().setIntegrationId(integrationId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/PublishedAppIntegrationAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/PublishedAppIntegrationAPI.java
@@ -35,6 +35,10 @@ public class PublishedAppIntegrationAPI {
     return impl.create(request);
   }
 
+  public void delete(String integrationId) {
+    delete(new DeletePublishedAppIntegrationRequest().setIntegrationId(integrationId));
+  }
+
   /**
    * Delete Published OAuth App Integration.
    *
@@ -43,6 +47,10 @@ public class PublishedAppIntegrationAPI {
    */
   public void delete(DeletePublishedAppIntegrationRequest request) {
     impl.delete(request);
+  }
+
+  public GetPublishedAppIntegrationOutput get(String integrationId) {
+    return get(new GetPublishedAppIntegrationRequest().setIntegrationId(integrationId));
   }
 
   /**
@@ -61,6 +69,10 @@ public class PublishedAppIntegrationAPI {
    */
   public GetPublishedAppIntegrationsOutput list() {
     return impl.list();
+  }
+
+  public void update(String integrationId) {
+    update(new UpdatePublishedAppIntegration().setIntegrationId(integrationId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/permissions/PermissionsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/permissions/PermissionsAPI.java
@@ -21,6 +21,11 @@ public class PermissionsAPI {
     impl = mock;
   }
 
+  public ObjectPermissions get(String requestObjectType, String requestObjectId) {
+    return get(
+        new Get().setRequestObjectType(requestObjectType).setRequestObjectId(requestObjectId));
+  }
+
   /**
    * Get object permissions.
    *
@@ -29,6 +34,14 @@ public class PermissionsAPI {
    */
   public ObjectPermissions get(Get request) {
     return impl.get(request);
+  }
+
+  public GetPermissionLevelsResponse getPermissionLevels(
+      String requestObjectType, String requestObjectId) {
+    return getPermissionLevels(
+        new GetPermissionLevels()
+            .setRequestObjectType(requestObjectType)
+            .setRequestObjectId(requestObjectId));
   }
 
   /**
@@ -40,6 +53,13 @@ public class PermissionsAPI {
     return impl.getPermissionLevels(request);
   }
 
+  public void set(String requestObjectType, String requestObjectId) {
+    set(
+        new PermissionsRequest()
+            .setRequestObjectType(requestObjectType)
+            .setRequestObjectId(requestObjectId));
+  }
+
   /**
    * Set permissions.
    *
@@ -48,6 +68,13 @@ public class PermissionsAPI {
    */
   public void set(PermissionsRequest request) {
     impl.set(request);
+  }
+
+  public void update(String requestObjectType, String requestObjectId) {
+    update(
+        new PermissionsRequest()
+            .setRequestObjectType(requestObjectType)
+            .setRequestObjectId(requestObjectId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/permissions/WorkspaceAssignmentAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/permissions/WorkspaceAssignmentAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.permissions;
 
 import com.databricks.sdk.client.ApiClient;
+import java.util.List;
 import org.apache.http.client.methods.*;
 
 /**
@@ -21,6 +22,13 @@ public class WorkspaceAssignmentAPI {
     impl = mock;
   }
 
+  public void delete(long workspaceId, long principalId) {
+    delete(
+        new DeleteWorkspaceAssignmentRequest()
+            .setWorkspaceId(workspaceId)
+            .setPrincipalId(principalId));
+  }
+
   /**
    * Delete permissions assignment.
    *
@@ -29,6 +37,10 @@ public class WorkspaceAssignmentAPI {
    */
   public void delete(DeleteWorkspaceAssignmentRequest request) {
     impl.delete(request);
+  }
+
+  public WorkspacePermissions get(long workspaceId) {
+    return get(new GetWorkspaceAssignmentRequest().setWorkspaceId(workspaceId));
   }
 
   /**
@@ -40,6 +52,10 @@ public class WorkspaceAssignmentAPI {
     return impl.get(request);
   }
 
+  public PermissionAssignments list(long workspaceId) {
+    return list(new ListWorkspaceAssignmentRequest().setWorkspaceId(workspaceId));
+  }
+
   /**
    * Get permission assignments.
    *
@@ -48,6 +64,14 @@ public class WorkspaceAssignmentAPI {
    */
   public PermissionAssignments list(ListWorkspaceAssignmentRequest request) {
     return impl.list(request);
+  }
+
+  public void update(List<WorkspacePermission> permissions, long workspaceId, long principalId) {
+    update(
+        new UpdateWorkspaceAssignments()
+            .setPermissions(permissions)
+            .setWorkspaceId(workspaceId)
+            .setPrincipalId(principalId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesAPI.java
@@ -42,6 +42,10 @@ public class PipelinesAPI {
     return impl.create(request);
   }
 
+  public void delete(String pipelineId) {
+    delete(new Delete().setPipelineId(pipelineId));
+  }
+
   /**
    * Delete a pipeline.
    *
@@ -51,9 +55,17 @@ public class PipelinesAPI {
     impl.delete(request);
   }
 
+  public GetPipelineResponse get(String pipelineId) {
+    return get(new Get().setPipelineId(pipelineId));
+  }
+
   /** Get a pipeline. */
   public GetPipelineResponse get(Get request) {
     return impl.get(request);
+  }
+
+  public GetUpdateResponse getUpdate(String pipelineId, String updateId) {
+    return getUpdate(new GetUpdate().setPipelineId(pipelineId).setUpdateId(updateId));
   }
 
   /**
@@ -63,6 +75,10 @@ public class PipelinesAPI {
    */
   public GetUpdateResponse getUpdate(GetUpdate request) {
     return impl.getUpdate(request);
+  }
+
+  public ListPipelineEventsResponse listPipelineEvents(String pipelineId) {
+    return listPipelineEvents(new ListPipelineEvents().setPipelineId(pipelineId));
   }
 
   /**
@@ -83,6 +99,10 @@ public class PipelinesAPI {
     return impl.listPipelines(request);
   }
 
+  public ListUpdatesResponse listUpdates(String pipelineId) {
+    return listUpdates(new ListUpdates().setPipelineId(pipelineId));
+  }
+
   /**
    * List pipeline updates.
    *
@@ -90,6 +110,10 @@ public class PipelinesAPI {
    */
   public ListUpdatesResponse listUpdates(ListUpdates request) {
     return impl.listUpdates(request);
+  }
+
+  public void reset(String pipelineId) {
+    reset(new Reset().setPipelineId(pipelineId));
   }
 
   /**
@@ -101,6 +125,10 @@ public class PipelinesAPI {
     impl.reset(request);
   }
 
+  public StartUpdateResponse startUpdate(String pipelineId) {
+    return startUpdate(new StartUpdate().setPipelineId(pipelineId));
+  }
+
   /**
    * Queue a pipeline update.
    *
@@ -110,6 +138,10 @@ public class PipelinesAPI {
     return impl.startUpdate(request);
   }
 
+  public void stop(String pipelineId) {
+    stop(new Stop().setPipelineId(pipelineId));
+  }
+
   /**
    * Stop a pipeline.
    *
@@ -117,6 +149,10 @@ public class PipelinesAPI {
    */
   public void stop(Stop request) {
     impl.stop(request);
+  }
+
+  public void update(String pipelineId) {
+    update(new EditPipeline().setPipelineId(pipelineId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/repos/ReposAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/repos/ReposAPI.java
@@ -30,6 +30,10 @@ public class ReposAPI {
     impl = mock;
   }
 
+  public RepoInfo create(String url, String provider) {
+    return create(new CreateRepo().setUrl(url).setProvider(provider));
+  }
+
   /**
    * Create a repo.
    *
@@ -41,6 +45,10 @@ public class ReposAPI {
     return impl.create(request);
   }
 
+  public void delete(long repoId) {
+    delete(new Delete().setRepoId(repoId));
+  }
+
   /**
    * Delete a repo.
    *
@@ -48,6 +56,10 @@ public class ReposAPI {
    */
   public void delete(Delete request) {
     impl.delete(request);
+  }
+
+  public RepoInfo get(long repoId) {
+    return get(new Get().setRepoId(repoId));
   }
 
   /**
@@ -67,6 +79,10 @@ public class ReposAPI {
    */
   public ListReposResponse list(List request) {
     return impl.list(request);
+  }
+
+  public void update(long repoId) {
+    update(new UpdateRepo().setRepoId(repoId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountGroupsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountGroupsAPI.java
@@ -25,6 +25,10 @@ public class AccountGroupsAPI {
     impl = mock;
   }
 
+  public Group create(String id) {
+    return create(new Group().setId(id));
+  }
+
   /**
    * Create a new group.
    *
@@ -35,6 +39,10 @@ public class AccountGroupsAPI {
     return impl.create(request);
   }
 
+  public void delete(String id) {
+    delete(new DeleteGroupRequest().setId(id));
+  }
+
   /**
    * Delete a group.
    *
@@ -42,6 +50,10 @@ public class AccountGroupsAPI {
    */
   public void delete(DeleteGroupRequest request) {
     impl.delete(request);
+  }
+
+  public Group get(String id) {
+    return get(new GetGroupRequest().setId(id));
   }
 
   /**
@@ -62,6 +74,10 @@ public class AccountGroupsAPI {
     return impl.list(request);
   }
 
+  public void patch(String id) {
+    patch(new PartialUpdate().setId(id));
+  }
+
   /**
    * Update group details.
    *
@@ -69,6 +85,10 @@ public class AccountGroupsAPI {
    */
   public void patch(PartialUpdate request) {
     impl.patch(request);
+  }
+
+  public void update(String id) {
+    update(new Group().setId(id));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountServicePrincipalsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountServicePrincipalsAPI.java
@@ -24,6 +24,10 @@ public class AccountServicePrincipalsAPI {
     impl = mock;
   }
 
+  public ServicePrincipal create(String id) {
+    return create(new ServicePrincipal().setId(id));
+  }
+
   /**
    * Create a service principal.
    *
@@ -33,6 +37,10 @@ public class AccountServicePrincipalsAPI {
     return impl.create(request);
   }
 
+  public void delete(String id) {
+    delete(new DeleteServicePrincipalRequest().setId(id));
+  }
+
   /**
    * Delete a service principal.
    *
@@ -40,6 +48,10 @@ public class AccountServicePrincipalsAPI {
    */
   public void delete(DeleteServicePrincipalRequest request) {
     impl.delete(request);
+  }
+
+  public ServicePrincipal get(String id) {
+    return get(new GetServicePrincipalRequest().setId(id));
   }
 
   /**
@@ -60,6 +72,10 @@ public class AccountServicePrincipalsAPI {
     return impl.list(request);
   }
 
+  public void patch(String id) {
+    patch(new PartialUpdate().setId(id));
+  }
+
   /**
    * Update service principal details.
    *
@@ -67,6 +83,10 @@ public class AccountServicePrincipalsAPI {
    */
   public void patch(PartialUpdate request) {
     impl.patch(request);
+  }
+
+  public void update(String id) {
+    update(new ServicePrincipal().setId(id));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountUsersAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountUsersAPI.java
@@ -28,6 +28,10 @@ public class AccountUsersAPI {
     impl = mock;
   }
 
+  public User create(String id) {
+    return create(new User().setId(id));
+  }
+
   /**
    * Create a new user.
    *
@@ -38,6 +42,10 @@ public class AccountUsersAPI {
     return impl.create(request);
   }
 
+  public void delete(String id) {
+    delete(new DeleteUserRequest().setId(id));
+  }
+
   /**
    * Delete a user.
    *
@@ -46,6 +54,10 @@ public class AccountUsersAPI {
    */
   public void delete(DeleteUserRequest request) {
     impl.delete(request);
+  }
+
+  public User get(String id) {
+    return get(new GetUserRequest().setId(id));
   }
 
   /**
@@ -66,6 +78,10 @@ public class AccountUsersAPI {
     return impl.list(request);
   }
 
+  public void patch(String id) {
+    patch(new PartialUpdate().setId(id));
+  }
+
   /**
    * Update user details.
    *
@@ -74,6 +90,10 @@ public class AccountUsersAPI {
    */
   public void patch(PartialUpdate request) {
     impl.patch(request);
+  }
+
+  public void update(String id) {
+    update(new User().setId(id));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/GroupsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/GroupsAPI.java
@@ -25,6 +25,10 @@ public class GroupsAPI {
     impl = mock;
   }
 
+  public Group create(String id) {
+    return create(new Group().setId(id));
+  }
+
   /**
    * Create a new group.
    *
@@ -35,6 +39,10 @@ public class GroupsAPI {
     return impl.create(request);
   }
 
+  public void delete(String id) {
+    delete(new DeleteGroupRequest().setId(id));
+  }
+
   /**
    * Delete a group.
    *
@@ -42,6 +50,10 @@ public class GroupsAPI {
    */
   public void delete(DeleteGroupRequest request) {
     impl.delete(request);
+  }
+
+  public Group get(String id) {
+    return get(new GetGroupRequest().setId(id));
   }
 
   /**
@@ -62,6 +74,10 @@ public class GroupsAPI {
     return impl.list(request);
   }
 
+  public void patch(String id) {
+    patch(new PartialUpdate().setId(id));
+  }
+
   /**
    * Update group details.
    *
@@ -69,6 +85,10 @@ public class GroupsAPI {
    */
   public void patch(PartialUpdate request) {
     impl.patch(request);
+  }
+
+  public void update(String id) {
+    update(new Group().setId(id));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/ServicePrincipalsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/ServicePrincipalsAPI.java
@@ -24,6 +24,10 @@ public class ServicePrincipalsAPI {
     impl = mock;
   }
 
+  public ServicePrincipal create(String id) {
+    return create(new ServicePrincipal().setId(id));
+  }
+
   /**
    * Create a service principal.
    *
@@ -33,6 +37,10 @@ public class ServicePrincipalsAPI {
     return impl.create(request);
   }
 
+  public void delete(String id) {
+    delete(new DeleteServicePrincipalRequest().setId(id));
+  }
+
   /**
    * Delete a service principal.
    *
@@ -40,6 +48,10 @@ public class ServicePrincipalsAPI {
    */
   public void delete(DeleteServicePrincipalRequest request) {
     impl.delete(request);
+  }
+
+  public ServicePrincipal get(String id) {
+    return get(new GetServicePrincipalRequest().setId(id));
   }
 
   /**
@@ -60,6 +72,10 @@ public class ServicePrincipalsAPI {
     return impl.list(request);
   }
 
+  public void patch(String id) {
+    patch(new PartialUpdate().setId(id));
+  }
+
   /**
    * Update service principal details.
    *
@@ -67,6 +83,10 @@ public class ServicePrincipalsAPI {
    */
   public void patch(PartialUpdate request) {
     impl.patch(request);
+  }
+
+  public void update(String id) {
+    update(new ServicePrincipal().setId(id));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/UsersAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/UsersAPI.java
@@ -28,6 +28,10 @@ public class UsersAPI {
     impl = mock;
   }
 
+  public User create(String id) {
+    return create(new User().setId(id));
+  }
+
   /**
    * Create a new user.
    *
@@ -38,6 +42,10 @@ public class UsersAPI {
     return impl.create(request);
   }
 
+  public void delete(String id) {
+    delete(new DeleteUserRequest().setId(id));
+  }
+
   /**
    * Delete a user.
    *
@@ -46,6 +54,10 @@ public class UsersAPI {
    */
   public void delete(DeleteUserRequest request) {
     impl.delete(request);
+  }
+
+  public User get(String id) {
+    return get(new GetUserRequest().setId(id));
   }
 
   /**
@@ -66,6 +78,10 @@ public class UsersAPI {
     return impl.list(request);
   }
 
+  public void patch(String id) {
+    patch(new PartialUpdate().setId(id));
+  }
+
   /**
    * Update user details.
    *
@@ -74,6 +90,10 @@ public class UsersAPI {
    */
   public void patch(PartialUpdate request) {
     impl.patch(request);
+  }
+
+  public void update(String id) {
+    update(new User().setId(id));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/secrets/SecretsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/secrets/SecretsAPI.java
@@ -28,6 +28,10 @@ public class SecretsAPI {
     impl = mock;
   }
 
+  public void createScope(String scope) {
+    createScope(new CreateScope().setScope(scope));
+  }
+
   /**
    * Create a new secret scope.
    *
@@ -36,6 +40,10 @@ public class SecretsAPI {
    */
   public void createScope(CreateScope request) {
     impl.createScope(request);
+  }
+
+  public void deleteAcl(String scope, String principal) {
+    deleteAcl(new DeleteAcl().setScope(scope).setPrincipal(principal));
   }
 
   /**
@@ -51,6 +59,10 @@ public class SecretsAPI {
     impl.deleteAcl(request);
   }
 
+  public void deleteScope(String scope) {
+    deleteScope(new DeleteScope().setScope(scope));
+  }
+
   /**
    * Delete a secret scope.
    *
@@ -61,6 +73,10 @@ public class SecretsAPI {
    */
   public void deleteScope(DeleteScope request) {
     impl.deleteScope(request);
+  }
+
+  public void deleteSecret(String scope, String key) {
+    deleteSecret(new DeleteSecret().setScope(scope).setKey(key));
   }
 
   /**
@@ -76,6 +92,10 @@ public class SecretsAPI {
     impl.deleteSecret(request);
   }
 
+  public AclItem getAcl(String scope, String principal) {
+    return getAcl(new GetAcl().setScope(scope).setPrincipal(principal));
+  }
+
   /**
    * Get secret ACL details.
    *
@@ -87,6 +107,10 @@ public class SecretsAPI {
    */
   public AclItem getAcl(GetAcl request) {
     return impl.getAcl(request);
+  }
+
+  public ListAclsResponse listAcls(String scope) {
+    return listAcls(new ListAcls().setScope(scope));
   }
 
   /**
@@ -113,6 +137,10 @@ public class SecretsAPI {
     return impl.listScopes();
   }
 
+  public ListSecretsResponse listSecrets(String scope) {
+    return listSecrets(new ListSecrets().setScope(scope));
+  }
+
   /**
    * List secret keys.
    *
@@ -126,6 +154,10 @@ public class SecretsAPI {
    */
   public ListSecretsResponse listSecrets(ListSecrets request) {
     return impl.listSecrets(request);
+  }
+
+  public void putAcl(String scope, String principal, AclPermission permission) {
+    putAcl(new PutAcl().setScope(scope).setPrincipal(principal).setPermission(permission));
   }
 
   /**
@@ -158,6 +190,10 @@ public class SecretsAPI {
    */
   public void putAcl(PutAcl request) {
     impl.putAcl(request);
+  }
+
+  public void putSecret(String scope, String key) {
+    putSecret(new PutSecret().setScope(scope).setKey(key));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsAPI.java
@@ -23,6 +23,10 @@ public class AlertsAPI {
     impl = mock;
   }
 
+  public Alert create(String name, AlertOptions options, String queryId) {
+    return create(new CreateAlert().setName(name).setOptions(options).setQueryId(queryId));
+  }
+
   /**
    * Create an alert.
    *
@@ -34,6 +38,10 @@ public class AlertsAPI {
     return impl.create(request);
   }
 
+  public void delete(String alertId) {
+    delete(new DeleteAlertRequest().setAlertId(alertId));
+  }
+
   /**
    * Delete an alert.
    *
@@ -42,6 +50,10 @@ public class AlertsAPI {
    */
   public void delete(DeleteAlertRequest request) {
     impl.delete(request);
+  }
+
+  public Alert get(String alertId) {
+    return get(new GetAlertRequest().setAlertId(alertId));
   }
 
   /**
@@ -60,6 +72,11 @@ public class AlertsAPI {
    */
   public List<Alert> list() {
     return impl.list();
+  }
+
+  public void update(String name, AlertOptions options, String queryId, String alertId) {
+    update(
+        new EditAlert().setName(name).setOptions(options).setQueryId(queryId).setAlertId(alertId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/ChannelName.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/ChannelName.java
@@ -2,6 +2,7 @@
 
 package com.databricks.sdk.service.sql;
 
+/** Name of the channel */
 public enum ChannelName {
   CHANNEL_NAME_CURRENT,
   CHANNEL_NAME_CUSTOM,

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardsAPI.java
@@ -28,6 +28,10 @@ public class DashboardsAPI {
     return impl.create(request);
   }
 
+  public void delete(String dashboardId) {
+    delete(new DeleteDashboardRequest().setDashboardId(dashboardId));
+  }
+
   /**
    * Remove a dashboard.
    *
@@ -36,6 +40,10 @@ public class DashboardsAPI {
    */
   public void delete(DeleteDashboardRequest request) {
     impl.delete(request);
+  }
+
+  public Dashboard get(String dashboardId) {
+    return get(new GetDashboardRequest().setDashboardId(dashboardId));
   }
 
   /**
@@ -55,6 +63,10 @@ public class DashboardsAPI {
    */
   public ListResponse list(ListDashboardsRequest request) {
     return impl.list(request);
+  }
+
+  public void restore(String dashboardId) {
+    restore(new RestoreDashboardRequest().setDashboardId(dashboardId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DbsqlPermissionsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DbsqlPermissionsAPI.java
@@ -31,6 +31,10 @@ public class DbsqlPermissionsAPI {
     impl = mock;
   }
 
+  public GetResponse get(ObjectTypePlural objectType, String objectId) {
+    return get(new GetDbsqlPermissionRequest().setObjectType(objectType).setObjectId(objectId));
+  }
+
   /**
    * Get object ACL.
    *
@@ -38,6 +42,10 @@ public class DbsqlPermissionsAPI {
    */
   public GetResponse get(GetDbsqlPermissionRequest request) {
     return impl.get(request);
+  }
+
+  public SetResponse set(ObjectTypePlural objectType, String objectId) {
+    return set(new SetRequest().setObjectType(objectType).setObjectId(objectId));
   }
 
   /**
@@ -48,6 +56,12 @@ public class DbsqlPermissionsAPI {
    */
   public SetResponse set(SetRequest request) {
     return impl.set(request);
+  }
+
+  public Success transferOwnership(
+      OwnableObjectType objectType, TransferOwnershipObjectId objectId) {
+    return transferOwnership(
+        new TransferOwnershipRequest().setObjectType(objectType).setObjectId(objectId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesAPI.java
@@ -37,6 +37,10 @@ public class QueriesAPI {
     return impl.create(request);
   }
 
+  public void delete(String queryId) {
+    delete(new DeleteQueryRequest().setQueryId(queryId));
+  }
+
   /**
    * Delete a query.
    *
@@ -45,6 +49,10 @@ public class QueriesAPI {
    */
   public void delete(DeleteQueryRequest request) {
     impl.delete(request);
+  }
+
+  public Query get(String queryId) {
+    return get(new GetQueryRequest().setQueryId(queryId));
   }
 
   /**
@@ -66,6 +74,10 @@ public class QueriesAPI {
     return impl.list(request);
   }
 
+  public void restore(String queryId) {
+    restore(new RestoreQueryRequest().setQueryId(queryId));
+  }
+
   /**
    * Restore a query.
    *
@@ -74,6 +86,10 @@ public class QueriesAPI {
    */
   public void restore(RestoreQueryRequest request) {
     impl.restore(request);
+  }
+
+  public Query update(String queryId) {
+    return update(new QueryEditContent().setQueryId(queryId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/StatementExecutionAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/StatementExecutionAPI.java
@@ -179,6 +179,10 @@ public class StatementExecutionAPI {
     impl = mock;
   }
 
+  public void cancelExecution(String statementId) {
+    cancelExecution(new CancelExecutionRequest().setStatementId(statementId));
+  }
+
   /**
    * Cancel statement execution.
    *
@@ -198,6 +202,10 @@ public class StatementExecutionAPI {
     return impl.executeStatement(request);
   }
 
+  public GetStatementResponse getStatement(String statementId) {
+    return getStatement(new GetStatementRequest().setStatementId(statementId));
+  }
+
   /**
    * Get status, manifest, and result first chunk.
    *
@@ -208,6 +216,13 @@ public class StatementExecutionAPI {
    */
   public GetStatementResponse getStatement(GetStatementRequest request) {
     return impl.getStatement(request);
+  }
+
+  public ResultData getStatementResultChunkN(String statementId, int chunkIndex) {
+    return getStatementResultChunkN(
+        new GetStatementResultChunkNRequest()
+            .setStatementId(statementId)
+            .setChunkIndex(chunkIndex));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesAPI.java
@@ -31,6 +31,10 @@ public class WarehousesAPI {
     return impl.create(request);
   }
 
+  public void delete(String id) {
+    delete(new DeleteWarehouseRequest().setId(id));
+  }
+
   /**
    * Delete a warehouse.
    *
@@ -40,6 +44,10 @@ public class WarehousesAPI {
     impl.delete(request);
   }
 
+  public void edit(String id) {
+    edit(new EditWarehouseRequest().setId(id));
+  }
+
   /**
    * Update a warehouse.
    *
@@ -47,6 +55,10 @@ public class WarehousesAPI {
    */
   public void edit(EditWarehouseRequest request) {
     impl.edit(request);
+  }
+
+  public GetWarehouseResponse get(String id) {
+    return get(new GetWarehouseRequest().setId(id));
   }
 
   /**
@@ -85,6 +97,10 @@ public class WarehousesAPI {
     impl.setWorkspaceWarehouseConfig(request);
   }
 
+  public void start(String id) {
+    start(new StartRequest().setId(id));
+  }
+
   /**
    * Start a warehouse.
    *
@@ -92,6 +108,10 @@ public class WarehousesAPI {
    */
   public void start(StartRequest request) {
     impl.start(request);
+  }
+
+  public void stop(String id) {
+    stop(new StopRequest().setId(id));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/tokenmanagement/TokenManagementAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/tokenmanagement/TokenManagementAPI.java
@@ -22,6 +22,13 @@ public class TokenManagementAPI {
     impl = mock;
   }
 
+  public CreateOboTokenResponse createOboToken(String applicationId, long lifetimeSeconds) {
+    return createOboToken(
+        new CreateOboTokenRequest()
+            .setApplicationId(applicationId)
+            .setLifetimeSeconds(lifetimeSeconds));
+  }
+
   /**
    * Create on-behalf token.
    *
@@ -31,6 +38,10 @@ public class TokenManagementAPI {
     return impl.createOboToken(request);
   }
 
+  public void delete(String tokenId) {
+    delete(new Delete().setTokenId(tokenId));
+  }
+
   /**
    * Delete a token.
    *
@@ -38,6 +49,10 @@ public class TokenManagementAPI {
    */
   public void delete(Delete request) {
     impl.delete(request);
+  }
+
+  public TokenInfo get(String tokenId) {
+    return get(new Get().setTokenId(tokenId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/tokens/TokensAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/tokens/TokensAPI.java
@@ -32,6 +32,10 @@ public class TokensAPI {
     return impl.create(request);
   }
 
+  public void delete(String tokenId) {
+    delete(new RevokeTokenRequest().setTokenId(tokenId));
+  }
+
   /**
    * Revoke token.
    *

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountMetastoreAssignmentsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountMetastoreAssignmentsAPI.java
@@ -19,6 +19,15 @@ public class AccountMetastoreAssignmentsAPI {
     impl = mock;
   }
 
+  public MetastoreAssignment create(
+      String metastoreId, String defaultCatalogName, long workspaceId) {
+    return create(
+        new CreateMetastoreAssignment()
+            .setMetastoreId(metastoreId)
+            .setDefaultCatalogName(defaultCatalogName)
+            .setWorkspaceId(workspaceId));
+  }
+
   /**
    * Assigns a workspace to a metastore.
    *
@@ -28,6 +37,13 @@ public class AccountMetastoreAssignmentsAPI {
     return impl.create(request);
   }
 
+  public void delete(long workspaceId, String metastoreId) {
+    delete(
+        new DeleteAccountMetastoreAssignmentRequest()
+            .setWorkspaceId(workspaceId)
+            .setMetastoreId(metastoreId));
+  }
+
   /**
    * Delete a metastore assignment.
    *
@@ -35,6 +51,10 @@ public class AccountMetastoreAssignmentsAPI {
    */
   public void delete(DeleteAccountMetastoreAssignmentRequest request) {
     impl.delete(request);
+  }
+
+  public MetastoreAssignment get(long workspaceId) {
+    return get(new GetAccountMetastoreAssignmentRequest().setWorkspaceId(workspaceId));
   }
 
   /**
@@ -48,6 +68,10 @@ public class AccountMetastoreAssignmentsAPI {
     return impl.get(request);
   }
 
+  public List<MetastoreAssignment> list(String metastoreId) {
+    return list(new ListAccountMetastoreAssignmentsRequest().setMetastoreId(metastoreId));
+  }
+
   /**
    * Get all workspaces assigned to a metastore.
    *
@@ -55,6 +79,11 @@ public class AccountMetastoreAssignmentsAPI {
    */
   public List<MetastoreAssignment> list(ListAccountMetastoreAssignmentsRequest request) {
     return impl.list(request);
+  }
+
+  public MetastoreAssignment update(long workspaceId, String metastoreId) {
+    return update(
+        new UpdateMetastoreAssignment().setWorkspaceId(workspaceId).setMetastoreId(metastoreId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountMetastoresAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountMetastoresAPI.java
@@ -21,6 +21,10 @@ public class AccountMetastoresAPI {
     impl = mock;
   }
 
+  public MetastoreInfo create(String name, String storageRoot) {
+    return create(new CreateMetastore().setName(name).setStorageRoot(storageRoot));
+  }
+
   /**
    * Create metastore.
    *
@@ -30,6 +34,10 @@ public class AccountMetastoresAPI {
     return impl.create(request);
   }
 
+  public void delete(String metastoreId) {
+    delete(new DeleteAccountMetastoreRequest().setMetastoreId(metastoreId));
+  }
+
   /**
    * Delete a metastore.
    *
@@ -37,6 +45,10 @@ public class AccountMetastoresAPI {
    */
   public void delete(DeleteAccountMetastoreRequest request) {
     impl.delete(request);
+  }
+
+  public MetastoreInfo get(String metastoreId) {
+    return get(new GetAccountMetastoreRequest().setMetastoreId(metastoreId));
   }
 
   /**
@@ -55,6 +67,10 @@ public class AccountMetastoresAPI {
    */
   public ListMetastoresResponse list() {
     return impl.list();
+  }
+
+  public MetastoreInfo update(String metastoreId, String id) {
+    return update(new UpdateMetastore().setMetastoreId(metastoreId).setId(id));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountStorageCredentialsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountStorageCredentialsAPI.java
@@ -19,6 +19,10 @@ public class AccountStorageCredentialsAPI {
     impl = mock;
   }
 
+  public StorageCredentialInfo create(String name, String metastoreId) {
+    return create(new CreateStorageCredential().setName(name).setMetastoreId(metastoreId));
+  }
+
   /**
    * Create a storage credential.
    *
@@ -34,6 +38,10 @@ public class AccountStorageCredentialsAPI {
     return impl.create(request);
   }
 
+  public StorageCredentialInfo get(String metastoreId, String name) {
+    return get(new GetAccountStorageCredentialRequest().setMetastoreId(metastoreId).setName(name));
+  }
+
   /**
    * Gets the named storage credential.
    *
@@ -42,6 +50,10 @@ public class AccountStorageCredentialsAPI {
    */
   public StorageCredentialInfo get(GetAccountStorageCredentialRequest request) {
     return impl.get(request);
+  }
+
+  public List<StorageCredentialInfo> list(String metastoreId) {
+    return list(new ListAccountStorageCredentialsRequest().setMetastoreId(metastoreId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/CatalogsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/CatalogsAPI.java
@@ -26,6 +26,10 @@ public class CatalogsAPI {
     impl = mock;
   }
 
+  public CatalogInfo create(String name) {
+    return create(new CreateCatalog().setName(name));
+  }
+
   /**
    * Create a catalog.
    *
@@ -36,6 +40,10 @@ public class CatalogsAPI {
     return impl.create(request);
   }
 
+  public void delete(String name) {
+    delete(new DeleteCatalogRequest().setName(name));
+  }
+
   /**
    * Delete a catalog.
    *
@@ -44,6 +52,10 @@ public class CatalogsAPI {
    */
   public void delete(DeleteCatalogRequest request) {
     impl.delete(request);
+  }
+
+  public CatalogInfo get(String name) {
+    return get(new GetCatalogRequest().setName(name));
   }
 
   /**
@@ -66,6 +78,10 @@ public class CatalogsAPI {
    */
   public ListCatalogsResponse list() {
     return impl.list();
+  }
+
+  public CatalogInfo update(String name) {
+    return update(new UpdateCatalog().setName(name));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/ExternalLocationsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/ExternalLocationsAPI.java
@@ -29,6 +29,11 @@ public class ExternalLocationsAPI {
     impl = mock;
   }
 
+  public ExternalLocationInfo create(String name, String url, String credentialName) {
+    return create(
+        new CreateExternalLocation().setName(name).setUrl(url).setCredentialName(credentialName));
+  }
+
   /**
    * Create an external location.
    *
@@ -40,6 +45,10 @@ public class ExternalLocationsAPI {
     return impl.create(request);
   }
 
+  public void delete(String name) {
+    delete(new DeleteExternalLocationRequest().setName(name));
+  }
+
   /**
    * Delete an external location.
    *
@@ -48,6 +57,10 @@ public class ExternalLocationsAPI {
    */
   public void delete(DeleteExternalLocationRequest request) {
     impl.delete(request);
+  }
+
+  public ExternalLocationInfo get(String name) {
+    return get(new GetExternalLocationRequest().setName(name));
   }
 
   /**
@@ -70,6 +83,10 @@ public class ExternalLocationsAPI {
    */
   public ListExternalLocationsResponse list() {
     return impl.list();
+  }
+
+  public ExternalLocationInfo update(String name) {
+    return update(new UpdateExternalLocation().setName(name));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/FunctionsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/FunctionsAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
+import java.util.List;
 import org.apache.http.client.methods.*;
 
 /**
@@ -25,6 +26,43 @@ public class FunctionsAPI {
     impl = mock;
   }
 
+  public FunctionInfo create(
+      String name,
+      String catalogName,
+      String schemaName,
+      List<FunctionParameterInfo> inputParams,
+      ColumnTypeName dataType,
+      String fullDataType,
+      List<FunctionParameterInfo> returnParams,
+      CreateFunctionRoutineBody routineBody,
+      String routineDefinition,
+      List<Dependency> routineDependencies,
+      CreateFunctionParameterStyle parameterStyle,
+      boolean isDeterministic,
+      CreateFunctionSqlDataAccess sqlDataAccess,
+      boolean isNullCall,
+      CreateFunctionSecurityType securityType,
+      String specificName) {
+    return create(
+        new CreateFunction()
+            .setName(name)
+            .setCatalogName(catalogName)
+            .setSchemaName(schemaName)
+            .setInputParams(inputParams)
+            .setDataType(dataType)
+            .setFullDataType(fullDataType)
+            .setReturnParams(returnParams)
+            .setRoutineBody(routineBody)
+            .setRoutineDefinition(routineDefinition)
+            .setRoutineDependencies(routineDependencies)
+            .setParameterStyle(parameterStyle)
+            .setIsDeterministic(isDeterministic)
+            .setSqlDataAccess(sqlDataAccess)
+            .setIsNullCall(isNullCall)
+            .setSecurityType(securityType)
+            .setSpecificName(specificName));
+  }
+
   /**
    * Create a function.
    *
@@ -38,6 +76,10 @@ public class FunctionsAPI {
     return impl.create(request);
   }
 
+  public void delete(String name) {
+    delete(new DeleteFunctionRequest().setName(name));
+  }
+
   /**
    * Delete a function.
    *
@@ -49,6 +91,10 @@ public class FunctionsAPI {
    */
   public void delete(DeleteFunctionRequest request) {
     impl.delete(request);
+  }
+
+  public FunctionInfo get(String name) {
+    return get(new GetFunctionRequest().setName(name));
   }
 
   /**
@@ -65,6 +111,10 @@ public class FunctionsAPI {
     return impl.get(request);
   }
 
+  public ListFunctionsResponse list(String catalogName, String schemaName) {
+    return list(new ListFunctionsRequest().setCatalogName(catalogName).setSchemaName(schemaName));
+  }
+
   /**
    * List functions.
    *
@@ -77,6 +127,10 @@ public class FunctionsAPI {
    */
   public ListFunctionsResponse list(ListFunctionsRequest request) {
     return impl.list(request);
+  }
+
+  public FunctionInfo update(String name) {
+    return update(new UpdateFunction().setName(name));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/GrantsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/GrantsAPI.java
@@ -28,6 +28,10 @@ public class GrantsAPI {
     impl = mock;
   }
 
+  public PermissionsList get(SecurableType securableType, String fullName) {
+    return get(new GetGrantRequest().setSecurableType(securableType).setFullName(fullName));
+  }
+
   /**
    * Get permissions.
    *
@@ -37,6 +41,11 @@ public class GrantsAPI {
     return impl.get(request);
   }
 
+  public EffectivePermissionsList getEffective(SecurableType securableType, String fullName) {
+    return getEffective(
+        new GetEffectiveRequest().setSecurableType(securableType).setFullName(fullName));
+  }
+
   /**
    * Get effective permissions.
    *
@@ -44,6 +53,10 @@ public class GrantsAPI {
    */
   public EffectivePermissionsList getEffective(GetEffectiveRequest request) {
     return impl.getEffective(request);
+  }
+
+  public PermissionsList update(SecurableType securableType, String fullName) {
+    return update(new UpdatePermissions().setSecurableType(securableType).setFullName(fullName));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/MetastoresAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/MetastoresAPI.java
@@ -30,6 +30,14 @@ public class MetastoresAPI {
     impl = mock;
   }
 
+  public void assign(String metastoreId, String defaultCatalogName, long workspaceId) {
+    assign(
+        new CreateMetastoreAssignment()
+            .setMetastoreId(metastoreId)
+            .setDefaultCatalogName(defaultCatalogName)
+            .setWorkspaceId(workspaceId));
+  }
+
   /**
    * Create an assignment.
    *
@@ -39,6 +47,10 @@ public class MetastoresAPI {
    */
   public void assign(CreateMetastoreAssignment request) {
     impl.assign(request);
+  }
+
+  public MetastoreInfo create(String name, String storageRoot) {
+    return create(new CreateMetastore().setName(name).setStorageRoot(storageRoot));
   }
 
   /**
@@ -59,6 +71,10 @@ public class MetastoresAPI {
     return impl.current();
   }
 
+  public void delete(String id) {
+    delete(new DeleteMetastoreRequest().setId(id));
+  }
+
   /**
    * Delete a metastore.
    *
@@ -66,6 +82,10 @@ public class MetastoresAPI {
    */
   public void delete(DeleteMetastoreRequest request) {
     impl.delete(request);
+  }
+
+  public MetastoreInfo get(String id) {
+    return get(new GetMetastoreRequest().setId(id));
   }
 
   /**
@@ -99,6 +119,10 @@ public class MetastoresAPI {
     return impl.summary();
   }
 
+  public void unassign(long workspaceId, String metastoreId) {
+    unassign(new UnassignRequest().setWorkspaceId(workspaceId).setMetastoreId(metastoreId));
+  }
+
   /**
    * Delete an assignment.
    *
@@ -108,6 +132,10 @@ public class MetastoresAPI {
     impl.unassign(request);
   }
 
+  public MetastoreInfo update(String metastoreId, String id) {
+    return update(new UpdateMetastore().setMetastoreId(metastoreId).setId(id));
+  }
+
   /**
    * Update a metastore.
    *
@@ -115,6 +143,11 @@ public class MetastoresAPI {
    */
   public MetastoreInfo update(UpdateMetastore request) {
     return impl.update(request);
+  }
+
+  public void updateAssignment(long workspaceId, String metastoreId) {
+    updateAssignment(
+        new UpdateMetastoreAssignment().setWorkspaceId(workspaceId).setMetastoreId(metastoreId));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/ProvidersAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/ProvidersAPI.java
@@ -18,6 +18,10 @@ public class ProvidersAPI {
     impl = mock;
   }
 
+  public ProviderInfo create(String name, AuthenticationType authenticationType) {
+    return create(new CreateProvider().setName(name).setAuthenticationType(authenticationType));
+  }
+
   /**
    * Create an auth provider.
    *
@@ -28,6 +32,10 @@ public class ProvidersAPI {
     return impl.create(request);
   }
 
+  public void delete(String name) {
+    delete(new DeleteProviderRequest().setName(name));
+  }
+
   /**
    * Delete a provider.
    *
@@ -36,6 +44,10 @@ public class ProvidersAPI {
    */
   public void delete(DeleteProviderRequest request) {
     impl.delete(request);
+  }
+
+  public ProviderInfo get(String name) {
+    return get(new GetProviderRequest().setName(name));
   }
 
   /**
@@ -59,6 +71,10 @@ public class ProvidersAPI {
     return impl.list(request);
   }
 
+  public ListProviderSharesResponse listShares(String name) {
+    return listShares(new ListSharesRequest().setName(name));
+  }
+
   /**
    * List shares by Provider.
    *
@@ -68,6 +84,10 @@ public class ProvidersAPI {
    */
   public ListProviderSharesResponse listShares(ListSharesRequest request) {
     return impl.listShares(request);
+  }
+
+  public ProviderInfo update(String name) {
+    return update(new UpdateProvider().setName(name));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/RecipientActivationAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/RecipientActivationAPI.java
@@ -18,6 +18,10 @@ public class RecipientActivationAPI {
     impl = mock;
   }
 
+  public void getActivationUrlInfo(String activationUrl) {
+    getActivationUrlInfo(new GetActivationUrlInfoRequest().setActivationUrl(activationUrl));
+  }
+
   /**
    * Get a share activation URL.
    *
@@ -25,6 +29,10 @@ public class RecipientActivationAPI {
    */
   public void getActivationUrlInfo(GetActivationUrlInfoRequest request) {
     impl.getActivationUrlInfo(request);
+  }
+
+  public RetrieveTokenResponse retrieveToken(String activationUrl) {
+    return retrieveToken(new RetrieveTokenRequest().setActivationUrl(activationUrl));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/RecipientsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/RecipientsAPI.java
@@ -18,6 +18,10 @@ public class RecipientsAPI {
     impl = mock;
   }
 
+  public RecipientInfo create(String name, AuthenticationType authenticationType) {
+    return create(new CreateRecipient().setName(name).setAuthenticationType(authenticationType));
+  }
+
   /**
    * Create a share recipient.
    *
@@ -28,6 +32,10 @@ public class RecipientsAPI {
     return impl.create(request);
   }
 
+  public void delete(String name) {
+    delete(new DeleteRecipientRequest().setName(name));
+  }
+
   /**
    * Delete a share recipient.
    *
@@ -36,6 +44,10 @@ public class RecipientsAPI {
    */
   public void delete(DeleteRecipientRequest request) {
     impl.delete(request);
+  }
+
+  public RecipientInfo get(String name) {
+    return get(new GetRecipientRequest().setName(name));
   }
 
   /**
@@ -61,6 +73,13 @@ public class RecipientsAPI {
     return impl.list(request);
   }
 
+  public RecipientInfo rotateToken(long existingTokenExpireInSeconds, String name) {
+    return rotateToken(
+        new RotateRecipientToken()
+            .setExistingTokenExpireInSeconds(existingTokenExpireInSeconds)
+            .setName(name));
+  }
+
   /**
    * Rotate a token.
    *
@@ -71,6 +90,10 @@ public class RecipientsAPI {
     return impl.rotateToken(request);
   }
 
+  public GetRecipientSharePermissionsResponse sharePermissions(String name) {
+    return sharePermissions(new SharePermissionsRequest().setName(name));
+  }
+
   /**
    * Get recipient share permissions.
    *
@@ -79,6 +102,10 @@ public class RecipientsAPI {
    */
   public GetRecipientSharePermissionsResponse sharePermissions(SharePermissionsRequest request) {
     return impl.sharePermissions(request);
+  }
+
+  public void update(String name) {
+    update(new UpdateRecipient().setName(name));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/SchemasAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/SchemasAPI.java
@@ -23,6 +23,10 @@ public class SchemasAPI {
     impl = mock;
   }
 
+  public SchemaInfo create(String name, String catalogName) {
+    return create(new CreateSchema().setName(name).setCatalogName(catalogName));
+  }
+
   /**
    * Create a schema.
    *
@@ -31,6 +35,10 @@ public class SchemasAPI {
    */
   public SchemaInfo create(CreateSchema request) {
     return impl.create(request);
+  }
+
+  public void delete(String fullName) {
+    delete(new DeleteSchemaRequest().setFullName(fullName));
   }
 
   /**
@@ -43,6 +51,10 @@ public class SchemasAPI {
     impl.delete(request);
   }
 
+  public SchemaInfo get(String fullName) {
+    return get(new GetSchemaRequest().setFullName(fullName));
+  }
+
   /**
    * Get a schema.
    *
@@ -51,6 +63,10 @@ public class SchemasAPI {
    */
   public SchemaInfo get(GetSchemaRequest request) {
     return impl.get(request);
+  }
+
+  public ListSchemasResponse list(String catalogName) {
+    return list(new ListSchemasRequest().setCatalogName(catalogName));
   }
 
   /**
@@ -64,6 +80,10 @@ public class SchemasAPI {
    */
   public ListSchemasResponse list(ListSchemasRequest request) {
     return impl.list(request);
+  }
+
+  public SchemaInfo update(String fullName) {
+    return update(new UpdateSchema().setFullName(fullName));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/SharesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/SharesAPI.java
@@ -18,6 +18,10 @@ public class SharesAPI {
     impl = mock;
   }
 
+  public ShareInfo create(String name) {
+    return create(new CreateShare().setName(name));
+  }
+
   /**
    * Create a share.
    *
@@ -29,6 +33,10 @@ public class SharesAPI {
     return impl.create(request);
   }
 
+  public void delete(String name) {
+    delete(new DeleteShareRequest().setName(name));
+  }
+
   /**
    * Delete a share.
    *
@@ -36,6 +44,10 @@ public class SharesAPI {
    */
   public void delete(DeleteShareRequest request) {
     impl.delete(request);
+  }
+
+  public ShareInfo get(String name) {
+    return get(new GetShareRequest().setName(name));
   }
 
   /**
@@ -59,6 +71,10 @@ public class SharesAPI {
     return impl.list();
   }
 
+  public PermissionsList sharePermissions(String name) {
+    return sharePermissions(new SharePermissionsRequest().setName(name));
+  }
+
   /**
    * Get permissions.
    *
@@ -67,6 +83,10 @@ public class SharesAPI {
    */
   public PermissionsList sharePermissions(SharePermissionsRequest request) {
     return impl.sharePermissions(request);
+  }
+
+  public ShareInfo update(String name) {
+    return update(new UpdateShare().setName(name));
   }
 
   /**
@@ -88,6 +108,10 @@ public class SharesAPI {
    */
   public ShareInfo update(UpdateShare request) {
     return impl.update(request);
+  }
+
+  public void updatePermissions(String name) {
+    updatePermissions(new UpdateSharePermissions().setName(name));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/StorageCredentialsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/StorageCredentialsAPI.java
@@ -31,6 +31,10 @@ public class StorageCredentialsAPI {
     impl = mock;
   }
 
+  public StorageCredentialInfo create(String name, String metastoreId) {
+    return create(new CreateStorageCredential().setName(name).setMetastoreId(metastoreId));
+  }
+
   /**
    * Create a storage credential.
    *
@@ -46,6 +50,10 @@ public class StorageCredentialsAPI {
     return impl.create(request);
   }
 
+  public void delete(String name) {
+    delete(new DeleteStorageCredentialRequest().setName(name));
+  }
+
   /**
    * Delete a credential.
    *
@@ -54,6 +62,10 @@ public class StorageCredentialsAPI {
    */
   public void delete(DeleteStorageCredentialRequest request) {
     impl.delete(request);
+  }
+
+  public StorageCredentialInfo get(String name) {
+    return get(new GetStorageCredentialRequest().setName(name));
   }
 
   /**
@@ -76,6 +88,10 @@ public class StorageCredentialsAPI {
    */
   public List<StorageCredentialInfo> list() {
     return impl.list();
+  }
+
+  public StorageCredentialInfo update(String name) {
+    return update(new UpdateStorageCredential().setName(name));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/TableConstraintsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/TableConstraintsAPI.java
@@ -29,6 +29,11 @@ public class TableConstraintsAPI {
     impl = mock;
   }
 
+  public TableConstraint create(String fullNameArg, TableConstraint constraint) {
+    return create(
+        new CreateTableConstraint().setFullNameArg(fullNameArg).setConstraint(constraint));
+  }
+
   /**
    * Create a table constraint.
    *
@@ -43,6 +48,14 @@ public class TableConstraintsAPI {
    */
   public TableConstraint create(CreateTableConstraint request) {
     return impl.create(request);
+  }
+
+  public void delete(String fullName, String constraintName, boolean cascade) {
+    delete(
+        new DeleteTableConstraintRequest()
+            .setFullName(fullName)
+            .setConstraintName(constraintName)
+            .setCascade(cascade));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/TablesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/TablesAPI.java
@@ -27,6 +27,10 @@ public class TablesAPI {
     impl = mock;
   }
 
+  public void delete(String fullName) {
+    delete(new DeleteTableRequest().setFullName(fullName));
+  }
+
   /**
    * Delete a table.
    *
@@ -37,6 +41,10 @@ public class TablesAPI {
    */
   public void delete(DeleteTableRequest request) {
     impl.delete(request);
+  }
+
+  public TableInfo get(String fullName) {
+    return get(new GetTableRequest().setFullName(fullName));
   }
 
   /**
@@ -51,6 +59,10 @@ public class TablesAPI {
     return impl.get(request);
   }
 
+  public ListTablesResponse list(String catalogName, String schemaName) {
+    return list(new ListTablesRequest().setCatalogName(catalogName).setSchemaName(schemaName));
+  }
+
   /**
    * List tables.
    *
@@ -62,6 +74,10 @@ public class TablesAPI {
    */
   public ListTablesResponse list(ListTablesRequest request) {
     return impl.list(request);
+  }
+
+  public ListTableSummariesResponse listSummaries(String catalogName) {
+    return listSummaries(new ListSummariesRequest().setCatalogName(catalogName));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/WorkspaceAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/WorkspaceAPI.java
@@ -24,6 +24,10 @@ public class WorkspaceAPI {
     impl = mock;
   }
 
+  public void delete(String path) {
+    delete(new Delete().setPath(path));
+  }
+
   /**
    * Delete a workspace object.
    *
@@ -36,6 +40,10 @@ public class WorkspaceAPI {
    */
   public void delete(Delete request) {
     impl.delete(request);
+  }
+
+  public ExportResponse export(String path) {
+    return export(new Export().setPath(path));
   }
 
   /**
@@ -53,6 +61,10 @@ public class WorkspaceAPI {
     return impl.export(request);
   }
 
+  public ObjectInfo getStatus(String path) {
+    return getStatus(new GetStatus().setPath(path));
+  }
+
   /**
    * Get status.
    *
@@ -61,6 +73,10 @@ public class WorkspaceAPI {
    */
   public ObjectInfo getStatus(GetStatus request) {
     return impl.getStatus(request);
+  }
+
+  public void importContent(String path) {
+    importContent(new Import().setPath(path));
   }
 
   /**
@@ -74,6 +90,10 @@ public class WorkspaceAPI {
     impl.importContent(request);
   }
 
+  public ListResponse list(String path) {
+    return list(new List().setPath(path));
+  }
+
   /**
    * List contents.
    *
@@ -82,6 +102,10 @@ public class WorkspaceAPI {
    */
   public ListResponse list(List request) {
     return impl.list(request);
+  }
+
+  public void mkdirs(String path) {
+    mkdirs(new Mkdirs().setPath(path));
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspaceconf/WorkspaceConfAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspaceconf/WorkspaceConfAPI.java
@@ -19,6 +19,10 @@ public class WorkspaceConfAPI {
     impl = mock;
   }
 
+  public Map<String, String> getStatus(String keys) {
+    return getStatus(new GetStatus().setKeys(keys));
+  }
+
   /**
    * Check configuration status.
    *


### PR DESCRIPTION
## Changes
For every method with required request fields, generate overloaded method with a simplified signature:

```java
  public PolicyFamily get(String policyFamilyId) {
    return get(new GetPolicyFamilyRequest().setPolicyFamilyId(policyFamilyId));
  }

  public PolicyFamily get(GetPolicyFamilyRequest request) {
    return impl.get(request);
  }
```

## Tests
n/a

