### PR TITLE
Added logging via `slf4j-api`

### DIFF
--- a/.codegen/api.java.tmpl
+++ b/.codegen/api.java.tmpl
@@ -10,7 +10,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.client.DatabricksException;
@@ -21,6 +22,8 @@ import com.databricks.sdk.support.Wait;
  {{.Comment " * " 80}}
  */{{end}}
 public class {{.PascalName}}API {
+  private static final Logger LOG = LoggerFactory.getLogger({{.PascalName}}API.class);
+
   private final {{.PascalName}}Service impl;
 
   /** Regular-use constructor */
@@ -75,8 +78,7 @@ public class {{.PascalName}}API {
             // sleep 10s max per attempt
             sleep = 10;
         }
-        String logMessage = String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-        // log.info(logMessage);
+        LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
         try {
             Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
         } catch (InterruptedException e) {

--- a/databricks-sdk-java/pom.xml
+++ b/databricks-sdk-java/pom.xml
@@ -16,6 +16,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <mockito.version>5.2.0</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <slf4j.version>2.0.7</slf4j.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -29,6 +30,17 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-reload4j</artifactId>
+      <version>2.0.7</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/client/BodyLogger.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/client/BodyLogger.java
@@ -1,0 +1,122 @@
+package com.databricks.sdk.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.util.*;
+
+class BodyLogger {
+  private final Set<String> redactKeys =
+      new HashSet<String>() {
+        {
+          add("string_value");
+          add("token_value");
+          add("content");
+        }
+      };
+  private int maxBytes = 1023;
+  private int debugTruncateBytes = 96;
+  private final ObjectMapper mapper;
+
+  public BodyLogger(ObjectMapper mapper, int maxBytes, int debugTruncateBytes) {
+    this.mapper = mapper;
+    if (maxBytes == 0) {
+      maxBytes = 1024;
+    }
+    if (debugTruncateBytes > maxBytes) {
+      maxBytes = debugTruncateBytes;
+    }
+    this.maxBytes = maxBytes;
+    this.debugTruncateBytes = debugTruncateBytes;
+  }
+
+  private List<String> mapKeys(TreeNode node) {
+    List<String> keys = new ArrayList<>();
+    node.fieldNames().forEachRemaining(keys::add);
+    Collections.sort(keys);
+    return keys;
+  }
+
+  public String redactedDump(String body) {
+    if (body == null || body.isEmpty()) {
+      return "";
+    }
+    try {
+      JsonNode rootNode = mapper.readTree(body);
+      Object result = recursiveMarshal(rootNode, maxBytes);
+      return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(result);
+    } catch (JsonProcessingException e) {
+      // Unable to unmarshal means the body isn't JSON (or something else)
+      return String.format("[unable to marshal: %s]", e.getMessage());
+    }
+  }
+
+  private Object recursiveMarshal(JsonNode node, int budget) {
+    if (node.isObject()) {
+      return recursiveMarshalObject(node, budget);
+    }
+    if (node.isArray()) {
+      return recursiveMarshalArray((ArrayNode) node, budget);
+    }
+    if (node.isTextual()) {
+      return onlyNBytes(node.asText(), debugTruncateBytes);
+    }
+    if (node.isNumber()) {
+      return node.asLong();
+    }
+    if (node.isDouble()) {
+      return node.asDouble();
+    }
+    if (node.isBoolean()) {
+      return node.asBoolean();
+    }
+    return node.asToken().asString();
+  }
+
+  private List<Object> recursiveMarshalArray(ArrayNode rawArray, int budget) {
+    List<Object> out = new ArrayList<>();
+
+    // The first element of a slice appears in the output, regardless of character budget.
+    // Subsequent elements are included if the budget allows.
+    for (int i = 0; i < rawArray.size(); i++) {
+      // If we're out of character budget, include trailer.
+      if (i > 0 && budget <= 0) {
+        out.add(String.format("... (%d additional elements)", rawArray.size() - out.size()));
+        break;
+      }
+      Object raw = recursiveMarshal(rawArray.get(i), budget);
+      out.add(raw);
+      budget -= raw.toString().length();
+    }
+
+    return out;
+  }
+
+  private Map<String, Object> recursiveMarshalObject(JsonNode node, int budget) {
+    Map<String, Object> out = new TreeMap<>();
+
+    // Each key in the map appears in the output, regardless of character budget.
+    for (String key : mapKeys(node)) {
+      if (redactKeys.contains(key)) {
+        out.put(key, "**REDACTED**");
+        continue;
+      }
+      JsonNode valueNode = node.get(key);
+      Object result = recursiveMarshal(valueNode, budget);
+      budget -= result.toString().length();
+      out.put(key, result);
+    }
+
+    return out;
+  }
+
+  private static String onlyNBytes(String j, int numBytes) {
+    int diff = j.getBytes().length - numBytes;
+    if (diff > 0) {
+      return String.format("%s... (%d more bytes)", j.substring(0, numBytes), diff);
+    }
+    return j;
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/client/ConfigLoader.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/client/ConfigLoader.java
@@ -13,9 +13,13 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import org.ini4j.Ini;
 import org.ini4j.Profile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConfigLoader {
-  private static List<ConfigAttributeAccessor> accessors = attributeAccessors();
+  private static final Logger LOG = LoggerFactory.getLogger(ConfigLoader.class);
+
+  private static final List<ConfigAttributeAccessor> accessors = attributeAccessors();
 
   static List<ConfigAttributeAccessor> attributeAccessors() {
     ArrayList<ConfigAttributeAccessor> attrs = new ArrayList<>();
@@ -220,7 +224,7 @@ public class ConfigLoader {
 
     Profile.Section section = ini.get(profile);
     if (section == null && !hasExplicitProfile) {
-      // logger.Debugf("%s has no %s profile configured", configFile, profile)
+      LOG.debug("{} has no {} profile configured", configFile, profile);
       return;
     }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/client/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/client/DatabricksConfig.java
@@ -117,7 +117,7 @@ public class DatabricksConfig {
 
   /** Debug HTTP headers of requests made by the provider. Default is false. */
   @ConfigAttribute(value = "debug_headers", env = "DATABRICKS_DEBUG_HEADERS")
-  private Boolean debugHeaders;
+  private boolean debugHeaders;
 
   /** Maximum number of requests per second made to Databricks REST API. */
   @ConfigAttribute(value = "rate_limit", env = "DATABRICKS_RATE_LIMIT")

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/client/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/client/DefaultCredentialsProvider.java
@@ -4,8 +4,12 @@ import com.databricks.sdk.client.oauth.AzureServicePrincipalCredentialsProvider;
 import com.databricks.sdk.client.oauth.OAuthM2MServicePrincipalCredentialsProvider;
 import java.util.Arrays;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultCredentialsProvider implements CredentialsProvider {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultCredentialsProvider.class);
+
   private List<CredentialsProvider> providers;
 
   private String authType = "default";
@@ -25,7 +29,8 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
       if (config.getAuthType() != null
           && !config.getAuthType().isEmpty()
           && provider.authType().equals(config.getAuthType())) {
-        // TODO: log this
+        LOG.info(
+            "Ignoring {} auth, because {} is preferred", provider.authType(), config.getAuthType());
         continue;
       }
       HeaderFactory headerFactory = provider.configure(config);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BillableUsageAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BillableUsageAPI.java
@@ -2,13 +2,16 @@
 package com.databricks.sdk.service.billing;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This API allows you to download billable usage logs for the specified account and date range.
  * This feature works with all account types.
  */
 public class BillableUsageAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(BillableUsageAPI.class);
+
   private final BillableUsageService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BudgetsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BudgetsAPI.java
@@ -2,13 +2,16 @@
 package com.databricks.sdk.service.billing;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs manage budget configuration including notifications for exceeding a budget for a
  * period. They can also retrieve the status of each budget.
  */
 public class BudgetsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(BudgetsAPI.class);
+
   private final BudgetsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/LogDeliveryAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/LogDeliveryAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.billing;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs manage log delivery configurations for this account. The two supported log types for
@@ -61,6 +62,8 @@ import org.apache.http.client.methods.*;
  * https://docs.databricks.com/administration-guide/account-api/aws-storage.html
  */
 public class LogDeliveryAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(LogDeliveryAPI.class);
+
   private final LogDeliveryService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusterpolicies/ClusterPoliciesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusterpolicies/ClusterPoliciesAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.clusterpolicies;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Cluster policy limits the ability to configure clusters based on a set of rules. The policy rules
@@ -27,6 +28,8 @@ import org.apache.http.client.methods.*;
  * policies.
  */
 public class ClusterPoliciesAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterPoliciesAPI.class);
+
   private final ClusterPoliciesService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusterpolicies/PolicyFamiliesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusterpolicies/PolicyFamiliesAPI.java
@@ -3,7 +3,8 @@ package com.databricks.sdk.service.clusterpolicies;
 
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.support.Paginator;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * View available policy families. A policy family contains a policy definition providing best
@@ -17,6 +18,8 @@ import org.apache.http.client.methods.*;
  * family's policy definition.
  */
 public class PolicyFamiliesAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(PolicyFamiliesAPI.class);
+
   private final PolicyFamiliesService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusters/ClustersAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusters/ClustersAPI.java
@@ -8,7 +8,8 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Clusters API allows you to create, start, edit, list, terminate, and delete clusters.
@@ -35,6 +36,8 @@ import org.apache.http.client.methods.*;
  * more than 30 days, an administrator can pin a cluster to the cluster list.
  */
 public class ClustersAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(ClustersAPI.class);
+
   private final ClustersService impl;
 
   /** Regular-use constructor */
@@ -79,9 +82,7 @@ public class ClustersAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
@@ -124,9 +125,7 @@ public class ClustersAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusters/InstanceProfilesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/clusters/InstanceProfilesAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.clusters;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Instance Profiles API allows admins to add, list, and remove instance profiles that users can
@@ -13,6 +14,8 @@ import org.apache.http.client.methods.*;
  * https://docs.databricks.com/administration-guide/cloud-configurations/aws/instance-profiles.html
  */
 public class InstanceProfilesAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(InstanceProfilesAPI.class);
+
   private final InstanceProfilesService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/commands/CommandExecutionAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/commands/CommandExecutionAPI.java
@@ -7,12 +7,15 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This API allows execution of Python, Scala, SQL, or R commands on running Databricks Clusters.
  */
 public class CommandExecutionAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(CommandExecutionAPI.class);
+
   private final CommandExecutionService impl;
 
   /** Regular-use constructor */
@@ -74,9 +77,7 @@ public class CommandExecutionAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
@@ -136,9 +137,7 @@ public class CommandExecutionAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
@@ -188,9 +187,7 @@ public class CommandExecutionAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dbfs/DbfsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dbfs/DbfsAPI.java
@@ -2,13 +2,16 @@
 package com.databricks.sdk.service.dbfs;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * DBFS API makes it simple to interact with various data sources without having to include a users
  * credentials every time to read a file.
  */
 public class DbfsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(DbfsAPI.class);
+
   private final DbfsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/CredentialsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/CredentialsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.deployment;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs manage credential configurations for this workspace. Databricks needs access to a
@@ -11,6 +12,8 @@ import org.apache.http.client.methods.*;
  * information, and its ID is used when creating a new workspace.
  */
 public class CredentialsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(CredentialsAPI.class);
+
   private final CredentialsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/EncryptionKeysAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/EncryptionKeysAPI.java
@@ -3,7 +3,8 @@ package com.databricks.sdk.service.deployment;
 
 import com.databricks.sdk.client.ApiClient;
 import java.util.Collection;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs manage encryption key configurations for this workspace (optional). A key
@@ -21,6 +22,8 @@ import org.apache.http.client.methods.*;
  * platform. If you are not sure, contact your Databricks representative.
  */
 public class EncryptionKeysAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(EncryptionKeysAPI.class);
+
   private final EncryptionKeysService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/NetworksAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/NetworksAPI.java
@@ -2,13 +2,16 @@
 package com.databricks.sdk.service.deployment;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs manage network configurations for customer-managed VPCs (optional). Its ID is used
  * when creating a new workspace if you use customer-managed VPCs.
  */
 public class NetworksAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(NetworksAPI.class);
+
   private final NetworksService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/PrivateAccessAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/PrivateAccessAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.deployment;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs manage private access settings for this account. A private access settings object
@@ -16,6 +17,8 @@ import org.apache.http.client.methods.*;
  * https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
  */
 public class PrivateAccessAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(PrivateAccessAPI.class);
+
   private final PrivateAccessService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/StorageAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/StorageAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.deployment;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs manage storage configurations for this workspace. A root storage S3 bucket in your
@@ -12,6 +13,8 @@ import org.apache.http.client.methods.*;
  * workspace.
  */
 public class StorageAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(StorageAPI.class);
+
   private final StorageService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/VpcEndpointsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/VpcEndpointsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.deployment;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs manage VPC endpoint configurations for this account. This object registers an AWS VPC
@@ -17,6 +18,8 @@ import org.apache.http.client.methods.*;
  * https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
  */
 public class VpcEndpointsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(VpcEndpointsAPI.class);
+
   private final VpcEndpointsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/WorkspacesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/deployment/WorkspacesAPI.java
@@ -7,7 +7,8 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs manage workspaces for this account. A Databricks workspace is an environment for
@@ -19,6 +20,8 @@ import org.apache.http.client.methods.*;
  * select custom plan that allows multiple workspaces per account.
  */
 public class WorkspacesAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(WorkspacesAPI.class);
+
   private final WorkspacesService impl;
 
   /** Regular-use constructor */
@@ -64,9 +67,7 @@ public class WorkspacesAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/endpoints/ServingEndpointsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/endpoints/ServingEndpointsAPI.java
@@ -8,7 +8,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Serving Endpoints API allows you to create, update, and delete model serving endpoints.
@@ -23,6 +24,8 @@ import org.apache.http.client.methods.*;
  * should be applied to each served model.
  */
 public class ServingEndpointsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(ServingEndpointsAPI.class);
+
   private final ServingEndpointsService impl;
 
   /** Regular-use constructor */
@@ -72,9 +75,7 @@ public class ServingEndpointsAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/gitcredentials/GitCredentialsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/gitcredentials/GitCredentialsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.gitcredentials;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Registers personal access token for Databricks to do operations on behalf of the user.
@@ -12,6 +13,8 @@ import org.apache.http.client.methods.*;
  * <p>[more info]: https://docs.databricks.com/repos/get-access-tokens-from-git-provider.html
  */
 public class GitCredentialsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(GitCredentialsAPI.class);
+
   private final GitCredentialsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/globalinitscripts/GlobalInitScriptsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/globalinitscripts/GlobalInitScriptsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.globalinitscripts;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Global Init Scripts API enables Workspace administrators to configure global initialization
@@ -14,6 +15,8 @@ import org.apache.http.client.methods.*;
  * enough containers fail, the entire cluster fails with a `GLOBAL_INIT_SCRIPT_FAILURE` error code.
  */
 public class GlobalInitScriptsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(GlobalInitScriptsAPI.class);
+
   private final GlobalInitScriptsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/instancepools/InstancePoolsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/instancepools/InstancePoolsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.instancepools;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Instance Pools API are used to create, edit, delete and list instance pools by using ready-to-use
@@ -22,6 +23,8 @@ import org.apache.http.client.methods.*;
  * billing does apply. See pricing.
  */
 public class InstancePoolsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(InstancePoolsAPI.class);
+
   private final InstancePoolsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ipaccesslists/IpAccessListsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ipaccesslists/IpAccessListsAPI.java
@@ -3,7 +3,8 @@ package com.databricks.sdk.service.ipaccesslists;
 
 import com.databricks.sdk.client.ApiClient;
 import java.util.Collection;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * IP Access List enables admins to configure IP access lists.
@@ -27,6 +28,8 @@ import org.apache.http.client.methods.*;
  * effect.
  */
 public class IpAccessListsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(IpAccessListsAPI.class);
+
   private final IpAccessListsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/JobsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/JobsAPI.java
@@ -8,7 +8,8 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Jobs API allows you to create, edit, and delete jobs.
@@ -29,6 +30,8 @@ import org.apache.http.client.methods.*;
  * https://docs.databricks.com/dev-tools/databricks-utils.html#dbutils-secrets
  */
 public class JobsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(JobsAPI.class);
+
   private final JobsService impl;
 
   /** Regular-use constructor */
@@ -80,9 +83,7 @@ public class JobsAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/libraries/LibrariesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/libraries/LibrariesAPI.java
@@ -3,7 +3,8 @@ package com.databricks.sdk.service.libraries;
 
 import com.databricks.sdk.client.ApiClient;
 import java.util.Collection;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Libraries API allows you to install and uninstall libraries and get the status of libraries
@@ -27,6 +28,8 @@ import org.apache.http.client.methods.*;
  * Uninstall pending restart.
  */
 public class LibrariesAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(LibrariesAPI.class);
+
   private final LibrariesService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ExperimentsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ExperimentsAPI.java
@@ -3,9 +3,12 @@ package com.databricks.sdk.service.mlflow;
 
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.support.Paginator;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ExperimentsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(ExperimentsAPI.class);
+
   private final ExperimentsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowArtifactsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowArtifactsAPI.java
@@ -3,9 +3,12 @@ package com.databricks.sdk.service.mlflow;
 
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.support.Paginator;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MLflowArtifactsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(MLflowArtifactsAPI.class);
+
   private final MLflowArtifactsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowDatabricksAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowDatabricksAPI.java
@@ -2,13 +2,16 @@
 package com.databricks.sdk.service.mlflow;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These endpoints are modified versions of the MLflow API that accept additional input parameters
  * or return additional information.
  */
 public class MLflowDatabricksAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(MLflowDatabricksAPI.class);
+
   private final MLflowDatabricksService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowMetricsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowMetricsAPI.java
@@ -2,9 +2,12 @@
 package com.databricks.sdk.service.mlflow;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MLflowMetricsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(MLflowMetricsAPI.class);
+
   private final MLflowMetricsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowRunsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/MLflowRunsAPI.java
@@ -3,9 +3,12 @@ package com.databricks.sdk.service.mlflow;
 
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.support.Paginator;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MLflowRunsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(MLflowRunsAPI.class);
+
   private final MLflowRunsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ModelVersionCommentsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ModelVersionCommentsAPI.java
@@ -2,9 +2,12 @@
 package com.databricks.sdk.service.mlflow;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ModelVersionCommentsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(ModelVersionCommentsAPI.class);
+
   private final ModelVersionCommentsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ModelVersionsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/ModelVersionsAPI.java
@@ -3,9 +3,12 @@ package com.databricks.sdk.service.mlflow;
 
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.support.Paginator;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ModelVersionsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(ModelVersionsAPI.class);
+
   private final ModelVersionsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/RegisteredModelsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/RegisteredModelsAPI.java
@@ -3,9 +3,12 @@ package com.databricks.sdk.service.mlflow;
 
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.support.Paginator;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RegisteredModelsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(RegisteredModelsAPI.class);
+
   private final RegisteredModelsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/RegistryWebhooksAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/RegistryWebhooksAPI.java
@@ -4,9 +4,12 @@ package com.databricks.sdk.service.mlflow;
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.support.Paginator;
 import java.util.Collection;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RegistryWebhooksAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(RegistryWebhooksAPI.class);
+
   private final RegistryWebhooksService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/TransitionRequestsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/mlflow/TransitionRequestsAPI.java
@@ -2,9 +2,12 @@
 package com.databricks.sdk.service.mlflow;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TransitionRequestsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(TransitionRequestsAPI.class);
+
   private final TransitionRequestsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/CustomAppIntegrationAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/CustomAppIntegrationAPI.java
@@ -3,7 +3,8 @@ package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.client.ApiClient;
 import java.util.Collection;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs enable administrators to manage custom oauth app integrations, which is required for
@@ -13,6 +14,8 @@ import org.apache.http.client.methods.*;
  * status is enabled. For more details see :method:OAuthEnrollment/create
  */
 public class CustomAppIntegrationAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(CustomAppIntegrationAPI.class);
+
   private final CustomAppIntegrationService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/OAuthEnrollmentAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/OAuthEnrollmentAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs enable administrators to enroll OAuth for their accounts, which is required for
@@ -12,6 +13,8 @@ import org.apache.http.client.methods.*;
  * only supported on the E2 version.
  */
 public class OAuthEnrollmentAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(OAuthEnrollmentAPI.class);
+
   private final OAuthEnrollmentService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/PublishedAppIntegrationAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/PublishedAppIntegrationAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs enable administrators to manage published oauth app integrations, which is required
@@ -12,6 +13,8 @@ import org.apache.http.client.methods.*;
  * enrollment status is enabled. For more details see :method:OAuthEnrollment/create
  */
 public class PublishedAppIntegrationAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(PublishedAppIntegrationAPI.class);
+
   private final PublishedAppIntegrationService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/permissions/PermissionsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/permissions/PermissionsAPI.java
@@ -2,13 +2,16 @@
 package com.databricks.sdk.service.permissions;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Permissions API are used to create read, write, edit, update and manage access for various users
  * on different objects and endpoints.
  */
 public class PermissionsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(PermissionsAPI.class);
+
   private final PermissionsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/permissions/WorkspaceAssignmentAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/permissions/WorkspaceAssignmentAPI.java
@@ -3,13 +3,16 @@ package com.databricks.sdk.service.permissions;
 
 import com.databricks.sdk.client.ApiClient;
 import java.util.Collection;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Workspace Permission Assignment API allows you to manage workspace permissions for principals
  * in your account.
  */
 public class WorkspaceAssignmentAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(WorkspaceAssignmentAPI.class);
+
   private final WorkspaceAssignmentService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesAPI.java
@@ -8,7 +8,8 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Delta Live Tables API allows you to create, edit, delete, start, and view details about
@@ -26,6 +27,8 @@ import org.apache.http.client.methods.*;
  * fail those expectations.
  */
 public class PipelinesAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(PipelinesAPI.class);
+
   private final PipelinesService impl;
 
   /** Regular-use constructor */
@@ -71,9 +74,7 @@ public class PipelinesAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
@@ -117,9 +118,7 @@ public class PipelinesAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/repos/ReposAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/repos/ReposAPI.java
@@ -3,7 +3,8 @@ package com.databricks.sdk.service.repos;
 
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.support.Paginator;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Repos API allows users to manage their git repos. Users can use the API to access all repos
@@ -18,6 +19,8 @@ import org.apache.http.client.methods.*;
  * CI/CD.
  */
 public class ReposAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(ReposAPI.class);
+
   private final ReposService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountGroupsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountGroupsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.scim;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Groups simplify identity management, making it easier to assign access to Databricks Account,
@@ -13,6 +14,8 @@ import org.apache.http.client.methods.*;
  * assigned as members of groups, and members inherit permissions that are assigned to their group.
  */
 public class AccountGroupsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(AccountGroupsAPI.class);
+
   private final AccountGroupsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountServicePrincipalsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountServicePrincipalsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.scim;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Identities for use with jobs, automated tools, and systems such as scripts, apps, and CI/CD
@@ -12,6 +13,8 @@ import org.apache.http.client.methods.*;
  * eliminates the risk of a user overwriting production data by accident.
  */
 public class AccountServicePrincipalsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(AccountServicePrincipalsAPI.class);
+
   private final AccountServicePrincipalsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountUsersAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/AccountUsersAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.scim;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * User identities recognized by Databricks and represented by email addresses.
@@ -16,6 +17,8 @@ import org.apache.http.client.methods.*;
  * process and prevents unauthorized users from accessing sensitive data.
  */
 public class AccountUsersAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(AccountUsersAPI.class);
+
   private final AccountUsersService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/CurrentUserAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/CurrentUserAPI.java
@@ -2,12 +2,15 @@
 package com.databricks.sdk.service.scim;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This API allows retrieving information about currently authenticated user or service principal.
  */
 public class CurrentUserAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(CurrentUserAPI.class);
+
   private final CurrentUserService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/GroupsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/GroupsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.scim;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Groups simplify identity management, making it easier to assign access to Databricks Workspace,
@@ -13,6 +14,8 @@ import org.apache.http.client.methods.*;
  * assigned as members of groups, and members inherit permissions that are assigned to their group.
  */
 public class GroupsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(GroupsAPI.class);
+
   private final GroupsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/ServicePrincipalsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/ServicePrincipalsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.scim;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Identities for use with jobs, automated tools, and systems such as scripts, apps, and CI/CD
@@ -12,6 +13,8 @@ import org.apache.http.client.methods.*;
  * eliminates the risk of a user overwriting production data by accident.
  */
 public class ServicePrincipalsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(ServicePrincipalsAPI.class);
+
   private final ServicePrincipalsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/UsersAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/scim/UsersAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.scim;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * User identities recognized by Databricks and represented by email addresses.
@@ -16,6 +17,8 @@ import org.apache.http.client.methods.*;
  * process and prevents unauthorized users from accessing sensitive data.
  */
 public class UsersAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(UsersAPI.class);
+
   private final UsersService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/secrets/SecretsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/secrets/SecretsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.secrets;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Secrets API allows you to manage secrets, secret scopes, and access permissions.
@@ -16,6 +17,8 @@ import org.apache.http.client.methods.*;
  * is not possible to prevent such users from reading secrets.
  */
 public class SecretsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(SecretsAPI.class);
+
   private final SecretsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The alerts API can be used to perform CRUD operations on alerts. An alert is a Databricks SQL
@@ -10,6 +11,8 @@ import org.apache.http.client.methods.*;
  * more users and/or notification destinations if the condition was met.
  */
 public class AlertsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(AlertsAPI.class);
+
   private final AlertsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardsAPI.java
@@ -3,7 +3,8 @@ package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.support.Paginator;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * In general, there is little need to modify dashboards using the API. However, it can be useful to
@@ -12,6 +13,8 @@ import org.apache.http.client.methods.*;
  * and then POST it to create a new one.
  */
 public class DashboardsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(DashboardsAPI.class);
+
   private final DashboardsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DataSourcesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DataSourcesAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This API is provided to assist you in making new query objects. When creating a query object, you
@@ -15,6 +16,8 @@ import org.apache.http.client.methods.*;
  * from this API for the name of your SQL warehouse as it appears in Databricks SQL.
  */
 public class DataSourcesAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(DataSourcesAPI.class);
+
   private final DataSourcesService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DbsqlPermissionsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DbsqlPermissionsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The SQL Permissions API is similar to the endpoints of the :method:permissions/set. However, this
@@ -19,6 +20,8 @@ import org.apache.http.client.methods.*;
  * `CAN_RUN`)
  */
 public class DbsqlPermissionsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(DbsqlPermissionsAPI.class);
+
   private final DbsqlPermissionsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesAPI.java
@@ -3,13 +3,16 @@ package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.support.Paginator;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These endpoints are used for CRUD operations on query definitions. Query definitions include the
  * target SQL warehouse, query text, name, description, tags, parameters, and visualizations.
  */
 public class QueriesAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(QueriesAPI.class);
+
   private final QueriesService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryHistoryAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryHistoryAPI.java
@@ -3,10 +3,13 @@ package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.client.ApiClient;
 import com.databricks.sdk.support.Paginator;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Access the history of queries through SQL warehouses. */
 public class QueryHistoryAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(QueryHistoryAPI.class);
+
   private final QueryHistoryService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/StatementExecutionAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/StatementExecutionAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The SQL Statement Execution API manages the execution of arbitrary SQL statements and the
@@ -167,6 +168,8 @@ import org.apache.http.client.methods.*;
  * tutorial]: https://docs.databricks.com/sql/api/sql-execution-tutorial.html
  */
 public class StatementExecutionAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(StatementExecutionAPI.class);
+
   private final StatementExecutionService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesAPI.java
@@ -7,7 +7,8 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A SQL warehouse is a compute resource that lets you run SQL commands on data objects within
@@ -15,6 +16,8 @@ import org.apache.http.client.methods.*;
  * capabilities in the cloud.
  */
 public class WarehousesAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(WarehousesAPI.class);
+
   private final WarehousesService impl;
 
   /** Regular-use constructor */
@@ -57,9 +60,7 @@ public class WarehousesAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
@@ -106,9 +107,7 @@ public class WarehousesAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
@@ -149,9 +148,7 @@ public class WarehousesAPI {
         // sleep 10s max per attempt
         sleep = 10;
       }
-      String logMessage =
-          String.format("%s: (%s) %s (sleeping ~%ds)%n", prefix, status, statusMessage, sleep);
-      // log.info(logMessage);
+      LOG.info("{}: ({}) {} (sleeping ~{}s)", prefix, status, statusMessage, sleep);
       try {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/tokenmanagement/TokenManagementAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/tokenmanagement/TokenManagementAPI.java
@@ -2,13 +2,16 @@
 package com.databricks.sdk.service.tokenmanagement;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Enables administrators to get all tokens and delete tokens for other users. Admins can either get
  * every token, get a specific token by ID, or get all tokens for a particular user.
  */
 public class TokenManagementAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(TokenManagementAPI.class);
+
   private final TokenManagementService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/tokens/TokensAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/tokens/TokensAPI.java
@@ -2,13 +2,16 @@
 package com.databricks.sdk.service.tokens;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Token API allows you to create, list, and revoke tokens that can be used to authenticate and
  * access Databricks REST APIs.
  */
 public class TokensAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(TokensAPI.class);
+
   private final TokensService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountMetastoreAssignmentsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountMetastoreAssignmentsAPI.java
@@ -2,10 +2,13 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** These APIs manage metastore assignments to a workspace. */
 public class AccountMetastoreAssignmentsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(AccountMetastoreAssignmentsAPI.class);
+
   private final AccountMetastoreAssignmentsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountMetastoresAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountMetastoresAPI.java
@@ -2,13 +2,16 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * These APIs manage Unity Catalog metastores for an account. A metastore contains catalogs that can
  * be associated with workspaces
  */
 public class AccountMetastoresAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(AccountMetastoresAPI.class);
+
   private final AccountMetastoresService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountStorageCredentialsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/AccountStorageCredentialsAPI.java
@@ -2,10 +2,13 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** These APIs manage storage credentials for a particular metastore. */
 public class AccountStorageCredentialsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(AccountStorageCredentialsAPI.class);
+
   private final AccountStorageCredentialsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/CatalogsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/CatalogsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A catalog is the first layer of Unity Catalog’s three-level namespace. It’s used to organize your
@@ -14,6 +15,8 @@ import org.apache.http.client.methods.*;
  * access to the same data, depending on privileges granted centrally in Unity Catalog.
  */
 public class CatalogsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(CatalogsAPI.class);
+
   private final CatalogsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/ExternalLocationsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/ExternalLocationsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An external location is an object that combines a cloud storage path with a storage credential
@@ -17,6 +18,8 @@ import org.apache.http.client.methods.*;
  * **CREATE_EXTERNAL_LOCATION** privilege.
  */
 public class ExternalLocationsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(ExternalLocationsAPI.class);
+
   private final ExternalLocationsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/FunctionsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/FunctionsAPI.java
@@ -3,7 +3,8 @@ package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
 import java.util.Collection;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Functions implement User-Defined Functions (UDFs) in Unity Catalog.
@@ -14,6 +15,8 @@ import org.apache.http.client.methods.*;
  * __catalog_name__.__schema_name__.__function_name__.
  */
 public class FunctionsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(FunctionsAPI.class);
+
   private final FunctionsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/GrantsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/GrantsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * In Unity Catalog, data is secure by default. Initially, users have no access to data in a
@@ -16,6 +17,8 @@ import org.apache.http.client.methods.*;
  * inherited by all current and future objects within that schema.
  */
 public class GrantsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(GrantsAPI.class);
+
   private final GrantsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/MetastoresAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/MetastoresAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A metastore is the top-level container of objects in Unity Catalog. It stores data assets (tables
@@ -18,6 +19,8 @@ import org.apache.http.client.methods.*;
  * in that metastore is available in a catalog named hive_metastore.
  */
 public class MetastoresAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(MetastoresAPI.class);
+
   private final MetastoresService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/ProvidersAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/ProvidersAPI.java
@@ -2,10 +2,13 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Databricks Delta Sharing: Providers REST API */
 public class ProvidersAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(ProvidersAPI.class);
+
   private final ProvidersService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/RecipientActivationAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/RecipientActivationAPI.java
@@ -2,10 +2,13 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Databricks Delta Sharing: Recipient Activation REST API */
 public class RecipientActivationAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(RecipientActivationAPI.class);
+
   private final RecipientActivationService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/RecipientsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/RecipientsAPI.java
@@ -2,10 +2,13 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Databricks Delta Sharing: Recipients REST API */
 public class RecipientsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(RecipientsAPI.class);
+
   private final RecipientsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/SchemasAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/SchemasAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A schema (also called a database) is the second layer of Unity Catalog’s three-level namespace. A
@@ -11,6 +12,8 @@ import org.apache.http.client.methods.*;
  * must have the SELECT permission on the table or view.
  */
 public class SchemasAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(SchemasAPI.class);
+
   private final SchemasService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/SharesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/SharesAPI.java
@@ -2,10 +2,13 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Databricks Delta Sharing: Shares REST API */
 public class SharesAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(SharesAPI.class);
+
   private final SharesService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/StorageCredentialsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/StorageCredentialsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A storage credential represents an authentication and authorization mechanism for accessing data
@@ -18,6 +19,8 @@ import org.apache.http.client.methods.*;
  * permissions on it.
  */
 public class StorageCredentialsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(StorageCredentialsAPI.class);
+
   private final StorageCredentialsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/TableConstraintsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/TableConstraintsAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Primary key and foreign key constraints encode relationships between fields in tables.
@@ -17,6 +18,8 @@ import org.apache.http.client.methods.*;
  * creation. You can also add or drop constraints on existing tables.
  */
 public class TableConstraintsAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(TableConstraintsAPI.class);
+
   private final TableConstraintsService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/TablesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/unitycatalog/TablesAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.unitycatalog;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A table resides in the third layer of Unity Catalog’s three-level namespace. It contains rows of
@@ -15,6 +16,8 @@ import org.apache.http.client.methods.*;
  * of table (rather than a managed or external table).
  */
 public class TablesAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(TablesAPI.class);
+
   private final TablesService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/WorkspaceAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/WorkspaceAPI.java
@@ -2,7 +2,8 @@
 package com.databricks.sdk.service.workspace;
 
 import com.databricks.sdk.client.ApiClient;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Workspace API allows you to list, import, export, and delete notebooks and folders.
@@ -11,6 +12,8 @@ import org.apache.http.client.methods.*;
  * and explanatory text.
  */
 public class WorkspaceAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(WorkspaceAPI.class);
+
   private final WorkspaceService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspaceconf/WorkspaceConfAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspaceconf/WorkspaceConfAPI.java
@@ -3,10 +3,13 @@ package com.databricks.sdk.service.workspaceconf;
 
 import com.databricks.sdk.client.ApiClient;
 import java.util.Map;
-import org.apache.http.client.methods.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** This API allows updating known workspace settings for advanced users. */
 public class WorkspaceConfAPI {
+  private static final Logger LOG = LoggerFactory.getLogger(WorkspaceConfAPI.class);
+
   private final WorkspaceConfService impl;
 
   /** Regular-use constructor */

--- a/databricks-sdk-java/src/test/resources/log4j.properties
+++ b/databricks-sdk-java/src/test/resources/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootLogger=INFO, CONSOLE
+
+# CONSOLE is set to be a ConsoleAppender using a PatternLayout
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm} [%-5p] %m%n
+
+# a more detailed PatternLayout: %d [%t] %-5p %c - %m%n
+
+log4j.logger.com.databricks=TRACE


### PR DESCRIPTION
## Changes
- Logging depends on `slf4j-api` 2.x implementation available on the classpath.
- All HTTP requests/responses are logged with sensitive values redacted away, when DEBUG level is explicitly enabled for `com.databricks.sdk.client.ApiClient` class (or any of the parent loggers). It's recommended to enable debug logging only on development machines and during incident troubleshooting, as Databricks REST API requests will go through re-formatting and redaction.
- All requests and responses are truncated for logging purposes. By default, they should not exceed approximately one kilobyte.
- `debug_truncate_bytes` (env: `DATABRICKS_DEBUG_TRUNCATE_BYTES`) config setting allows to control the default 96 bytes of JSON body truncation for debug logs.
- Long-running operations do log their intermediate state on INFO level.

## Tests
non-auth tests are passing now

