### PR TITLE
Some Fixes for the OAuth-M2M Pathway

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/client/oauth/OAuthM2MServicePrincipalCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/client/oauth/OAuthM2MServicePrincipalCredentialsProvider.java
@@ -55,7 +55,7 @@ public class OAuthM2MServicePrincipalCredentialsProvider implements CredentialsP
               .build();
 
       return () -> {
-        Token token = tokenSource.refresh();
+        Token token = tokenSource.getToken();
         Map<String, String> headers = new HashMap<>();
         headers.put("Authorization", token.getTokenType() + " " + token.getAccessToken());
         return headers;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/client/oauth/OpenIDConnectResponse.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/client/oauth/OpenIDConnectResponse.java
@@ -1,7 +1,9 @@
 package com.databricks.sdk.client.oauth;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OpenIDConnectResponse {
   @JsonProperty("token_endpoint")
   private String tokenEndpoint;


### PR DESCRIPTION
## Changes
This PR fixes two small bugs in the OAuth M2M pathway:
1. Call `.getToken()` instead of `.refresh()` when authorizing a request. Refresh only needs to be called when a token is about to expire or is expired.
2. Add JsonIgnoreProperties to ignore extra fields in the OIDC response.

## Tests
- [ ] ClustersIT tests succeed. Note: there is currently a bug in the in-house M2M pathway. This has been fixed in dev and is expected to be released by end of month.

