### PR TITLE
Use `maven-failsafe-plugin` plugin to use `integration-test` phase in maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,14 @@
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.22.0</version>
+        <version>3.0.0-M6</version>
         <executions>
           <execution>
             <goals>
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
+            <phase>integration-test</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
We don't run integration tests in `integration-test` or `verify` phase of maven -- currently it only runs unit tests. Adding failsafe plugin for that.

Version - 3.0.0-M6
> 3.0.0-M6 | ReportEntry contains new fields testRunId:long and RunMode which help identifying the tests and logs. The plugin supports Java 1.8 and Maven Plugin API 3.2.5. Many bug fixes.


Note: Nightly job is here: https://github.com/databricks/eng-dev-ecosystem/pull/246 (we use `mvn clean verify`)

## Tests
<!-- How is this tested? -->
`mvn test` --> runs only units tests
`mvn integration-test` --> runs integration tests (also unit tests since it comes before that phase in the lifecycle and maven runs all the phases before that: https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle).

This PR only adds functionality to run the test. It doesn't fix them (they are failing currently). Java 8 compatibility will be tested here: https://github.com/databricks/databricks-sdk-jvm/pull/37
