### PR TITLE
Mocked `DatabricksConfig.resolve()` to fix `SimpleHttpServerTest` and `ClustersExtTest`

### DIFF
--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/client/SimpleHttpServerTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/client/SimpleHttpServerTest.java
@@ -3,9 +3,11 @@ package com.databricks.sdk.client;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.databricks.sdk.DatabricksWorkspace;
+import com.databricks.sdk.client.commons.CommonsHttpClient;
 import com.databricks.sdk.service.compute.ListNodeTypesResponse;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class SimpleHttpServerTest {
 
@@ -14,9 +16,15 @@ class SimpleHttpServerTest {
     try (FixtureServer fixtures = new FixtureServer()) {
       fixtures.with("GET /api/2.0/clusters/list-node-types", "{\"node_types\": []}");
 
-      DatabricksWorkspace workspace =
-          new DatabricksWorkspace(
-              new DatabricksConfig().setHost(fixtures.getUrl()).setToken("..."));
+      DatabricksConfig config =
+          new DatabricksConfig()
+              .setHost(fixtures.getUrl())
+              .setToken("...")
+              .setHttpClient(new CommonsHttpClient(30));
+      DatabricksConfig mockConfig = Mockito.spy(config);
+      Mockito.doReturn(mockConfig).when(mockConfig).resolve();
+
+      DatabricksWorkspace workspace = new DatabricksWorkspace(mockConfig);
       ListNodeTypesResponse nodeTypes = workspace.clusters().listNodeTypes();
 
       assertEquals(0, nodeTypes.getNodeTypes().size());

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/ClustersExtTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/ClustersExtTest.java
@@ -7,6 +7,7 @@ import com.databricks.sdk.client.http.Request;
 import com.databricks.sdk.client.http.Response;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class ClustersExtTest {
 
@@ -18,13 +19,16 @@ class ClustersExtTest {
                 new Request("GET", "https://localhost/api/2.0/clusters/get")
                     .withQueryParam("cluster_id", "abc"),
                 new Response("{}"));
-    ClustersExt clustersExt =
-        new ClustersExt(
-            new ApiClient(
-                new DatabricksConfig()
-                    .setHost("localhost")
-                    .setToken("bcd")
-                    .setHttpClient(httpClient)));
+
+    DatabricksConfig config =
+        new DatabricksConfig()
+            .setHost("https://localhost")
+            .setToken("bcd")
+            .setHttpClient(httpClient);
+    DatabricksConfig mockConfig = Mockito.spy(config);
+    Mockito.doReturn(mockConfig).when(mockConfig).resolve();
+
+    ClustersExt clustersExt = new ClustersExt(new ApiClient(mockConfig));
 
     clustersExt.ensureClusterIsRunning("abc");
   }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
We need to mock `resolve()` for these tests because otherwise it fails due to more than one authorization method configured since it reads environment variables from the system. 

## Tests
<!-- How is this tested? -->
These test fail on main for `azure-prod`, `azure-prod-acct` and `aws-prod`. Both are passing on all three of them with the changes in PR.
