### PR TITLE
Fixed `jacoco-maven-plugin` to not break build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
               <goal>check</goal>
             </goals>
             <configuration>
+              <haltOnFailure>false</haltOnFailure>
               <rules>
                 <rule>
                   <element>BUNDLE</element>


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Jacoco doesn't fail the build if coverage is lower than threshold. However we still keep it in case we want to check locally. Just putting this flag to true or removing this configuration (since default is true) we can check coverage.

## Tests
<!-- How is this tested? -->
Set limit to 0.9 and it didn't fail build for both `mvn clean install` and `mvn clean verify`
<img width="992" alt="image" src="https://user-images.githubusercontent.com/88379306/236254734-0330d713-3210-4417-a1a5-3e94245ce115.png">
