### PR TITLE
Added `cluster_id` to `DatabricksConfig` for DBConnect

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -58,6 +58,9 @@ public class DatabricksConfig {
   @ConfigAttribute(value = "config_file", env = "DATABRICKS_CONFIG_FILE")
   private String configFile;
 
+  @ConfigAttribute(value = "cluster_id", env = "DATABRICKS_CLUSTER_ID")
+  private String clusterId;
+
   @ConfigAttribute(
       value = "google_service_account",
       env = "DATABRICKS_GOOGLE_SERVICE_ACCOUNT",
@@ -249,6 +252,15 @@ public class DatabricksConfig {
 
   public DatabricksConfig setUsername(String username) {
     this.username = username;
+    return this;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public DatabricksConfig setClusterId(String clusterId) {
+    this.clusterId = clusterId;
     return this;
   }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Python SDK for reference: https://github.com/databricks/databricks-sdk-py/blob/main/databricks/sdk/core.py#LL392C2-L392C2.

## Tests
<!-- How is this tested? -->
PR Tests
