### PR TITLE
Synchronize auth permutation tests with Go SDK

### DIFF
--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
@@ -220,6 +220,34 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
   }
 
   @Test
+  public void testTestConfigConfigFileWithEmptyDefaultProfileSelectDefault() {
+    // Set environment variables
+    StaticEnv env = new StaticEnv().with("HOME", resource("/testdata/empty_default"));
+    raises(
+        "default auth: cannot configure default credentials",
+        () -> {
+          DatabricksConfig config = new DatabricksConfig();
+          resolveConfig(config, env);
+          config.authenticate();
+        });
+  }
+
+  @Test
+  public void testTestConfigConfigFileWithEmptyDefaultProfileSelectAbc() {
+    // Set environment variables
+    StaticEnv env =
+        new StaticEnv()
+            .with("DATABRICKS_CONFIG_PROFILE", "abc")
+            .with("HOME", resource("/testdata/empty_default"));
+    DatabricksConfig config = new DatabricksConfig();
+    resolveConfig(config, env);
+    config.authenticate();
+
+    assertEquals("pat", config.getAuthType());
+    assertEquals("https://foo", config.getHost());
+  }
+
+  @Test
   public void testTestConfigPatFromDatabricksCfg() {
     // Set environment variables
     StaticEnv env = new StaticEnv().with("HOME", resource("/testdata"));

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java.tmpl
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java.tmpl
@@ -4,10 +4,10 @@
 package com.databricks.sdk;
 
 import static org.junit.jupiter.api.Assertions.*;
-import com.databricks.sdk.client.ConfigResolving;
-import com.databricks.sdk.client.DatabricksConfig;
-import com.databricks.sdk.client.utils.GitHubUtils;
-import com.databricks.sdk.client.utils.TestOSUtils;
+import com.databricks.sdk.core.ConfigResolving;
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.utils.GitHubUtils;
+import com.databricks.sdk.core.utils.TestOSUtils;
 import java.io.File;
 import org.junit.jupiter.api.Test;
 import java.net.URL;

--- a/databricks-sdk-java/src/test/resources/testdata/empty_default/.databrickscfg
+++ b/databricks-sdk-java/src/test/resources/testdata/empty_default/.databrickscfg
@@ -1,0 +1,6 @@
+; The profile defined in the DEFAULT section is be used as fallback when no profile is explicitly specified.
+[DEFAULT]
+
+[abc]
+host  = https://foo
+token = xyz


### PR DESCRIPTION
## Changes

Incorporate auth permutations tests from databricks/databricks-sdk-go#496.

## Tests

New auth tests pass.

