### PR TITLE
Add accounts-dod support in the Java SDK

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -491,10 +491,7 @@ public class DatabricksConfig {
     if (host == null) {
       return false;
     }
-    if (host.contains("https://accounts.")) {
-      return true;
-    }
-    return false;
+    return host.startsWith("https://accounts.") || host.startsWith("https://accounts-dod.");
   }
 
   public OpenIDConnectEndpoints getOidcEndpoints() throws IOException {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -1,0 +1,23 @@
+package com.databricks.sdk.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DatabricksConfigTest {
+  @Test
+  public void testIsAccountHost() {
+    assertTrue(new DatabricksConfig().setHost("https://accounts.azuredatabricks.net").isAccountClient());
+  }
+
+  @Test
+  public void testIsAccountHostDod() {
+    assertTrue(new DatabricksConfig().setHost("https://accounts-dod.cloud.databricks.us").isAccountClient());
+  }
+
+  @Test
+  public void testIsAccountHostWorkspace() {
+    assertFalse(new DatabricksConfig().setHost("https://westeurope.azuredatabricks.net").isAccountClient());
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -1,23 +1,28 @@
 package com.databricks.sdk.core;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 public class DatabricksConfigTest {
   @Test
   public void testIsAccountHost() {
-    assertTrue(new DatabricksConfig().setHost("https://accounts.azuredatabricks.net").isAccountClient());
+    assertTrue(
+        new DatabricksConfig().setHost("https://accounts.azuredatabricks.net").isAccountClient());
   }
 
   @Test
   public void testIsAccountHostDod() {
-    assertTrue(new DatabricksConfig().setHost("https://accounts-dod.cloud.databricks.us").isAccountClient());
+    assertTrue(
+        new DatabricksConfig()
+            .setHost("https://accounts-dod.cloud.databricks.us")
+            .isAccountClient());
   }
 
   @Test
   public void testIsAccountHostWorkspace() {
-    assertFalse(new DatabricksConfig().setHost("https://westeurope.azuredatabricks.net").isAccountClient());
+    assertFalse(
+        new DatabricksConfig().setHost("https://westeurope.azuredatabricks.net").isAccountClient());
   }
 }


### PR DESCRIPTION
## Changes
Adds support for the accounts-dod.cloud.databricks.us endpoint as an accounts endpoint in the SDK.

## Tests
- [x] Unit test
