### PR TITLE
Fix release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,4 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          draft: true
           files: target/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
         run: mvn -Prelease -DskipTests=true --batch-mode deploy
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Changes
I think there are two small bugs in the configuration of the release deployment in our github action:
1. the environment variable name is incorrect: it should be OSSRH_USERNAME/OSSRH_PASSWORD instead of MAVEN_USERNAME/MAVEN_PASSWORD.
2. action-gh-release should attach these resources to the existing release that will be created by our release automation tooling. This will not be a draft release, so I'll remove that flag.

## Tests
<!-- How is this tested? -->

