### PR TITLE
Add merge queue for Java SDK

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,8 +3,8 @@ name: build
 on:
   pull_request:
     types: [opened, synchronize]
-  push:
-    branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   fmt:


### PR DESCRIPTION
## Changes
Add merge queue for Java SDK to support merging PRs which haven't been manually updated to latest main.

## Tests
<!-- How is this tested? -->

