### PR TITLE
Set necessary headers when authenticating via Azure CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+fmt:
+	mvn spotless:apply
+

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
@@ -43,6 +43,7 @@ public class AzureCliCredentialsProvider implements CredentialsProvider, AzureUt
       try {
         mgmtTokenSource.getToken();
       } catch (Exception e) {
+        LOG.debug("Not including service management token in headers", e);
         mgmtTokenSource = null;
       }
       CliTokenSource finalMgmtTokenSource = mgmtTokenSource;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
@@ -37,12 +37,23 @@ public class AzureCliCredentialsProvider implements CredentialsProvider, AzureUt
       ensureHostPresent(config, mapper);
       String resource = config.getEffectiveAzureLoginAppId();
       CliTokenSource tokenSource = tokenSourceFor(config, resource);
+      CliTokenSource mgmtTokenSource =
+          tokenSourceFor(config, config.getAzureEnvironment().getServiceManagementEndpoint());
       tokenSource.getToken(); // We need this for checking if Azure CLI is installed.
+      try {
+        mgmtTokenSource.getToken();
+      } catch (Exception e) {
+        mgmtTokenSource = null;
+      }
+      CliTokenSource finalMgmtTokenSource = mgmtTokenSource;
       return () -> {
         Token token = tokenSource.getToken();
         Map<String, String> headers = new HashMap<>();
         headers.put("Authorization", token.getTokenType() + " " + token.getAccessToken());
-        return headers;
+        if (finalMgmtTokenSource != null) {
+          addSpManagementToken(finalMgmtTokenSource, headers);
+        }
+        return addWorkspaceResourceId(config, headers);
       };
     } catch (DatabricksException e) {
       String stderr = e.getMessage();

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/AzureServicePrincipalCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/AzureServicePrincipalCredentialsProvider.java
@@ -34,11 +34,8 @@ public class AzureServicePrincipalCredentialsProvider implements CredentialsProv
     return () -> {
       Map<String, String> headers = new HashMap<>();
       headers.put("Authorization", "Bearer " + inner.getToken().getAccessToken());
-      headers.put("X-Databricks-Azure-SP-Management-Token", cloud.getToken().getAccessToken());
-      if (config.getAzureWorkspaceResourceId() != null) {
-        headers.put(
-            "X-Databricks-Azure-Workspace-Resource-Id", config.getAzureWorkspaceResourceId());
-      }
+      addWorkspaceResourceId(config, headers);
+      addSpManagementToken(cloud, headers);
       return headers;
     };
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/AzureUtils.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/AzureUtils.java
@@ -92,4 +92,17 @@ public interface AzureUtils {
       throw new DatabricksException("Unable to fetch workspace URL: " + e.getMessage(), e);
     }
   }
+
+  default Map<String, String> addWorkspaceResourceId(DatabricksConfig config, Map<String, String> headers) {
+    if (config.getAzureWorkspaceResourceId() != null) {
+      headers.put(
+          "X-Databricks-Azure-Workspace-Resource-Id", config.getAzureWorkspaceResourceId());
+    }
+    return headers;
+  }
+
+  default Map<String, String> addSpManagementToken(RefreshableTokenSource tokenSource, Map<String, String> headers) {
+    headers.put("X-Databricks-Azure-SP-Management-Token", tokenSource.getToken().getAccessToken());
+    return headers;
+  }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/AzureUtils.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/AzureUtils.java
@@ -93,15 +93,16 @@ public interface AzureUtils {
     }
   }
 
-  default Map<String, String> addWorkspaceResourceId(DatabricksConfig config, Map<String, String> headers) {
+  default Map<String, String> addWorkspaceResourceId(
+      DatabricksConfig config, Map<String, String> headers) {
     if (config.getAzureWorkspaceResourceId() != null) {
-      headers.put(
-          "X-Databricks-Azure-Workspace-Resource-Id", config.getAzureWorkspaceResourceId());
+      headers.put("X-Databricks-Azure-Workspace-Resource-Id", config.getAzureWorkspaceResourceId());
     }
     return headers;
   }
 
-  default Map<String, String> addSpManagementToken(RefreshableTokenSource tokenSource, Map<String, String> headers) {
+  default Map<String, String> addSpManagementToken(
+      RefreshableTokenSource tokenSource, Map<String, String> headers) {
     headers.put("X-Databricks-Azure-SP-Management-Token", tokenSource.getToken().getAccessToken());
     return headers;
   }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
@@ -1,0 +1,56 @@
+package com.databricks.sdk;
+
+import com.databricks.sdk.core.ConfigResolving;
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.utils.TestOSUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class DatabricksAuthManualTest implements ConfigResolving {
+  @Test
+  void azureCliWorkspaceHeaderPresent() {
+    StaticEnv env =
+      new StaticEnv().with("HOME", TestOSUtils.resource("/testdata/azure")).with("PATH", "testdata:/bin");
+    String azureWorkspaceResourceId = "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
+    DatabricksConfig config = new DatabricksConfig()
+        .setAuthType("azure-cli")
+        .setHost("https://x")
+        .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
+    resolveConfig(config, env);
+    Map<String, String> headers = config.authenticate();
+    Assertions.assertEquals(azureWorkspaceResourceId, headers.get("X-Databricks-Azure-Workspace-Resource-Id"));
+  }
+
+  @Test
+  void azureCliUserWithManagementAccess() {
+    StaticEnv env = new StaticEnv()
+        .with("HOME", TestOSUtils.resource("/testdata/azure"))
+        .with("PATH", "testdata:/bin");
+    String azureWorkspaceResourceId = "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
+    DatabricksConfig config = new DatabricksConfig()
+        .setAuthType("azure-cli")
+        .setHost("https://x")
+        .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
+    resolveConfig(config, env);
+    Map<String, String> headers = config.authenticate();
+    Assertions.assertEquals("...", headers.get("X-Databricks-Azure-SP-Management-Token"));
+  }
+
+  @Test
+  void azureCliUserNoManagementAccess() {
+    StaticEnv env = new StaticEnv()
+        .with("HOME", TestOSUtils.resource("/testdata/azure"))
+        .with("PATH", "testdata:/bin")
+        .with("FAIL_IF", "https://management.core.windows.net/");
+    String azureWorkspaceResourceId = "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
+    DatabricksConfig config = new DatabricksConfig()
+        .setAuthType("azure-cli")
+        .setHost("https://x")
+        .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
+    resolveConfig(config, env);
+    Map<String, String> headers = config.authenticate();
+    Assertions.assertNull(headers.get("X-Databricks-Azure-SP-Management-Token"));
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
@@ -3,36 +3,43 @@ package com.databricks.sdk;
 import com.databricks.sdk.core.ConfigResolving;
 import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.core.utils.TestOSUtils;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
 
 public class DatabricksAuthManualTest implements ConfigResolving {
   @Test
   void azureCliWorkspaceHeaderPresent() {
     StaticEnv env =
-      new StaticEnv().with("HOME", TestOSUtils.resource("/testdata/azure")).with("PATH", "testdata:/bin");
-    String azureWorkspaceResourceId = "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
-    DatabricksConfig config = new DatabricksConfig()
-        .setAuthType("azure-cli")
-        .setHost("https://x")
-        .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
+        new StaticEnv()
+            .with("HOME", TestOSUtils.resource("/testdata/azure"))
+            .with("PATH", "testdata:/bin");
+    String azureWorkspaceResourceId =
+        "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
+    DatabricksConfig config =
+        new DatabricksConfig()
+            .setAuthType("azure-cli")
+            .setHost("https://x")
+            .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
     resolveConfig(config, env);
     Map<String, String> headers = config.authenticate();
-    Assertions.assertEquals(azureWorkspaceResourceId, headers.get("X-Databricks-Azure-Workspace-Resource-Id"));
+    Assertions.assertEquals(
+        azureWorkspaceResourceId, headers.get("X-Databricks-Azure-Workspace-Resource-Id"));
   }
 
   @Test
   void azureCliUserWithManagementAccess() {
-    StaticEnv env = new StaticEnv()
-        .with("HOME", TestOSUtils.resource("/testdata/azure"))
-        .with("PATH", "testdata:/bin");
-    String azureWorkspaceResourceId = "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
-    DatabricksConfig config = new DatabricksConfig()
-        .setAuthType("azure-cli")
-        .setHost("https://x")
-        .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
+    StaticEnv env =
+        new StaticEnv()
+            .with("HOME", TestOSUtils.resource("/testdata/azure"))
+            .with("PATH", "testdata:/bin");
+    String azureWorkspaceResourceId =
+        "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
+    DatabricksConfig config =
+        new DatabricksConfig()
+            .setAuthType("azure-cli")
+            .setHost("https://x")
+            .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
     resolveConfig(config, env);
     Map<String, String> headers = config.authenticate();
     Assertions.assertEquals("...", headers.get("X-Databricks-Azure-SP-Management-Token"));
@@ -40,15 +47,18 @@ public class DatabricksAuthManualTest implements ConfigResolving {
 
   @Test
   void azureCliUserNoManagementAccess() {
-    StaticEnv env = new StaticEnv()
-        .with("HOME", TestOSUtils.resource("/testdata/azure"))
-        .with("PATH", "testdata:/bin")
-        .with("FAIL_IF", "https://management.core.windows.net/");
-    String azureWorkspaceResourceId = "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
-    DatabricksConfig config = new DatabricksConfig()
-        .setAuthType("azure-cli")
-        .setHost("https://x")
-        .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
+    StaticEnv env =
+        new StaticEnv()
+            .with("HOME", TestOSUtils.resource("/testdata/azure"))
+            .with("PATH", "testdata:/bin")
+            .with("FAIL_IF", "https://management.core.windows.net/");
+    String azureWorkspaceResourceId =
+        "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
+    DatabricksConfig config =
+        new DatabricksConfig()
+            .setAuthType("azure-cli")
+            .setHost("https://x")
+            .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
     resolveConfig(config, env);
     Map<String, String> headers = config.authenticate();
     Assertions.assertNull(headers.get("X-Databricks-Azure-SP-Management-Token"));

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
@@ -10,8 +10,6 @@ import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.core.utils.GitHubUtils;
 import com.databricks.sdk.core.utils.TestOSUtils;
 import java.io.File;
-import java.net.URL;
-
 import org.junit.jupiter.api.Test;
 
 public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
@@ -336,7 +334,9 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
   public void testTestConfigAzureCliHost() {
     // Set environment variables
     StaticEnv env =
-        new StaticEnv().with("HOME", TestOSUtils.resource("/testdata/azure")).with("PATH", "testdata:/bin");
+        new StaticEnv()
+            .with("HOME", TestOSUtils.resource("/testdata/azure"))
+            .with("PATH", "testdata:/bin");
     DatabricksConfig config =
         new DatabricksConfig().setHost("x").setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
@@ -369,7 +369,9 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
   public void testTestConfigAzureCliHostAzNotInstalled() {
     // Set environment variables
     StaticEnv env =
-        new StaticEnv().with("HOME", TestOSUtils.resource("/testdata/azure")).with("PATH", "whatever");
+        new StaticEnv()
+            .with("HOME", TestOSUtils.resource("/testdata/azure"))
+            .with("PATH", "whatever");
     raises(
         "default auth: cannot configure default credentials. Config: azure_workspace_resource_id=/sub/rg/ws",
         () -> {
@@ -384,7 +386,9 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
   public void testTestConfigAzureCliHostPatConflictWithConfigFilePresentWithoutDefaultProfile() {
     // Set environment variables
     StaticEnv env =
-        new StaticEnv().with("HOME", TestOSUtils.resource("/testdata/azure")).with("PATH", "testdata:/bin");
+        new StaticEnv()
+            .with("HOME", TestOSUtils.resource("/testdata/azure"))
+            .with("PATH", "testdata:/bin");
     raises(
         "validate: more than one authorization method configured: azure and pat. Config: token=***, azure_workspace_resource_id=/sub/rg/ws",
         () -> {
@@ -399,7 +403,9 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
   public void testTestConfigAzureCliHostAndResourceId() {
     // Set environment variables
     StaticEnv env =
-        new StaticEnv().with("HOME", TestOSUtils.resource("/testdata")).with("PATH", "testdata:/bin");
+        new StaticEnv()
+            .with("HOME", TestOSUtils.resource("/testdata"))
+            .with("PATH", "testdata:/bin");
     DatabricksConfig config =
         new DatabricksConfig().setHost("x").setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
@@ -11,18 +11,13 @@ import com.databricks.sdk.core.utils.GitHubUtils;
 import com.databricks.sdk.core.utils.TestOSUtils;
 import java.io.File;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Supplier;
+
 import org.junit.jupiter.api.Test;
 
-public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResolving {
-
-  private static String prefixPath;
+public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
 
   public DatabricksAuthTest() {
     setPermissionOnTestAz();
-    prefixPath = System.getProperty("user.dir") + getTestDir();
   }
 
   @Test
@@ -209,7 +204,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
   @Test
   public void testTestConfigConfigFileSkipDefaultProfileIfHostSpecified() {
     // Set environment variables
-    StaticEnv env = new StaticEnv().with("HOME", resource("/testdata"));
+    StaticEnv env = new StaticEnv().with("HOME", TestOSUtils.resource("/testdata"));
     raises(
         "default auth: cannot configure default credentials. Config: host=https://x",
         () -> {
@@ -222,7 +217,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
   @Test
   public void testTestConfigConfigFileWithEmptyDefaultProfileSelectDefault() {
     // Set environment variables
-    StaticEnv env = new StaticEnv().with("HOME", resource("/testdata/empty_default"));
+    StaticEnv env = new StaticEnv().with("HOME", TestOSUtils.resource("/testdata/empty_default"));
     raises(
         "default auth: cannot configure default credentials",
         () -> {
@@ -238,7 +233,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
     StaticEnv env =
         new StaticEnv()
             .with("DATABRICKS_CONFIG_PROFILE", "abc")
-            .with("HOME", resource("/testdata/empty_default"));
+            .with("HOME", TestOSUtils.resource("/testdata/empty_default"));
     DatabricksConfig config = new DatabricksConfig();
     resolveConfig(config, env);
     config.authenticate();
@@ -250,7 +245,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
   @Test
   public void testTestConfigPatFromDatabricksCfg() {
     // Set environment variables
-    StaticEnv env = new StaticEnv().with("HOME", resource("/testdata"));
+    StaticEnv env = new StaticEnv().with("HOME", TestOSUtils.resource("/testdata"));
     DatabricksConfig config = new DatabricksConfig();
     resolveConfig(config, env);
     config.authenticate();
@@ -265,7 +260,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
     StaticEnv env =
         new StaticEnv()
             .with("DATABRICKS_CONFIG_PROFILE", "pat.with.dot")
-            .with("HOME", resource("/testdata"));
+            .with("HOME", TestOSUtils.resource("/testdata"));
     DatabricksConfig config = new DatabricksConfig();
     resolveConfig(config, env);
     config.authenticate();
@@ -280,7 +275,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
     StaticEnv env =
         new StaticEnv()
             .with("DATABRICKS_CONFIG_PROFILE", "nohost")
-            .with("HOME", resource("/testdata"));
+            .with("HOME", TestOSUtils.resource("/testdata"));
     raises(
         "default auth: cannot configure default credentials. Config: token=***, profile=nohost. Env: DATABRICKS_CONFIG_PROFILE",
         () -> {
@@ -297,7 +292,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
         new StaticEnv()
             .with("DATABRICKS_CONFIG_PROFILE", "nohost")
             .with("DATABRICKS_TOKEN", "x")
-            .with("HOME", resource("/testdata"));
+            .with("HOME", TestOSUtils.resource("/testdata"));
     raises(
         "default auth: cannot configure default credentials. Config: token=***, profile=nohost. Env: DATABRICKS_TOKEN, DATABRICKS_CONFIG_PROFILE",
         () -> {
@@ -314,7 +309,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
         new StaticEnv()
             .with("DATABRICKS_CONFIG_PROFILE", "nohost")
             .with("DATABRICKS_USERNAME", "x")
-            .with("HOME", resource("/testdata"));
+            .with("HOME", TestOSUtils.resource("/testdata"));
     raises(
         "validate: more than one authorization method configured: basic and pat. Config: token=***, username=x, profile=nohost. Env: DATABRICKS_USERNAME, DATABRICKS_CONFIG_PROFILE",
         () -> {
@@ -341,7 +336,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
   public void testTestConfigAzureCliHost() {
     // Set environment variables
     StaticEnv env =
-        new StaticEnv().with("HOME", resource("/testdata/azure")).with("PATH", "testdata:/bin");
+        new StaticEnv().with("HOME", TestOSUtils.resource("/testdata/azure")).with("PATH", "testdata:/bin");
     DatabricksConfig config =
         new DatabricksConfig().setHost("x").setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
@@ -358,7 +353,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
     StaticEnv env =
         new StaticEnv()
             .with("FAIL", "yes")
-            .with("HOME", resource("/testdata/azure"))
+            .with("HOME", TestOSUtils.resource("/testdata/azure"))
             .with("PATH", "testdata:/bin");
     raises(
         "default auth: azure-cli: cannot get access token: This is just a failing script.\n. Config: azure_workspace_resource_id=/sub/rg/ws",
@@ -374,7 +369,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
   public void testTestConfigAzureCliHostAzNotInstalled() {
     // Set environment variables
     StaticEnv env =
-        new StaticEnv().with("HOME", resource("/testdata/azure")).with("PATH", "whatever");
+        new StaticEnv().with("HOME", TestOSUtils.resource("/testdata/azure")).with("PATH", "whatever");
     raises(
         "default auth: cannot configure default credentials. Config: azure_workspace_resource_id=/sub/rg/ws",
         () -> {
@@ -389,7 +384,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
   public void testTestConfigAzureCliHostPatConflictWithConfigFilePresentWithoutDefaultProfile() {
     // Set environment variables
     StaticEnv env =
-        new StaticEnv().with("HOME", resource("/testdata/azure")).with("PATH", "testdata:/bin");
+        new StaticEnv().with("HOME", TestOSUtils.resource("/testdata/azure")).with("PATH", "testdata:/bin");
     raises(
         "validate: more than one authorization method configured: azure and pat. Config: token=***, azure_workspace_resource_id=/sub/rg/ws",
         () -> {
@@ -404,7 +399,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
   public void testTestConfigAzureCliHostAndResourceId() {
     // Set environment variables
     StaticEnv env =
-        new StaticEnv().with("HOME", resource("/testdata")).with("PATH", "testdata:/bin");
+        new StaticEnv().with("HOME", TestOSUtils.resource("/testdata")).with("PATH", "testdata:/bin");
     DatabricksConfig config =
         new DatabricksConfig().setHost("x").setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
@@ -421,7 +416,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
     StaticEnv env =
         new StaticEnv()
             .with("DATABRICKS_CONFIG_PROFILE", "justhost")
-            .with("HOME", resource("/testdata/azure"))
+            .with("HOME", TestOSUtils.resource("/testdata/azure"))
             .with("PATH", "testdata:/bin");
     DatabricksConfig config =
         new DatabricksConfig().setHost("x").setAzureWorkspaceResourceId("/sub/rg/ws");
@@ -439,7 +434,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
     StaticEnv env =
         new StaticEnv()
             .with("DATABRICKS_USERNAME", "x")
-            .with("HOME", resource("/testdata/azure"))
+            .with("HOME", TestOSUtils.resource("/testdata/azure"))
             .with("PATH", "testdata:/bin");
     raises(
         "validate: more than one authorization method configured: azure and basic. Config: host=x, username=x, azure_workspace_resource_id=/sub/rg/ws. Env: DATABRICKS_USERNAME",
@@ -457,7 +452,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
     StaticEnv env =
         new StaticEnv()
             .with("DATABRICKS_CONFIG_PROFILE", "DEFAULT")
-            .with("HOME", resource("/testdata/corrupt"));
+            .with("HOME", TestOSUtils.resource("/testdata/corrupt"));
     raises(
         "resolve: testdata/corrupt/.databrickscfg has no DEFAULT profile configured. Config: profile=DEFAULT. Env: DATABRICKS_CONFIG_PROFILE",
         () -> {
@@ -484,31 +479,6 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
     assertEquals("https://x", config.getHost());
   }
 
-  private String resource(String file) {
-    URL resource = getClass().getResource(file);
-    if (resource == null) {
-      fail("Asset not found: " + file);
-    }
-    return resource.getFile();
-  }
-
-  static class StaticEnv implements Supplier<Map<String, String>> {
-    private final Map<String, String> env = new HashMap<>();
-
-    public StaticEnv with(String key, String value) {
-      if (key.equals("PATH")) {
-        value = prefixPath + value;
-      }
-      env.put(key, value);
-      return this;
-    }
-
-    @Override
-    public Map<String, String> get() {
-      return env;
-    }
-  }
-
   private void raises(String contains, Runnable cb) {
     boolean raised = false;
     try {
@@ -521,7 +491,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
               File.separator,
               "/"); // We would need to do this upstream also for making paths compatible with
       // windows
-      message = message.replace(prefixPath, "");
+      message = message.replace(StaticEnv.getPrefixPath(), "");
       if (!message.contains(contains)) {
         fail(String.format("Expected exception to contain '%s'", contains), e);
       }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java.tmpl
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java.tmpl
@@ -16,13 +16,10 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 
-public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResolving {
-
-    private static String prefixPath;
+public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
 
     public DatabricksAuthTest() {
       setPermissionOnTestAz();
-      prefixPath = System.getProperty("user.dir") + getTestDir();
     }
 
     {{range .}}
@@ -30,7 +27,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
     public void test{{.PascalName}}() {
         {{with .Env}}// Set environment variables
         StaticEnv env = new StaticEnv(){{range $k,$v := .}}
-          .with("{{$k}}", {{if eq $k "HOME"}}resource("/{{$v}}"){{else}}"{{$v}}"{{end}}){{end}};{{end}}
+          .with("{{$k}}", {{if eq $k "HOME"}}TestOSUtils.resource("/{{$v}}"){{else}}"{{$v}}"{{end}}){{end}};{{end}}
         {{- with .AssertError}}
         raises("{{.}}", () -> { {{end}}
           DatabricksConfig config = new DatabricksConfig(){{range .Fields}}
@@ -46,31 +43,6 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
     }
     {{end}}
 
-    private String resource(String file) {
-      URL resource = getClass().getResource(file);
-      if (resource == null) {
-        fail("Asset not found: " + file);
-      }
-      return resource.getFile();
-    }
-
-    static class StaticEnv implements Supplier<Map<String, String>> {
-      private final Map<String, String> env = new HashMap<>();
-
-      public StaticEnv with(String key, String value) {
-        if (key.equals("PATH")) {
-          value = prefixPath + value;
-        }
-        env.put(key, value);
-        return this;
-      }
-
-      @Override
-      public Map<String, String> get() {
-        return env;
-      }
-    }
-
     private void raises(String contains, Runnable cb) {
       boolean raised = false;
       try {
@@ -83,7 +55,7 @@ public class DatabricksAuthTest implements TestOSUtils, GitHubUtils, ConfigResol
                 File.separator,
                 "/"); // We would need to do this upstream also for making paths compatible with
         // windows
-        message = message.replace(prefixPath, "");
+        message = message.replace(StaticEnv.getPrefixPath(), "");
         if (!message.contains(contains)) {
           fail(String.format("Expected exception to contain '%s'", contains), e);
         }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/StaticEnv.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/StaticEnv.java
@@ -1,0 +1,29 @@
+package com.databricks.sdk;
+
+import com.databricks.sdk.core.utils.TestOSUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+class StaticEnv implements Supplier<Map<String, String>> {
+  private static String prefixPath = System.getProperty("user.dir") + TestOSUtils.getTestDir();
+  private final Map<String, String> env = new HashMap<>();
+
+  public StaticEnv with(String key, String value) {
+    if (key.equals("PATH")) {
+      value = prefixPath + value;
+    }
+    env.put(key, value);
+    return this;
+  }
+
+  public static String getPrefixPath() {
+    return prefixPath;
+  }
+
+  @Override
+  public Map<String, String> get() {
+    return env;
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/StaticEnv.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/StaticEnv.java
@@ -1,7 +1,6 @@
 package com.databricks.sdk;
 
 import com.databricks.sdk.core.utils.TestOSUtils;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/GitHubUtils.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/GitHubUtils.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  * GitHubUtils is an interface that provides utility methods for working with GitHub actions and
  * testing on various operating systems.
  */
-public interface GitHubUtils extends TestOSUtils {
+public interface GitHubUtils {
 
   Logger LOG = LoggerFactory.getLogger(GitHubUtils.class);
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/TestOSUtils.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/TestOSUtils.java
@@ -1,14 +1,18 @@
 package com.databricks.sdk.core.utils;
 
 import java.io.File;
+import java.net.URL;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * TestOSUtils is an interface that extends the OSUtils interface and provides utility methods for
  * testing on various operating systems.
  */
-public interface TestOSUtils extends OSUtils {
+public class TestOSUtils implements OSUtils {
 
   Logger LOG = LoggerFactory.getLogger(TestOSUtils.class);
 
@@ -18,8 +22,16 @@ public interface TestOSUtils extends OSUtils {
    * @return a String representing the path to the directory containing test files. The path will
    *     use the correct file separator for the current operating system.
    */
-  default String getTestDir() {
+  public static String getTestDir() {
     String testDir = "/target/test-classes/";
     return testDir.replace("/", File.separator);
+  }
+
+  public static String resource(String file) {
+    URL resource = TestOSUtils.class.getResource(file);
+    if (resource == null) {
+      fail("Asset not found: " + file);
+    }
+    return resource.getFile();
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/TestOSUtils.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/TestOSUtils.java
@@ -1,12 +1,11 @@
 package com.databricks.sdk.core.utils;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.net.URL;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * TestOSUtils is an interface that extends the OSUtils interface and provides utility methods for

--- a/databricks-sdk-java/src/test/resources/testdata/az
+++ b/databricks-sdk-java/src/test/resources/testdata/az
@@ -15,6 +15,13 @@ if [ "corrupt" == "$FAIL" ]; then
     exit
 fi
 
+for arg in "$@"; do
+    if [[ "$arg" == "$FAIL_IF" ]]; then
+        echo "Failed"
+        exit 1
+    fi
+done
+
 # Macos
 EXP="$(/bin/date -v+${EXPIRE:=10S} +'%F %T' 2>/dev/null)"
 if [ -z "${EXP}" ]; then


### PR DESCRIPTION
## Changes
The Java SDK request authentication logic is inconsistent between the Azure login types: for service principal auth, the SDK correctly adds the X-Databricks-Azure-Workspace-Resource-Id when configured, but this is missed for Azure CLI auth. Additionally, when logging in via Azure CLI using a service principal, the service management token must also be fetched from the CLI.

This PR fixes this by defining the logic to attach these header in a common function that is used by all Azure-specific authentication types.

See https://github.com/databricks/databricks-sdk-go/pull/584 for the same change in the Go SDK.
See https://github.com/databricks/databricks-sdk-py/pull/290 for the same changes in the Python SDK.
## Tests
- [x] Unit tests to cover the two scenarios for Azure CLI w.r.t. management endpoint token fetching, and one to verify that X-Databricks-Azure-Workspace-Resource-Id is included when using Azure CLI.
