### PR TITLE
Fix query param serialization for requests with enums

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -89,7 +89,7 @@ public class ApiClient {
     if (entity == null) {
       return in;
     }
-    for (GrpcTranscodingQueryParamsSerializer.HeaderEntry e :
+    for (GrpcTranscodingQueryParamsSerializer.QueryParamPair e :
         GrpcTranscodingQueryParamsSerializer.serialize(entity)) {
       in.withQueryParam(e.getKey(), e.getValue());
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GrpcTranscodingQueryParamsSerializer.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GrpcTranscodingQueryParamsSerializer.java
@@ -17,11 +17,11 @@ import java.util.*;
  * documentation for gRPC transcoding</a> for more details.
  */
 public class GrpcTranscodingQueryParamsSerializer {
-  public static class HeaderEntry {
+  public static class QueryParamPair {
     private final String key;
     private final String value;
 
-    public HeaderEntry(String key, String value) {
+    public QueryParamPair(String key, String value) {
       this.key = key;
       this.value = value;
     }
@@ -47,25 +47,19 @@ public class GrpcTranscodingQueryParamsSerializer {
    * @param o The object to serialize.
    * @return A list of query parameter entries compatible with gRPC-transcoding.
    */
-  public static List<HeaderEntry> serialize(Object o) {
+  public static List<QueryParamPair> serialize(Object o) {
     Map<String, Object> flattened = flattenObject(o, true);
-    for (Field f : o.getClass().getDeclaredFields()) {
-      QueryParam queryParam = f.getAnnotation(QueryParam.class);
-      if (queryParam == null) {
-        flattened.remove(getFieldName(f));
-      }
-    }
 
-    List<HeaderEntry> result = new ArrayList<>();
+    List<QueryParamPair> result = new ArrayList<>();
     for (Map.Entry<String, Object> entry : flattened.entrySet()) {
       String key = entry.getKey();
       Object value = entry.getValue();
       if (value instanceof Collection) {
         for (Object v : (Collection<Object>) value) {
-          result.add(new HeaderEntry(key, v.toString()));
+          result.add(new QueryParamPair(key, v.toString()));
         }
       } else {
-        result.add(new HeaderEntry(key, value.toString()));
+        result.add(new QueryParamPair(key, value.toString()));
       }
     }
     return result;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GrpcTranscodingQueryParamsSerializer.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GrpcTranscodingQueryParamsSerializer.java
@@ -114,7 +114,9 @@ public class GrpcTranscodingQueryParamsSerializer {
         }
         // check if object is a primitive type, a collection of some kind, or an enum
         Class<?> type = f.getType();
-        if (primitiveTypes.contains(type) || Iterable.class.isAssignableFrom(type) || type.isEnum()) {
+        if (primitiveTypes.contains(type)
+            || Iterable.class.isAssignableFrom(type)
+            || type.isEnum()) {
           result.put(name, value);
         } else {
           // recursively flatten the object

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GrpcTranscodingQueryParamsSerializer.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GrpcTranscodingQueryParamsSerializer.java
@@ -115,8 +115,9 @@ public class GrpcTranscodingQueryParamsSerializer {
         if (value == null) {
           continue;
         }
-        // check if object is a primitive type or a collection of some kind
-        if (primitiveTypes.contains(f.getType()) || Iterable.class.isAssignableFrom(f.getType())) {
+        // check if object is a primitive type, a collection of some kind, or an enum
+        Class<?> type = f.getType();
+        if (primitiveTypes.contains(type) || Iterable.class.isAssignableFrom(type) || type.isEnum()) {
           result.put(name, value);
         } else {
           // recursively flatten the object


### PR DESCRIPTION
## Changes
Query parameters are determined reflectively from request classes by scanning for fields with a QueryParam annotation. Serialization of query parameters is recursive in order to support complex types like the filter structures used for listing in the SQL query history service. This PR makes the following changes:

1. Terminate recursion when the request field is an enum.
2. When iterating through the request object's fields, skip any fields not annotated with QueryParam (but recursively, all fields do need to be serialized).
3. Rename the inner class from HeaderEntry to QueryParamPair (it represents query param pairs, not header entries).

## Tests
Test for this change is dependent on other testing refactors that will be merged as part of https://github.com/databricks/databricks-sdk-java/pull/139.
