### PR TITLE
Fix refactor to serialize body

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -175,8 +175,8 @@ public class ApiClient {
   }
 
   private <I> Request prepareRequest(
-      String method, String path, I in, Map<String, String> headers) {
-    Request req = new Request(method, path);
+      String method, String path, I in, Map<String, String> headers) throws JsonProcessingException {
+    Request req = new Request(method, path, serialize(in));
     setQuery(req, in);
     setHeaders(req, headers);
     return req;


### PR DESCRIPTION
## Changes
In https://github.com/databricks/databricks-sdk-java/pull/135 there was a refactor to ApiClient's methods by introducing `prepareRequest`. This accidentally removed the serialization of the body. This PR corrects that issue.

## Tests
<!-- How is this tested? -->

