### PR TITLE
Add ErrorInfo to API errors

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
@@ -117,12 +117,8 @@ public class DatabricksError extends DatabricksException {
     return false;
   }
 
-  private List<ErrorDetail> getErrorsOfType(String type) {
+  List<ErrorDetail> getErrorsOfType(String type) {
     return this.details.stream().filter(e -> e.getType().equals(type)).collect(Collectors.toList());
-  }
-
-  public List<ErrorDetail> getErrorInfo() {
-    return this.getErrorsOfType(ERROR_INFO_TYPE);
   }
 
   private static boolean isCausedBy(Throwable throwable, Class<? extends Throwable> clazz) {
@@ -133,12 +129,5 @@ public class DatabricksError extends DatabricksException {
       return true;
     }
     return isCausedBy(throwable.getCause(), clazz);
-  }
-
-  public static List<ErrorDetail> getErrorInfo(Throwable throwable) {
-    if (!(throwable instanceof DatabricksError)) {
-      return Collections.emptyList();
-    }
-    return ((DatabricksError) throwable).getErrorInfo();
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
@@ -20,8 +20,7 @@ import org.slf4j.LoggerFactory;
  * unrecoverable way and this exception should be thrown, potentially wrapped in another exception.
  */
 public class DatabricksError extends DatabricksException {
-
-  static final String ERROR_INFO_TYPE = "type.googleapis.com/google.rpc.ErrorInfo";
+  private static final String ERROR_INFO_TYPE = "type.googleapis.com/google.rpc.ErrorInfo";
   private final Logger LOG = LoggerFactory.getLogger(getClass().getName());
 
   /** Errors returned by Databricks services which are known to be retriable. */
@@ -80,6 +79,10 @@ public class DatabricksError extends DatabricksException {
     this.cause = cause;
     this.statusCode = statusCode;
     this.details = details == null ? Collections.emptyList() : details;
+  }
+
+  public List<ErrorDetail> getErrorInfo() {
+    return this.getDetailsByType(ERROR_INFO_TYPE);
   }
 
   public String getErrorCode() {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
@@ -1,10 +1,13 @@
 package com.databricks.sdk.core;
 
+import com.databricks.sdk.core.error.ErrorDetail;
 import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +20,8 @@ import org.slf4j.LoggerFactory;
  * unrecoverable way and this exception should be thrown, potentially wrapped in another exception.
  */
 public class DatabricksError extends DatabricksException {
+
+  static final String ERROR_INFO_TYPE = "type.googleapis.com/google.rpc.ErrorInfo";
   private final Logger LOG = LoggerFactory.getLogger(getClass().getName());
 
   /** Errors returned by Databricks services which are known to be retriable. */
@@ -40,28 +45,41 @@ public class DatabricksError extends DatabricksException {
   private final String errorCode;
   private final int statusCode;
 
+  private final List<ErrorDetail> details;
+
   public DatabricksError(int statusCode) {
-    this("", "OK", statusCode, null);
+    this("", "OK", statusCode, null, Collections.emptyList());
   }
 
   public DatabricksError(String errorCode, String message) {
-    this(errorCode, message, 400, null);
+    this(errorCode, message, 400, null, Collections.emptyList());
   }
 
   public DatabricksError(String errorCode, String message, int statusCode) {
-    this(errorCode, message, statusCode, null);
+    this(errorCode, message, statusCode, null, Collections.emptyList());
   }
 
   public DatabricksError(String errorCode, int statusCode, Throwable cause) {
-    this(errorCode, cause.getMessage(), statusCode, cause);
+    this(errorCode, cause.getMessage(), statusCode, cause, Collections.emptyList());
   }
 
-  private DatabricksError(String errorCode, String message, int statusCode, Throwable cause) {
+  public DatabricksError(
+      String errorCode, String message, int statusCode, List<ErrorDetail> details) {
+    this(errorCode, message, statusCode, null, details);
+  }
+
+  private DatabricksError(
+      String errorCode,
+      String message,
+      int statusCode,
+      Throwable cause,
+      List<ErrorDetail> details) {
     super(message, cause);
     this.errorCode = errorCode;
     this.message = message;
     this.cause = cause;
     this.statusCode = statusCode;
+    this.details = details == null ? Collections.emptyList() : details;
   }
 
   public String getErrorCode() {
@@ -99,6 +117,14 @@ public class DatabricksError extends DatabricksException {
     return false;
   }
 
+  private List<ErrorDetail> getErrorsOfType(String type) {
+    return this.details.stream().filter(e -> e.getType().equals(type)).collect(Collectors.toList());
+  }
+
+  public List<ErrorDetail> getErrorInfo() {
+    return this.getErrorsOfType(ERROR_INFO_TYPE);
+  }
+
   private static boolean isCausedBy(Throwable throwable, Class<? extends Throwable> clazz) {
     if (throwable == null) {
       return false;
@@ -107,5 +133,12 @@ public class DatabricksError extends DatabricksException {
       return true;
     }
     return isCausedBy(throwable.getCause(), clazz);
+  }
+
+  public static List<ErrorDetail> getErrorInfo(Throwable throwable) {
+    if (!(throwable instanceof DatabricksError)) {
+      return Collections.emptyList();
+    }
+    return ((DatabricksError) throwable).getErrorInfo();
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
@@ -117,7 +117,7 @@ public class DatabricksError extends DatabricksException {
     return false;
   }
 
-  List<ErrorDetail> getErrorsOfType(String type) {
+  List<ErrorDetail> getDetailsByType(String type) {
     return this.details.stream().filter(e -> e.getType().equals(type)).collect(Collectors.toList());
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksException.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksException.java
@@ -19,6 +19,6 @@ public class DatabricksException extends RuntimeException {
     if (!(this instanceof DatabricksError)) {
       return Collections.emptyList();
     }
-    return ((DatabricksError) this).getErrorsOfType(ERROR_INFO_TYPE);
+    return ((DatabricksError) this).getDetailsByType(ERROR_INFO_TYPE);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksException.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksException.java
@@ -1,11 +1,5 @@
 package com.databricks.sdk.core;
 
-import static com.databricks.sdk.core.DatabricksError.ERROR_INFO_TYPE;
-
-import com.databricks.sdk.core.error.ErrorDetail;
-import java.util.Collections;
-import java.util.List;
-
 public class DatabricksException extends RuntimeException {
   public DatabricksException(String message) {
     super(message);
@@ -13,12 +7,5 @@ public class DatabricksException extends RuntimeException {
 
   public DatabricksException(String message, Throwable cause) {
     super(message, cause);
-  }
-
-  public List<ErrorDetail> getErrorInfo() {
-    if (!(this instanceof DatabricksError)) {
-      return Collections.emptyList();
-    }
-    return ((DatabricksError) this).getDetailsByType(ERROR_INFO_TYPE);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksException.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksException.java
@@ -1,5 +1,11 @@
 package com.databricks.sdk.core;
 
+import static com.databricks.sdk.core.DatabricksError.ERROR_INFO_TYPE;
+
+import com.databricks.sdk.core.error.ErrorDetail;
+import java.util.Collections;
+import java.util.List;
+
 public class DatabricksException extends RuntimeException {
   public DatabricksException(String message) {
     super(message);
@@ -7,5 +13,12 @@ public class DatabricksException extends RuntimeException {
 
   public DatabricksException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  public List<ErrorDetail> getErrorInfo() {
+    if (!(this instanceof DatabricksError)) {
+      return Collections.emptyList();
+    }
+    return ((DatabricksError) this).getErrorsOfType(ERROR_INFO_TYPE);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ApiErrorBody.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ApiErrorBody.java
@@ -2,6 +2,7 @@ package com.databricks.sdk.core.error;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
 /**
  * The union of all JSON error responses from the Databricks APIs, not including HTML responses.
@@ -20,6 +21,7 @@ public class ApiErrorBody {
   private String scimStatus;
   private String scimType;
   private String api12Error;
+  private List<ErrorDetail> errorDetails;
 
   public ApiErrorBody() {}
 
@@ -29,13 +31,23 @@ public class ApiErrorBody {
       @JsonProperty("detail") String scimDetail,
       @JsonProperty("status") String scimStatus,
       @JsonProperty("scimType") String scimType,
-      @JsonProperty("error") String api12Error) {
+      @JsonProperty("error") String api12Error,
+      @JsonProperty("details") List<ErrorDetail> errorDetails) {
     this.errorCode = errorCode;
     this.message = message;
     this.scimDetail = scimDetail;
     this.scimStatus = scimStatus;
     this.scimType = scimType;
     this.api12Error = api12Error;
+    this.errorDetails = errorDetails;
+  }
+
+  public List<ErrorDetail> getErrorDetails() {
+    return errorDetails;
+  }
+
+  public void setErrorDetails(List<ErrorDetail> errorDetails) {
+    this.errorDetails = errorDetails;
   }
 
   public String getErrorCode() {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ApiErrors.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ApiErrors.java
@@ -6,6 +6,7 @@ import com.databricks.sdk.core.http.Response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.io.IOUtils;
@@ -47,8 +48,14 @@ public class ApiErrors {
       errorBody.setMessage(message.trim());
       errorBody.setErrorCode("SCIM_" + errorBody.getScimStatus());
     }
+    if (errorBody.getErrorDetails() == null) {
+      errorBody.setErrorDetails(Collections.emptyList());
+    }
     return new DatabricksError(
-        errorBody.getErrorCode(), errorBody.getMessage(), response.getStatusCode());
+        errorBody.getErrorCode(),
+        errorBody.getMessage(),
+        response.getStatusCode(),
+        errorBody.getErrorDetails());
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ErrorDetail.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ErrorDetail.java
@@ -33,28 +33,12 @@ public class ErrorDetail {
     return type;
   }
 
-  public void setType(String type) {
-    this.type = type;
-  }
-
   public String getReason() {
     return reason;
   }
 
-  public void setReason(String reason) {
-    this.reason = reason;
-  }
-
-  public void setDomain(String domain) {
-    this.domain = domain;
-  }
-
   public Map<String, String> getMetadata() {
     return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
   }
 
   public String getDomain() {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ErrorDetail.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ErrorDetail.java
@@ -1,0 +1,80 @@
+package com.databricks.sdk.core.error;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ErrorDetail {
+
+  private String type;
+
+  private String reason;
+
+  private String domain;
+
+  private Map<String, String> metadata;
+
+  public ErrorDetail() {}
+
+  public ErrorDetail(
+      @JsonProperty("@type") String type,
+      @JsonProperty("reason") String reason,
+      @JsonProperty("domain") String domain,
+      @JsonProperty("metadata") Map<String, String> metadata) {
+    this.type = type;
+    this.reason = reason;
+    this.domain = domain;
+    this.metadata = Collections.unmodifiableMap(metadata);
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public void setReason(String reason) {
+    this.reason = reason;
+  }
+
+  public void setDomain(String domain) {
+    this.domain = domain;
+  }
+
+  public Map<String, String> getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(Map<String, String> metadata) {
+    this.metadata = metadata;
+  }
+
+  public String getDomain() {
+    return domain;
+  }
+
+  @Override
+  public String toString() {
+    return "ErrorDetails{"
+        + "type='"
+        + type
+        + '\''
+        + ", reason='"
+        + reason
+        + '\''
+        + ", domain='"
+        + domain
+        + '\''
+        + ", metadata="
+        + metadata
+        + '}';
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
@@ -213,7 +213,7 @@ public class ApiClientTest {
                         Arrays.asList(errorDetails, unrelatedDetails))),
                 getSuccessResponse(req)),
             MyEndpointResponse.class);
-    List<ErrorDetail> responseErrors = DatabricksError.getErrorInfo(error);
+    List<ErrorDetail> responseErrors = error.getErrorInfo();
     assertEquals(responseErrors.size(), 1);
     ErrorDetail responseError = responseErrors.get(0);
     assertEquals(errorDetails.getType(), responseError.getType());

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
@@ -1,9 +1,11 @@
 package com.databricks.sdk.core;
 
+import static com.databricks.sdk.core.DatabricksError.ERROR_INFO_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.databricks.sdk.core.error.ApiErrorBody;
+import com.databricks.sdk.core.error.ErrorDetail;
 import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.core.http.Response;
 import com.databricks.sdk.core.utils.FakeTimer;
@@ -67,12 +69,16 @@ public class ApiClientTest {
 
   private void runFailingApiClientTest(
       Request request, List<ResponseProvider> responses, Class<?> clazz, String expectedMessage) {
-    ApiClient client = getApiClient(request, responses);
-    DatabricksException exception =
-        assertThrows(
-            DatabricksException.class,
-            () -> client.GET(request.getUri().getPath(), clazz, Collections.emptyMap()));
+    DatabricksException exception = runFailingApiClientTest(request, responses, clazz);
     assertEquals(exception.getMessage(), expectedMessage);
+  }
+
+  private DatabricksException runFailingApiClientTest(
+      Request request, List<ResponseProvider> responses, Class<?> clazz) {
+    ApiClient client = getApiClient(request, responses);
+    return assertThrows(
+        DatabricksException.class,
+        () -> client.GET(request.getUri().getPath(), clazz, Collections.emptyMap()));
   }
 
   private Request getBasicRequest() {
@@ -173,10 +179,47 @@ public class ApiClientTest {
                     null,
                     null,
                     null,
-                    "Workspace 123 does not have any associated worker environments")),
+                    "Workspace 123 does not have any associated worker environments",
+                    null)),
             getSuccessResponse(req)),
         MyEndpointResponse.class,
         new MyEndpointResponse().setKey("value"));
+  }
+
+  @Test
+  void errorDetails() throws JsonProcessingException {
+    Request req = getBasicRequest();
+
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("etag", "value");
+    ErrorDetail errorDetails = new ErrorDetail(ERROR_INFO_TYPE, "reason", "domain", metadata);
+    ErrorDetail unrelatedDetails =
+        new ErrorDetail("unrelated", "wrong", "wrongDomain", new HashMap<>());
+
+    DatabricksException error =
+        runFailingApiClientTest(
+            req,
+            Arrays.asList(
+                getTransientError(
+                    req,
+                    401,
+                    new ApiErrorBody(
+                        "ERROR",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        Arrays.asList(errorDetails, unrelatedDetails))),
+                getSuccessResponse(req)),
+            MyEndpointResponse.class);
+    List<ErrorDetail> responseErrors = DatabricksError.getErrorInfo(error);
+    assertEquals(responseErrors.size(), 1);
+    ErrorDetail responseError = responseErrors.get(0);
+    assertEquals(errorDetails.getType(), responseError.getType());
+    assertEquals(errorDetails.getReason(), responseError.getReason());
+    assertEquals(errorDetails.getMetadata(), responseError.getMetadata());
+    assertEquals(errorDetails.getDomain(), responseError.getDomain());
   }
 
   @Test
@@ -193,6 +236,7 @@ public class ApiClientTest {
                 new ApiErrorBody(
                     "ERROR",
                     "Workspace 123 does not have any associated worker environments",
+                    null,
                     null,
                     null,
                     null,

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/error/ApiErrorBodyDeserializationSuite.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/error/ApiErrorBodyDeserializationSuite.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.*;
 import org.junit.jupiter.api.Test;
 
 public class ApiErrorBodyDeserializationSuite {
@@ -21,13 +22,31 @@ public class ApiErrorBodyDeserializationSuite {
     assertEquals(error.getApi12Error(), "theerror");
   }
 
+  @Test
+  void deserializeDetailedResponse() throws JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    String rawResponse =
+        "{\"error_code\":\"theerrorcode\",\"message\":\"themessage\","
+            + "\"details\":["
+            + "{\"@type\": \"type.googleapis.com/google.rpc.ErrorInfo\", \"reason\":\"detailreason\", \"domain\":\"detaildomain\",\"metadata\":{\"etag\":\"detailsetag\"}}"
+            + "]}";
+    ApiErrorBody error = mapper.readValue(rawResponse, ApiErrorBody.class);
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("etag", "detailsetag");
+    ErrorDetail errorDetails = error.getErrorDetails().get(0);
+    assertEquals(errorDetails.getType(), "type.googleapis.com/google.rpc.ErrorInfo");
+    assertEquals(errorDetails.getReason(), "detailreason");
+    assertEquals(errorDetails.getDomain(), "detaildomain");
+    assertEquals(errorDetails.getMetadata(), metadata);
+  }
+
   // Test that an ApiErrorBody can be deserialized, even if the response includes unexpected
   // parameters.
   @Test
   void handleUnexpectedFieldsInErrorResponse() throws JsonProcessingException {
     ObjectMapper mapper = new ObjectMapper();
     String rawResponse =
-        "{\"error_code\":\"theerrorcode\",\"message\":\"themessage\",\"details\":[\"unexpected\"]}";
+        "{\"error_code\":\"theerrorcode\",\"message\":\"themessage\",\"unexpectedField\":[\"unexpected\"]}";
     ApiErrorBody error = mapper.readValue(rawResponse, ApiErrorBody.class);
     assertEquals(error.getErrorCode(), "theerrorcode");
     assertEquals(error.getMessage(), "themessage");


### PR DESCRIPTION
## Changes
Databricks API can return error details in case of errors. In some cases, users need to access such details to be able to solve the issue. This is the case for the errors of type ErrorInfo used by the Settings Platform.
This PR adds the necessary fields to the APIError to Unmarshal the ErrorDetails and to expose the details of type ErrorInfo to the users.

## Tests
- [X] Unit test
- [X] `make fmt`
- [X] Integration test
