### PR TITLE
Don't fail codegen if the tree was already removed

### DIFF
--- a/.codegen.json
+++ b/.codegen.json
@@ -22,7 +22,7 @@
   },
   "toolchain": {
     "require": ["mvn", "java"],
-    "setup": ["rm -r databricks-sdk-java/src/main/java/com/databricks/sdk/service"],
+    "setup": ["rm -rf databricks-sdk-java/src/main/java/com/databricks/sdk/service"],
     "post_generate": ["mvn --errors clean test"]
   }
 }


### PR DESCRIPTION
This may happen if you retry after a codegen failure.
