### PR TITLE
Adjust token expiry window to 40 seconds because of Azure

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -4,7 +4,7 @@ import com.databricks.sdk.core.error.ApiErrors;
 import com.databricks.sdk.core.http.HttpClient;
 import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.core.http.Response;
-import com.databricks.sdk.core.utils.RealTimer;
+import com.databricks.sdk.core.utils.SystemTimer;
 import com.databricks.sdk.core.utils.Timer;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -46,7 +46,7 @@ public class ApiClient {
   }
 
   public ApiClient(DatabricksConfig config) {
-    this(config, new RealTimer());
+    this(config, new SystemTimer());
   }
 
   public ApiClient(DatabricksConfig config, Timer timer) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Token.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Token.java
@@ -30,7 +30,7 @@ public class Token {
     this(accessToken, tokenType, null, expiry, null);
   }
 
-  /** Constructor for non-refreshable tokens (e.g. M2M). with ClockSupplier */
+  /** Constructor for non-refreshable tokens (e.g. M2M) with ClockSupplier */
   public Token(
       String accessToken, String tokenType, LocalDateTime expiry, ClockSupplier clockSupplier) {
     this(accessToken, tokenType, null, expiry, clockSupplier);
@@ -41,7 +41,7 @@ public class Token {
     this(accessToken, tokenType, refreshToken, expiry, null);
   }
 
-  /** Constructor for refreshable tokens. with ClockSupplier */
+  /** Constructor for refreshable tokens with ClockSupplier. */
   public Token(
       String accessToken,
       String tokenType,

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Token.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Token.java
@@ -41,7 +41,9 @@ public class Token {
     if (expiry == null) {
       return false;
     }
-    LocalDateTime potentiallyExpired = expiry.minus(10, ChronoUnit.SECONDS);
+    // Azure Databricks rejects tokens that expire in 30 seconds or less,
+    // so we refresh the token 40 seconds before it expires.
+    LocalDateTime potentiallyExpired = expiry.minus(40, ChronoUnit.SECONDS);
     LocalDateTime now = LocalDateTime.now();
     return potentiallyExpired.isBefore(now);
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Token.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Token.java
@@ -1,7 +1,7 @@
 package com.databricks.sdk.core.oauth;
 
 import com.databricks.sdk.core.utils.ClockSupplier;
-import com.databricks.sdk.core.utils.RealClockSupplier;
+import com.databricks.sdk.core.utils.SystemClockSupplier;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -27,7 +27,7 @@ public class Token {
 
   /** Constructor for non-refreshable tokens (e.g. M2M). */
   public Token(String accessToken, String tokenType, LocalDateTime expiry) {
-    this(accessToken, tokenType, null, expiry, null);
+    this(accessToken, tokenType, null, expiry, new SystemClockSupplier());
   }
 
   /** Constructor for non-refreshable tokens (e.g. M2M) with ClockSupplier */
@@ -38,7 +38,7 @@ public class Token {
 
   /** Constructor for refreshable tokens. */
   public Token(String accessToken, String tokenType, String refreshToken, LocalDateTime expiry) {
-    this(accessToken, tokenType, refreshToken, expiry, null);
+    this(accessToken, tokenType, refreshToken, expiry, new SystemClockSupplier());
   }
 
   /** Constructor for refreshable tokens with ClockSupplier. */
@@ -51,13 +51,12 @@ public class Token {
     Objects.requireNonNull(accessToken, "accessToken must be defined");
     Objects.requireNonNull(tokenType, "tokenType must be defined");
     Objects.requireNonNull(expiry, "expiry must be defined");
+    Objects.requireNonNull(clockSupplier, "clockSupplier must be defined");
     this.accessToken = accessToken;
     this.tokenType = tokenType;
     this.refreshToken = refreshToken;
     this.expiry = expiry;
-    if (clockSupplier == null) {
-      this.clockSupplier = new RealClockSupplier();
-    } else this.clockSupplier = clockSupplier;
+    this.clockSupplier = clockSupplier;
   }
 
   public boolean isExpired() {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/ClockSupplier.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/ClockSupplier.java
@@ -1,0 +1,7 @@
+package com.databricks.sdk.core.utils;
+
+import java.time.Clock;
+
+public interface ClockSupplier {
+  Clock getClock();
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/RealClockSupplier.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/RealClockSupplier.java
@@ -1,0 +1,10 @@
+package com.databricks.sdk.core.utils;
+
+import java.time.Clock;
+
+public class RealClockSupplier implements ClockSupplier {
+  @Override
+  public Clock getClock() {
+    return Clock.systemDefaultZone();
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/SystemClockSupplier.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/SystemClockSupplier.java
@@ -2,7 +2,7 @@ package com.databricks.sdk.core.utils;
 
 import java.time.Clock;
 
-public class RealClockSupplier implements ClockSupplier {
+public class SystemClockSupplier implements ClockSupplier {
   @Override
   public Clock getClock() {
     return Clock.systemDefaultZone();

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/SystemTimer.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/SystemTimer.java
@@ -1,6 +1,6 @@
 package com.databricks.sdk.core.utils;
 
-public class RealTimer implements Timer {
+public class SystemTimer implements Timer {
   @Override
   public void wait(int milliseconds) throws InterruptedException {
     Thread.sleep(milliseconds);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/TokenTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/TokenTest.java
@@ -57,10 +57,4 @@ class TokenTest {
     assertTrue(token.isExpired());
     assertFalse(token.isValid());
   }
-
-  @Test
-  void invalidToken() {
-    Token token = new Token(null, tokenType, currentLocalDateTime.plusMinutes(5));
-    assertFalse(token.isValid());
-  }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/TokenTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/TokenTest.java
@@ -1,0 +1,66 @@
+package com.databricks.sdk.core.oauth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TokenTest {
+
+  private static final String accessToken = "testAccessToken";
+  private static final String refreshToken = "testRefreshToken";
+  private static final String tokenType = "testTokenType";
+  private LocalDateTime currentLocalDateTime;
+
+  @BeforeEach
+  void init() {
+    currentLocalDateTime = LocalDateTime.now();
+  }
+
+  @Test
+  void createNonRefreshableToken() {
+    Token token = new Token(accessToken, tokenType, currentLocalDateTime.plusMinutes(5));
+    assertEquals(accessToken, token.getAccessToken());
+    assertEquals(tokenType, token.getTokenType());
+    assertNull(token.getRefreshToken());
+    assertTrue(token.isValid());
+  }
+
+  @Test
+  void createRefreshableToken() {
+    Token token =
+        new Token(accessToken, tokenType, refreshToken, currentLocalDateTime.plusMinutes(5));
+    assertEquals(accessToken, token.getAccessToken());
+    assertEquals(tokenType, token.getTokenType());
+    assertEquals(refreshToken, token.getRefreshToken());
+    assertTrue(token.isValid());
+  }
+
+  @Test
+  void tokenExpiryMoreThan40Seconds() {
+    Token token = new Token(accessToken, tokenType, currentLocalDateTime.plusSeconds(50));
+    assertFalse(token.isExpired());
+    assertTrue(token.isValid());
+  }
+
+  @Test
+  void tokenExpiryLessThan40Seconds() {
+    Token token = new Token(accessToken, tokenType, currentLocalDateTime.plusSeconds(30));
+    assertTrue(token.isExpired());
+    assertFalse(token.isValid());
+  }
+
+  @Test
+  void expiredToken() {
+    Token token = new Token(accessToken, tokenType, currentLocalDateTime.minusSeconds(10));
+    assertTrue(token.isExpired());
+    assertFalse(token.isValid());
+  }
+
+  @Test
+  void invalidToken() {
+    Token token = new Token(null, tokenType, currentLocalDateTime.plusMinutes(5));
+    assertFalse(token.isValid());
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/FakeClockSupplier.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/FakeClockSupplier.java
@@ -1,0 +1,18 @@
+package com.databricks.sdk.core.utils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class FakeClockSupplier implements ClockSupplier {
+  private final Clock clock;
+
+  public FakeClockSupplier(Instant fixedInstant, ZoneId zoneId) {
+    clock = Clock.fixed(fixedInstant, zoneId);
+  }
+
+  @Override
+  public Clock getClock() {
+    return clock;
+  }
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

- Align with https://github.com/databricks/databricks-sdk-py/pull/392
- Add ClockSupplier so that we don't depend on system clock while testing. Modify Token class to be more test friendly. 

## Tests
<!-- How is this tested? -->
Unit Tests
All nightly tests passed except two tests (which failed due to Max limit of 100 scopes has been reached!). It's a known current test infra issue and unrelated to these changes. 
