### PR TITLE
Implement notebook-native auth for the Java SDK

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
@@ -60,7 +60,12 @@ public class DatabricksError extends DatabricksException {
   }
 
   public DatabricksError(String errorCode, int statusCode, Throwable cause) {
-    this(errorCode, cause.getMessage() != null ? cause.getMessage() : "(no message)", statusCode, cause, Collections.emptyList());
+    this(
+        errorCode,
+        cause.getMessage() != null ? cause.getMessage() : "(no message)",
+        statusCode,
+        cause,
+        Collections.emptyList());
   }
 
   public DatabricksError(

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
@@ -60,12 +60,7 @@ public class DatabricksError extends DatabricksException {
   }
 
   public DatabricksError(String errorCode, int statusCode, Throwable cause) {
-    this(
-        errorCode,
-        cause.getMessage() != null ? cause.getMessage() : "(no message)",
-        statusCode,
-        cause,
-        Collections.emptyList());
+    this(errorCode, cause.getMessage(), statusCode, cause, Collections.emptyList());
   }
 
   public DatabricksError(
@@ -113,7 +108,7 @@ public class DatabricksError extends DatabricksException {
       return true;
     }
     for (String substring : TRANSIENT_ERROR_STRING_MATCHES) {
-      if (message.contains(substring)) {
+      if (message != null && message.contains(substring)) {
         LOG.debug("Attempting retry because of {}", substring);
         return true;
       }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
@@ -7,6 +7,7 @@ import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,7 @@ public class DatabricksError extends DatabricksException {
   }
 
   public DatabricksError(String errorCode, int statusCode, Throwable cause) {
-    this(errorCode, cause.getMessage(), statusCode, cause, Collections.emptyList());
+    this(errorCode, cause.getMessage() != null ? cause.getMessage() : "(no message)", statusCode, cause, Collections.emptyList());
   }
 
   public DatabricksError(
@@ -74,6 +75,7 @@ public class DatabricksError extends DatabricksException {
       Throwable cause,
       List<ErrorDetail> details) {
     super(message, cause);
+    Objects.requireNonNull(message);
     this.errorCode = errorCode;
     this.message = message;
     this.cause = cause;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksError.java
@@ -7,7 +7,6 @@ import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +74,6 @@ public class DatabricksError extends DatabricksException {
       Throwable cause,
       List<ErrorDetail> details) {
     super(message, cause);
-    Objects.requireNonNull(message);
     this.errorCode = errorCode;
     this.message = message;
     this.cause = cause;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
@@ -28,7 +28,8 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
             new AzureServicePrincipalCredentialsProvider(),
             new AzureCliCredentialsProvider(),
             new ExternalBrowserCredentialsProvider(),
-            new DatabricksCliCredentialsProvider());
+            new DatabricksCliCredentialsProvider(),
+            new NotebookNativeCredentialsProvider());
   }
 
   @Override
@@ -42,6 +43,7 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
         continue;
       }
       try {
+        LOG.info("Trying {} auth", provider.authType());
         HeaderFactory headerFactory = provider.configure(config);
         if (headerFactory == null) {
           continue;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
@@ -2,23 +2,24 @@ package com.databricks.sdk.core;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A CredentialsProvider that uses the API token from the command context to authenticate.
- * <p>
- * The token and hostname are read from the command context, which can be retrieved through the dbutils API. As the Java
- * SDK does not depend on DBUtils directly, reflection is used to retrieve the token. This token should be available
- * wherever the DBUtils API is accessible (i.e. in the Spark driver).
+ *
+ * <p>The token and hostname are read from the command context, which can be retrieved through the
+ * dbutils API. As the Java SDK does not depend on DBUtils directly, reflection is used to retrieve
+ * the token. This token should be available wherever the DBUtils API is accessible (i.e. in the
+ * Spark driver).
  */
 public class NotebookNativeCredentialsProvider implements CredentialsProvider {
-  private static final Logger LOG = LoggerFactory.getLogger(NotebookNativeCredentialsProvider.class);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(NotebookNativeCredentialsProvider.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   @Override
@@ -33,7 +34,8 @@ public class NotebookNativeCredentialsProvider implements CredentialsProvider {
     }
 
     // DBUtils is not available in the Java SDK, so we have to use reflection to get the token.
-    // First, we get the context by calling getContext on the notebook field of dbutils, then we get the apiKey and
+    // First, we get the context by calling getContext on the notebook field of dbutils, then we get
+    // the apiKey and
     // apiUrl fields from the context. If this is successful, we set the host on the config.
     try {
       Object dbutils = getDbUtils();
@@ -49,7 +51,10 @@ public class NotebookNativeCredentialsProvider implements CredentialsProvider {
         TokenAndUrl tokenAndUrl;
         try {
           tokenAndUrl = getTokenAndUrl(notebook);
-        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException | JsonProcessingException e) {
+        } catch (IllegalAccessException
+            | NoSuchMethodException
+            | InvocationTargetException
+            | JsonProcessingException e) {
           throw new RuntimeException(e);
         }
         headers.put("Authorization", String.format("Bearer %s", tokenAndUrl.token));
@@ -109,9 +114,17 @@ public class NotebookNativeCredentialsProvider implements CredentialsProvider {
   }
 
   /** Fetch the current command context, and read the API token and URL from it. */
-  private static TokenAndUrl getTokenAndUrl(Object notebook) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, JsonProcessingException {
-    Object testCommandContext = notebook.getClass().getDeclaredMethod("getContext").invoke(notebook);
-    String json = (String) testCommandContext.getClass().getDeclaredMethod("safeToJson").invoke(testCommandContext);
+  private static TokenAndUrl getTokenAndUrl(Object notebook)
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException,
+          JsonProcessingException {
+    Object testCommandContext =
+        notebook.getClass().getDeclaredMethod("getContext").invoke(notebook);
+    String json =
+        (String)
+            testCommandContext
+                .getClass()
+                .getDeclaredMethod("safeToJson")
+                .invoke(testCommandContext);
     CommandContext deserialized = MAPPER.readValue(json, CommandContext.class);
     String token = deserialized.attributes.get("api_token");
     String host = deserialized.attributes.get("api_url");

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
@@ -1,0 +1,109 @@
+package com.databricks.sdk.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class NotebookNativeCredentialsProvider implements CredentialsProvider {
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookNativeCredentialsProvider.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Override
+  public String authType() {
+    return "runtime";
+  }
+
+  @Override
+  public HeaderFactory configure(DatabricksConfig config) {
+    if (System.getenv("DATABRICKS_RUNTIME_VERSION") == null) {
+      return null;
+    }
+
+    // DBUtils is not available in the Java SDK, so we have to use reflection to get the token.
+    // First, we get the context by calling getContext on the notebook field of dbutils, then we get the apiKey and
+    // apiUrl fields from the context.
+    try {
+      Object dbutils = getDbUtils();
+      Object notebook = getField(dbutils, "notebook");
+      TokenAndUrl testTokenAndUrl = getTokenAndUrl(notebook);
+      if (testTokenAndUrl.url == null) {
+        LOG.debug("Workspace URL is not available, skipping runtime auth");
+      }
+      config.setHost(testTokenAndUrl.url);
+
+      return () -> {
+        Map<String, String> headers = new HashMap<>();
+        TokenAndUrl tokenAndUrl;
+        try {
+          tokenAndUrl = getTokenAndUrl(notebook);
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException | JsonProcessingException e) {
+          throw new RuntimeException(e);
+        }
+        headers.put("Authorization", String.format("Bearer %s", tokenAndUrl.token));
+        return headers;
+      };
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  public static Object getDbUtils() {
+    try {
+      Class<?> dbutilsHolderClass = Class.forName("com.databricks.dbutils_v1.DBUtilsHolder$");
+      Object dbutilsHolder = dbutilsHolderClass.getDeclaredField("MODULE$").get(null);
+      InheritableThreadLocal<Object> dbutils = getField(dbutilsHolder, "dbutils0");
+      return dbutils.get();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static <T> T getField(Object o, String fieldName) {
+    Field f;
+    try {
+      f = o.getClass().getDeclaredField(fieldName);
+    } catch (NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
+    boolean accessible = f.isAccessible();
+    try {
+      f.setAccessible(true);
+      return (T) f.get(o);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } finally {
+      if (!accessible) {
+        f.setAccessible(false);
+      }
+    }
+  }
+
+  public static class TokenAndUrl {
+    public final String token;
+    public final String url;
+
+    public TokenAndUrl(String token, String url) {
+      this.token = token;
+      this.url = url;
+    }
+  }
+
+  public static class CommandContext {
+    public Map<String, String> attributes;
+  }
+
+  public static TokenAndUrl getTokenAndUrl(Object notebook) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, JsonProcessingException {
+    Object testCommandContext = notebook.getClass().getDeclaredMethod("getContext").invoke(notebook);
+    String json = (String) testCommandContext.getClass().getDeclaredMethod("safeToJson").invoke(testCommandContext);
+    CommandContext deserialized = MAPPER.readValue(json, CommandContext.class);
+    String token = deserialized.attributes.get("api_token");
+    String host = deserialized.attributes.get("api_url");
+    return new TokenAndUrl(token, host);
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
@@ -2,10 +2,8 @@ package com.databricks.sdk.core;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,12 +110,12 @@ public class NotebookNativeCredentialsProvider implements CredentialsProvider {
     try {
       Object testCommandContext =
           notebook.getClass().getDeclaredMethod("getContext").invoke(notebook);
-      Object tokenOpt = getField(testCommandContext, "apiToken");
-      Object hostOpt = getField(testCommandContext, "apiUrl");
+      Object tokenOpt = testCommandContext.getClass().getDeclaredMethod( "apiToken").invoke(testCommandContext);
       String token = (String) tokenOpt.getClass().getDeclaredMethod("get").invoke(tokenOpt);
+      Object hostOpt = testCommandContext.getClass().getDeclaredMethod( "apiUrl").invoke(testCommandContext);
       String host = (String) hostOpt.getClass().getDeclaredMethod("get").invoke(hostOpt);
       return new TokenAndUrl(token, host);
-    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException | NoSuchElementException e) {
       throw new DatabricksException("failed to get token and URL from command context", e);
     }
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
@@ -7,8 +7,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.crypto.Data;
-
 /**
  * A CredentialsProvider that uses the API token from the command context to authenticate.
  *
@@ -35,8 +33,10 @@ public class NotebookNativeCredentialsProvider implements CredentialsProvider {
 
     try {
       // DBUtils is not available in the Java SDK, so we have to use reflection to get the token.
-      // First, we get the context by calling getContext on the notebook field of dbutils, then we get
-      // the apiKey and apiUrl fields from the context. If this is successful, we set the host on the
+      // First, we get the context by calling getContext on the notebook field of dbutils, then we
+      // get
+      // the apiKey and apiUrl fields from the context. If this is successful, we set the host on
+      // the
       // config.
       Object dbutils = getDbUtils();
       if (dbutils == null) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
@@ -3,7 +3,6 @@ package com.databricks.sdk.core;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,12 +109,17 @@ public class NotebookNativeCredentialsProvider implements CredentialsProvider {
     try {
       Object testCommandContext =
           notebook.getClass().getDeclaredMethod("getContext").invoke(notebook);
-      Object tokenOpt = testCommandContext.getClass().getDeclaredMethod( "apiToken").invoke(testCommandContext);
+      Object tokenOpt =
+          testCommandContext.getClass().getDeclaredMethod("apiToken").invoke(testCommandContext);
       String token = (String) tokenOpt.getClass().getDeclaredMethod("get").invoke(tokenOpt);
-      Object hostOpt = testCommandContext.getClass().getDeclaredMethod( "apiUrl").invoke(testCommandContext);
+      Object hostOpt =
+          testCommandContext.getClass().getDeclaredMethod("apiUrl").invoke(testCommandContext);
       String host = (String) hostOpt.getClass().getDeclaredMethod("get").invoke(hostOpt);
       return new TokenAndUrl(token, host);
-    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException | NoSuchElementException e) {
+    } catch (InvocationTargetException
+        | NoSuchMethodException
+        | IllegalAccessException
+        | NoSuchElementException e) {
       throw new DatabricksException("failed to get token and URL from command context", e);
     }
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
@@ -2,7 +2,9 @@ package com.databricks.sdk.core;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
@@ -33,10 +33,8 @@ public class NotebookNativeCredentialsProvider implements CredentialsProvider {
     try {
       // DBUtils is not available in the Java SDK, so we have to use reflection to get the token.
       // First, we get the context by calling getContext on the notebook field of dbutils, then we
-      // get
-      // the apiKey and apiUrl fields from the context. If this is successful, we set the host on
-      // the
-      // config.
+      // get the apiKey and apiUrl fields from the context. If this is successful, we set the host
+      // on the config.
       Object dbutils = getDbUtils();
       if (dbutils == null) {
         LOG.debug("DBUtils is not available, skipping runtime auth");


### PR DESCRIPTION
## Changes
Notebook-native authentication has been supported in the Python SDK for the last several months, and customers using the SDKs in Databricks appreciate the easier CUJ for authentication. This PR ports the behavior to the Java SDK. The approach taken for this implementation differs somewhat from the Python SDK's implementation. In particular, in Python, DBR provides some functionality to get the command context (`from dbruntime.databricks_repl_context import get_context`, `from dbruntime.sdk_credential_provider import init_runtime_native_auth`) as well as from IPython. The Java SDK uses the DBUtils object directly. However, the SDK doesn't depend on the DBUtils API (which is only in Scala), so instead we load it reflectively.

## Tests
Ran in a notebook in DBR, worked.

