### PR TITLE
Use same logic as Go SDK for DatabricksConfig.isAzure()

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -463,7 +463,7 @@ public class DatabricksConfig {
     if (host == null) {
       return false;
     }
-    return host.contains(".azuredatabricks.");
+    return host.contains(".azuredatabricks.") || host.contains("databricks.azure.cn") || host.contains(".databricks.azure.us");
   }
 
   public synchronized void authenticate(HttpMessage request) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -463,7 +463,9 @@ public class DatabricksConfig {
     if (host == null) {
       return false;
     }
-    return host.contains(".azuredatabricks.net") || host.contains("databricks.azure.cn") || host.contains(".databricks.azure.us");
+    return host.contains(".azuredatabricks.net")
+        || host.contains("databricks.azure.cn")
+        || host.contains(".databricks.azure.us");
   }
 
   public synchronized void authenticate(HttpMessage request) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -463,7 +463,7 @@ public class DatabricksConfig {
     if (host == null) {
       return false;
     }
-    return host.contains(".azuredatabricks.") || host.contains("databricks.azure.cn") || host.contains(".databricks.azure.us");
+    return host.contains(".azuredatabricks.net") || host.contains("databricks.azure.cn") || host.contains(".databricks.azure.us");
   }
 
   public synchronized void authenticate(HttpMessage request) {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/AzureCliCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/AzureCliCredentialsProviderTest.java
@@ -86,7 +86,7 @@ class AzureCliCredentialsProviderTest {
   void testGetTokenWithoutWorkspaceResourceID() {
     AzureCliCredentialsProvider provider = getAzureCliCredentialsProvider(mockTokenSource());
     DatabricksConfig config =
-        new DatabricksConfig().setHost(".azuredatabricks.").setCredentialsProvider(provider);
+        new DatabricksConfig().setHost(".azuredatabricks.net").setCredentialsProvider(provider);
 
     ArgumentCaptor<List<String>> argument = ArgumentCaptor.forClass(List.class);
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -25,4 +25,10 @@ public class DatabricksConfigTest {
     assertFalse(
         new DatabricksConfig().setHost("https://westeurope.azuredatabricks.net").isAccountClient());
   }
+
+  @Test
+  public void testIsAzureMooncake() {
+    assertTrue(
+        new DatabricksConfig().setHost("https://adb-1234567890.0.databricks.azure.cn/").isAzure());
+  }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -31,4 +31,10 @@ public class DatabricksConfigTest {
     assertTrue(
         new DatabricksConfig().setHost("https://adb-1234567890.0.databricks.azure.cn/").isAzure());
   }
+
+  @Test
+  public void testIsAzureUsGov() {
+    assertTrue(
+        new DatabricksConfig().setHost("https://adb-1234567890.0.databricks.azure.us/").isAzure());
+  }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -27,6 +27,18 @@ public class DatabricksConfigTest {
   }
 
   @Test
+  public void testIsAzureForAwsHost() {
+    assertFalse(
+        new DatabricksConfig().setHost("https://my-workspace.cloud.databricks.com/").isAzure());
+  }
+
+  @Test
+  public void testIsAzurePublic() {
+    assertTrue(
+        new DatabricksConfig().setHost("https://adb-1234567890.0.azuredatabricks.net/").isAzure());
+  }
+
+  @Test
   public void testIsAzureMooncake() {
     assertTrue(
         new DatabricksConfig().setHost("https://adb-1234567890.0.databricks.azure.cn/").isAzure());

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/AzureServicePrincipalCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/AzureServicePrincipalCredentialsProviderTest.java
@@ -44,7 +44,7 @@ class AzureServicePrincipalCredentialsProviderTest {
         getAzureServicePrincipalCredentialsProvider(mockTokenSource());
     DatabricksConfig config =
         new DatabricksConfig()
-            .setHost(".azuredatabricks.")
+            .setHost(".azuredatabricks.net")
             .setCredentialsProvider(provider)
             .setAzureClientId("clientID")
             .setAzureClientSecret("clientSecret")


### PR DESCRIPTION
## Changes
The current isAzure() logic only checks if ".azuredatabricks." is contained in the hostname, which fails for workspaces in other Azure environments. This PR copies the logic directly from the Go SDK: https://github.com/databricks/databricks-sdk-go/blob/main/config/config.go#L142

## Tests
- [x] Some unit tests ensuring that isAzure() returns the right values for various hosts, including AWS, Azure public, Azure US Gov, and Azure China.
