### PR TITLE
Paginate all SCIM list requests in the SDK

### DIFF
--- a/.codegen/api.java.tmpl
+++ b/.codegen/api.java.tmpl
@@ -131,7 +131,19 @@ public class {{.PascalName}}API {
 {{define "method-call-paginated" -}}
   {{- if .Pagination.MultiRequest -}}
     {{- if and .Pagination.Offset (not (eq .Path "/api/2.0/clusters/events")) -}}
-    request.set{{.Pagination.Offset.PascalName}}({{if eq .Pagination.Increment 1}}1{{else}}0{{end}}L);{{end -}}
+    request.set{{.Pagination.Offset.PascalName}}(
+    {{- if eq .Pagination.Increment 1 -}}
+      1
+    {{- else if contains .Path "/scim/v2/" -}}
+      1
+    {{- else -}}
+      0
+    {{- end}}L);{{end -}}
+    {{if and .Pagination.Limit (contains .Path "/scim/v2/")}}
+    if (request.get{{.Pagination.Limit.PascalName}}() == 0) {
+       request.set{{.Pagination.Limit.PascalName}}(100);
+    }
+    {{end}}
     return new Paginator<>(request, impl::{{template "java-name" .}}, {{template "type" .Response}}::get{{.Pagination.Results.PascalName}}, response -> {
       {{if eq .Path "/api/2.0/clusters/events" -}}
       return response.getNextPage();


### PR DESCRIPTION
## Changes
This PR incorporates two hard-coded changes for the SCIM API in the Python SDK:

startIndex starts at 1 for SCIM APIs, not 0. However, the existing .Pagination.Increment controls both the start index as well as whether the pagination is per-page or per-resource. Later, we should replace this extension with two independent OpenAPI options: `one_indexed` (defaulting to `false`) and `pagination_basis` (defaulting to resource but can be overridden to page).
If users don't specify a limit, the SDK will include a hard-coded limit of 100 resources per request. We could add this to the OpenAPI spec as an option `default_limit`, which is useful for any non-paginated APIs that later expose pagination options and allow the SDK to gracefully support those. However, we don't want to encourage folks to use this pattern: all new list APIs are required to be paginated from the start.

## Tests
<!-- How is this tested? -->

