### PR TITLE
Support custom scopes and redirectUrl for U2M OAuth flow

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -7,6 +7,7 @@ import com.databricks.sdk.core.http.Response;
 import com.databricks.sdk.core.oauth.OpenIDConnectEndpoints;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -36,6 +37,20 @@ public class DatabricksConfig {
       auth = "oauth",
       sensitive = true)
   private String clientSecret;
+
+  @ConfigAttribute(
+      value = "scopes",
+      env = "DATABRICKS_SCOPES",
+      auth = "oauth",
+      sensitive = true)
+  private List<String> scopes;
+
+  @ConfigAttribute(
+      value = "redirect_url",
+      env = "DATABRICKS_REDIRECT_URL",
+      auth = "oauth",
+      sensitive = true)
+  private String redirectUrl;
 
   @ConfigAttribute(value = "username", env = "DATABRICKS_USERNAME", auth = "basic")
   private String username;
@@ -288,6 +303,24 @@ public class DatabricksConfig {
 
   public DatabricksConfig setClientSecret(String clientSecret) {
     this.clientSecret = clientSecret;
+    return this;
+  }
+
+  public String getOAuthRedirectUrl() {
+    return redirectUrl;
+  }
+
+  public DatabricksConfig setOAuthRedirectUrl(String redirectUrl) {
+    this.redirectUrl = redirectUrl;
+    return this;
+  }
+
+  public List<String> getScopes() {
+    return scopes;
+  }
+
+  public DatabricksConfig setScopes(List<String> scopes) {
+    this.scopes = scopes;
     return this;
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -41,10 +41,7 @@ public class DatabricksConfig {
   @ConfigAttribute(value = "scopes", env = "DATABRICKS_SCOPES", auth = "oauth")
   private List<String> scopes;
 
-  @ConfigAttribute(
-      value = "redirect_url",
-      env = "DATABRICKS_REDIRECT_URL",
-      auth = "oauth")
+  @ConfigAttribute(value = "redirect_url", env = "DATABRICKS_REDIRECT_URL", auth = "oauth")
   private String redirectUrl;
 
   @ConfigAttribute(value = "username", env = "DATABRICKS_USERNAME", auth = "basic")

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -38,11 +38,7 @@ public class DatabricksConfig {
       sensitive = true)
   private String clientSecret;
 
-  @ConfigAttribute(
-      value = "scopes",
-      env = "DATABRICKS_SCOPES",
-      auth = "oauth",
-      sensitive = true)
+  @ConfigAttribute(value = "scopes", env = "DATABRICKS_SCOPES", auth = "oauth", sensitive = true)
   private List<String> scopes;
 
   @ConfigAttribute(

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -38,14 +38,13 @@ public class DatabricksConfig {
       sensitive = true)
   private String clientSecret;
 
-  @ConfigAttribute(value = "scopes", env = "DATABRICKS_SCOPES", auth = "oauth", sensitive = true)
+  @ConfigAttribute(value = "scopes", env = "DATABRICKS_SCOPES", auth = "oauth")
   private List<String> scopes;
 
   @ConfigAttribute(
       value = "redirect_url",
       env = "DATABRICKS_REDIRECT_URL",
-      auth = "oauth",
-      sensitive = true)
+      auth = "oauth")
   private String redirectUrl;
 
   @ConfigAttribute(value = "username", env = "DATABRICKS_USERNAME", auth = "basic")

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
@@ -120,9 +120,6 @@ public class OAuthClient {
     List<String> scopes = b.scopes;
     if (scopes == null) {
       scopes = Arrays.asList("offline_access", "clusters", "sql");
-    } else if (!scopes.contains("offline_access")) {
-      scopes = new ArrayList<>(scopes);
-      scopes.add("offline_access");
     }
     if (config.isAzure()) {
       scopes =

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
@@ -92,7 +92,11 @@ public class OAuthClient {
             .withClientId(config.getClientId())
             .withClientSecret(config.getClientSecret())
             .withHost(config.getHost())
-            .withRedirectUrl("http://localhost:8080/callback"));
+            .withRedirectUrl(
+                config.getOAuthRedirectUrl() != null
+                    ? config.getOAuthRedirectUrl()
+                    : "http://localhost:8080/callback")
+            .withScopes(config.getScopes()));
   }
 
   private OAuthClient(Builder b) throws IOException {
@@ -116,6 +120,9 @@ public class OAuthClient {
     List<String> scopes = b.scopes;
     if (scopes == null) {
       scopes = Arrays.asList("offline_access", "clusters", "sql");
+    } else if (!scopes.contains("offline_access")) {
+      scopes = new ArrayList<>(scopes);
+      scopes.add("offline_access");
     }
     if (config.isAzure()) {
       scopes =

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
@@ -87,7 +87,7 @@ public class ExternalBrowserCredentialsProviderTest {
       assertTrue(authUrl.contains("response_type=code"));
       assertTrue(authUrl.contains("client_id=test-client-id"));
       assertTrue(authUrl.contains("redirect_uri=http://localhost:8010"));
-      assertTrue(authUrl.contains("scope=sql%20offline_access"));
+      assertTrue(authUrl.contains("scope=sql"));
     }
   }
 


### PR DESCRIPTION
## Changes

Added following utility methods to DatabricksConfig

a. setRedirectUrl: This will be passed to OAuthClient and will be used in U2M OAuth flow if client wants to provide a custom redirect Url as per OAuth configuration of their application.
b. setScopes: Clients can set custom scopes for U2M OAuth flow. If offline_access is not present, it will be added to the scopes for refresh token support.

## Tests

Tested manually using JDBC driver as a client. Also, added test case for custom values of redirectUrl and scopes.

