### PR TITLE
Fix databricks CLI authentication on Windows

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
@@ -47,7 +47,7 @@ public class AzureCliCredentialsProvider implements CredentialsProvider, AzureUt
 
   protected CliTokenSource getToken(DatabricksConfig config, List<String> cmd) {
     CliTokenSource token =
-        new CliTokenSource(cmd, "tokenType", "accessToken", "expiresOn", config::getAllEnv);
+        new CliTokenSource(config, cmd, "tokenType", "accessToken", "expiresOn", config::getAllEnv);
     token.getToken(); // We need this to check if the CLI is installed and to validate the config.
     return token;
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
@@ -47,7 +47,7 @@ public class AzureCliCredentialsProvider implements CredentialsProvider, AzureUt
 
   protected CliTokenSource getToken(DatabricksConfig config, List<String> cmd) {
     CliTokenSource token =
-        new CliTokenSource(config, cmd, "tokenType", "accessToken", "expiresOn", config::getAllEnv);
+        new CliTokenSource(cmd, "tokenType", "accessToken", "expiresOn", config.getEnv());
     token.getToken(); // We need this to check if the CLI is installed and to validate the config.
     return token;
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/CliTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/CliTokenSource.java
@@ -24,13 +24,14 @@ public class CliTokenSource extends RefreshableTokenSource {
   private Supplier<Map<String, String>> getAllEnv;
 
   public CliTokenSource(
+      DatabricksConfig cfg,
       List<String> cmd,
       String tokenTypeField,
       String accessTokenField,
       String expiryField,
       Supplier<Map<String, String>> getAllEnv) {
     super();
-    this.cmd = OSUtils.get().getCliExecutableCommand(cmd);
+    this.cmd = OSUtils.get(cfg).getCliExecutableCommand(cmd);
     this.tokenTypeField = tokenTypeField;
     this.accessTokenField = accessTokenField;
     this.expiryField = expiryField;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/CliTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/CliTokenSource.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.commons.io.IOUtils;
 
-public class CliTokenSource extends RefreshableTokenSource implements OSUtils {
+public class CliTokenSource extends RefreshableTokenSource {
   private List<String> cmd;
   private String tokenTypeField;
   private String accessTokenField;
@@ -30,7 +30,7 @@ public class CliTokenSource extends RefreshableTokenSource implements OSUtils {
       String expiryField,
       Supplier<Map<String, String>> getAllEnv) {
     super();
-    this.cmd = getCliExecutableCommand(cmd);
+    this.cmd = OSUtils.get().getCliExecutableCommand(cmd);
     this.tokenTypeField = tokenTypeField;
     this.accessTokenField = accessTokenField;
     this.expiryField = expiryField;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/CliTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/CliTokenSource.java
@@ -13,8 +13,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
 import org.apache.commons.io.IOUtils;
 
 public class CliTokenSource extends RefreshableTokenSource {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/CliTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/CliTokenSource.java
@@ -35,6 +35,7 @@ public class CliTokenSource extends RefreshableTokenSource {
     this.tokenTypeField = tokenTypeField;
     this.accessTokenField = accessTokenField;
     this.expiryField = expiryField;
+    this.env = env;
   }
 
   static LocalDateTime parseExpiry(String expiry) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/CliTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/CliTokenSource.java
@@ -2,6 +2,7 @@ package com.databricks.sdk.core;
 
 import com.databricks.sdk.core.oauth.RefreshableTokenSource;
 import com.databricks.sdk.core.oauth.Token;
+import com.databricks.sdk.core.utils.Environment;
 import com.databricks.sdk.core.utils.OSUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,21 +22,19 @@ public class CliTokenSource extends RefreshableTokenSource {
   private String tokenTypeField;
   private String accessTokenField;
   private String expiryField;
-  private Supplier<Map<String, String>> getAllEnv;
+  private Environment env;
 
   public CliTokenSource(
-      DatabricksConfig cfg,
       List<String> cmd,
       String tokenTypeField,
       String accessTokenField,
       String expiryField,
-      Supplier<Map<String, String>> getAllEnv) {
+      Environment env) {
     super();
-    this.cmd = OSUtils.get(cfg).getCliExecutableCommand(cmd);
+    this.cmd = OSUtils.get(env).getCliExecutableCommand(cmd);
     this.tokenTypeField = tokenTypeField;
     this.accessTokenField = accessTokenField;
     this.expiryField = expiryField;
-    this.getAllEnv = getAllEnv;
   }
 
   static LocalDateTime parseExpiry(String expiry) {
@@ -69,7 +68,7 @@ public class CliTokenSource extends RefreshableTokenSource {
   protected Token refresh() {
     try {
       ProcessBuilder processBuilder = new ProcessBuilder(cmd);
-      processBuilder.environment().putAll(getAllEnv.get());
+      processBuilder.environment().putAll(env.getEnv());
       Process process = processBuilder.start();
       String stdout = getProcessStream(process.getInputStream());
       String stderr = getProcessStream(process.getErrorStream());

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigLoader.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigLoader.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.*;
 import org.ini4j.Ini;
 import org.ini4j.Profile;
@@ -70,18 +71,19 @@ public class ConfigLoader {
       return;
     }
 
-    String configFile = cfg.getConfigFile();
-    boolean isDefaultConfig = false;
-    if (isNullOrEmpty(configFile)) {
-      configFile = DatabricksConfig.DEFAULT_CONFIG_FILE;
-      isDefaultConfig = true;
-    }
-
     String userHome = cfg.getAllEnv().get("HOME");
     if (isNullOrEmpty(userHome)) {
       userHome = System.getProperty("user.home");
     }
-    configFile = configFile.replaceFirst("^~", userHome);
+
+    String configFile = cfg.getConfigFile();
+    boolean isDefaultConfig = false;
+    if (isNullOrEmpty(configFile)) {
+      configFile = Paths.get(userHome, ".databrickscfg").toString();
+      isDefaultConfig = true;
+    } else {
+      configFile = configFile.replaceFirst("^~", userHome);
+    }
 
     Ini ini = parseDatabricksCfg(configFile, isDefaultConfig);
     if (ini == null) return;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigLoader.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigLoader.java
@@ -40,12 +40,12 @@ public class ConfigLoader {
   }
 
   static void loadFromEnvironmentVariables(DatabricksConfig cfg) throws IllegalAccessException {
-    if (cfg.getAllEnv() == null) {
+    if (cfg.getEnv() == null) {
       return;
     }
     try {
       for (ConfigAttributeAccessor accessor : accessors) {
-        String env = cfg.getAllEnv().get(accessor.getEnvVariable());
+        String env = cfg.getEnv().get(accessor.getEnvVariable());
         if (isNullOrEmpty(env)) {
           continue;
         }
@@ -71,7 +71,7 @@ public class ConfigLoader {
       return;
     }
 
-    String userHome = cfg.getAllEnv().get("HOME");
+    String userHome = cfg.getEnv().get("HOME");
     if (isNullOrEmpty(userHome)) {
       userHome = System.getProperty("user.home");
     }
@@ -182,7 +182,7 @@ public class ConfigLoader {
         true; // TODO - pass status code with exception, default this to false
     if (statusCode == 401 || statusCode == 402) isHttpUnauthorizedOrForbidden = true;
     String debugString = "";
-    if (cfg.getAllEnv() != null) {
+    if (cfg.getEnv() != null) {
       debugString = debugString(cfg);
     }
     if (!debugString.isEmpty() && isHttpUnauthorizedOrForbidden) {
@@ -197,7 +197,7 @@ public class ConfigLoader {
       List<String> attrsUsed = new ArrayList<>();
       List<String> buf = new ArrayList<>();
 
-      Map<String, String> getEnvAllEnv = cfg.getAllEnv();
+      Map<String, String> getEnvAllEnv = cfg.getEnv().getEnv();
 
       for (ConfigAttributeAccessor accessor : accessors) {
         String envVariable = accessor.getEnvVariable();

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksCliCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksCliCredentialsProvider.java
@@ -20,7 +20,7 @@ public class DatabricksCliCredentialsProvider implements CredentialsProvider {
   private CliTokenSource getDatabricksCliTokenSource(DatabricksConfig config) {
     String cliPath = config.getDatabricksCliPath();
     if (cliPath == null) {
-      cliPath = OSUtils.get(config).getDatabricksCliPath();
+      cliPath = OSUtils.get(config.getEnv()).getDatabricksCliPath();
     }
     if (cliPath == null) {
       LOG.debug("Databricks CLI could not be found");
@@ -32,7 +32,7 @@ public class DatabricksCliCredentialsProvider implements CredentialsProvider {
       cmd.add("--account-id");
       cmd.add(config.getAccountId());
     }
-    return new CliTokenSource(config, cmd, "token_type", "access_token", "expiry", config::getAllEnv);
+    return new CliTokenSource(cmd, "token_type", "access_token", "expiry", config.getEnv());
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksCliCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksCliCredentialsProvider.java
@@ -32,7 +32,7 @@ public class DatabricksCliCredentialsProvider implements CredentialsProvider {
       cmd.add("--account-id");
       cmd.add(config.getAccountId());
     }
-    return new CliTokenSource(cmd, "token_type", "access_token", "expiry", config::getAllEnv);
+    return new CliTokenSource(config, cmd, "token_type", "access_token", "expiry", config::getAllEnv);
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -150,7 +150,7 @@ public class DatabricksConfig {
 
   public synchronized DatabricksConfig resolve() {
     String[] path = System.getenv("PATH").split(File.pathSeparator);
-    Environment env = new Environment(System.getenv(), path);
+    Environment env = new Environment(System.getenv(), path, System.getProperty("os.name"));
     return resolve(env);
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -5,11 +5,12 @@ import com.databricks.sdk.core.http.HttpClient;
 import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.core.http.Response;
 import com.databricks.sdk.core.oauth.OpenIDConnectEndpoints;
+import com.databricks.sdk.core.utils.Environment;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Supplier;
+
 import org.apache.http.HttpMessage;
 
 public class DatabricksConfig {
@@ -141,24 +142,25 @@ public class DatabricksConfig {
 
   private HttpClient httpClient;
 
-  private Map<String, String> allEnv;
+  private Environment env;
 
-  public Map<String, String> getAllEnv() {
-    return allEnv;
+  public Environment getEnv() {
+    return env;
   }
 
   public synchronized DatabricksConfig resolve() {
-    return resolve(System::getenv);
+    Environment env = new Environment(System.getenv(), System.getenv("PATH"));
+    return resolve(env);
   }
 
-  synchronized DatabricksConfig resolve(Supplier<Map<String, String>> getAllEnv) {
-    allEnv = getAllEnv.get();
+  synchronized DatabricksConfig resolve(Environment env) {
+    this.env = env;
     innerResolve();
     return this;
   }
 
   private synchronized DatabricksConfig innerResolve() {
-    Objects.requireNonNull(allEnv);
+    Objects.requireNonNull(env);
     try {
       ConfigLoader.resolve(this);
       ConfigLoader.validate(this);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -7,10 +7,10 @@ import com.databricks.sdk.core.http.Response;
 import com.databricks.sdk.core.oauth.OpenIDConnectEndpoints;
 import com.databricks.sdk.core.utils.Environment;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.http.HttpMessage;
 
 public class DatabricksConfig {
@@ -149,7 +149,8 @@ public class DatabricksConfig {
   }
 
   public synchronized DatabricksConfig resolve() {
-    Environment env = new Environment(System.getenv(), System.getenv("PATH"));
+    String[] path = System.getenv("PATH").split(File.pathSeparator);
+    Environment env = new Environment(System.getenv(), path);
     return resolve(env);
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -13,9 +13,6 @@ import java.util.function.Supplier;
 import org.apache.http.HttpMessage;
 
 public class DatabricksConfig {
-
-  public static final String DEFAULT_CONFIG_FILE = "~/.databrickscfg";
-
   private CredentialsProvider credentialsProvider = new DefaultCredentialsProvider();
 
   @ConfigAttribute(value = "host", env = "DATABRICKS_HOST")

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/Environment.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/Environment.java
@@ -1,11 +1,18 @@
 package com.databricks.sdk.core.utils;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 public class Environment {
   private final Map<String, String> env;
-  private final String path;
-  public Environment(Map<String, String> map, String path) {
+  private final List<String> path;
+
+  public Environment(Map<String, String> map, String[] path) {
+    this(map, Arrays.asList(path));
+  }
+
+  public Environment(Map<String, String> map, List<String> path) {
     this.env = map;
     this.path = path;
   }
@@ -18,7 +25,7 @@ public class Environment {
     return env;
   }
 
-  public String getPath() {
+  public List<String> getPath() {
     return path;
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/Environment.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/Environment.java
@@ -1,0 +1,24 @@
+package com.databricks.sdk.core.utils;
+
+import java.util.Map;
+
+public class Environment {
+  private final Map<String, String> env;
+  private final String path;
+  public Environment(Map<String, String> map, String path) {
+    this.env = map;
+    this.path = path;
+  }
+
+  public String get(String key) {
+    return env.get(key);
+  }
+
+  public Map<String, String> getEnv() {
+    return env;
+  }
+
+  public String getPath() {
+    return path;
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/Environment.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/Environment.java
@@ -7,14 +7,16 @@ import java.util.Map;
 public class Environment {
   private final Map<String, String> env;
   private final List<String> path;
+  private final String systemName;
 
-  public Environment(Map<String, String> map, String[] path) {
-    this(map, Arrays.asList(path));
+  public Environment(Map<String, String> map, String[] path, String systemName) {
+    this(map, Arrays.asList(path), systemName);
   }
 
-  public Environment(Map<String, String> map, List<String> path) {
+  public Environment(Map<String, String> map, List<String> path, String systemName) {
     this.env = map;
     this.path = path;
+    this.systemName = systemName;
   }
 
   public String get(String key) {
@@ -27,5 +29,9 @@ public class Environment {
 
   public List<String> getPath() {
     return path;
+  }
+
+  public String getSystemName() {
+    return systemName;
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/LinuxUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/LinuxUtilities.java
@@ -6,9 +6,9 @@ import java.util.Arrays;
 import java.util.List;
 
 public class LinuxUtilities implements OSUtilities {
-  private final DatabricksConfig config;
-  public LinuxUtilities(DatabricksConfig config) {
-    this.config = config;
+  private final Environment env;
+  public LinuxUtilities(Environment env) {
+    this.env = env;
   }
 
   @Override
@@ -19,6 +19,6 @@ public class LinuxUtilities implements OSUtilities {
 
   @Override
   public String getDatabricksCliPath() {
-    return OSUtils.findExecutable(config, "databricks");
+    return OSUtils.findExecutable(env.getPath(), "databricks");
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/LinuxUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/LinuxUtilities.java
@@ -4,14 +4,14 @@ import java.util.Arrays;
 import java.util.List;
 
 public class LinuxUtilities implements OSUtilities {
-    @Override
-    public List<String> getCliExecutableCommand(List<String> cmd) {
-        String cmdToString = String.join(" ", cmd);
-        return Arrays.asList("/bin/bash", "-c", cmdToString);
-    }
+  @Override
+  public List<String> getCliExecutableCommand(List<String> cmd) {
+    String cmdToString = String.join(" ", cmd);
+    return Arrays.asList("/bin/bash", "-c", cmdToString);
+  }
 
-    @Override
-    public String getDatabricksCliFileName() {
-        return "databricks";
-    }
+  @Override
+  public String getDatabricksCliPath() {
+    return OSUtils.findExecutable("databricks");
+  }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/LinuxUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/LinuxUtilities.java
@@ -1,9 +1,16 @@
 package com.databricks.sdk.core.utils;
 
+import com.databricks.sdk.core.DatabricksConfig;
+
 import java.util.Arrays;
 import java.util.List;
 
 public class LinuxUtilities implements OSUtilities {
+  private final DatabricksConfig config;
+  public LinuxUtilities(DatabricksConfig config) {
+    this.config = config;
+  }
+
   @Override
   public List<String> getCliExecutableCommand(List<String> cmd) {
     String cmdToString = String.join(" ", cmd);
@@ -12,6 +19,6 @@ public class LinuxUtilities implements OSUtilities {
 
   @Override
   public String getDatabricksCliPath() {
-    return OSUtils.findExecutable("databricks");
+    return OSUtils.findExecutable(config, "databricks");
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/LinuxUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/LinuxUtilities.java
@@ -1,12 +1,12 @@
 package com.databricks.sdk.core.utils;
 
-import com.databricks.sdk.core.DatabricksConfig;
-
 import java.util.Arrays;
 import java.util.List;
 
+/** Linux specific utilities. */
 public class LinuxUtilities implements OSUtilities {
   private final Environment env;
+
   public LinuxUtilities(Environment env) {
     this.env = env;
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/LinuxUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/LinuxUtilities.java
@@ -1,0 +1,17 @@
+package com.databricks.sdk.core.utils;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class LinuxUtilities implements OSUtilities {
+    @Override
+    public List<String> getCliExecutableCommand(List<String> cmd) {
+        String cmdToString = String.join(" ", cmd);
+        return Arrays.asList("/bin/bash", "-c", cmdToString);
+    }
+
+    @Override
+    public String getDatabricksCliFileName() {
+        return "databricks";
+    }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/MacOSUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/MacOSUtilities.java
@@ -3,11 +3,14 @@ package com.databricks.sdk.core.utils;
 import java.util.Arrays;
 import java.util.List;
 
+/** MacOS specific utilities. */
 public class MacOSUtilities implements OSUtilities {
   private final Environment env;
+
   public MacOSUtilities(Environment env) {
     this.env = env;
   }
+
   @Override
   public List<String> getCliExecutableCommand(List<String> cmd) {
     String cmdToString = String.join(" ", cmd);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/MacOSUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/MacOSUtilities.java
@@ -1,0 +1,17 @@
+package com.databricks.sdk.core.utils;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class MacOSUtilities implements OSUtilities {
+    @Override
+    public List<String> getCliExecutableCommand(List<String> cmd) {
+        String cmdToString = String.join(" ", cmd);
+        return Arrays.asList("/bin/bash", "-c", cmdToString);
+    }
+
+    @Override
+    public String getDatabricksCliFileName() {
+        return "databricks";
+    }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/MacOSUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/MacOSUtilities.java
@@ -4,14 +4,14 @@ import java.util.Arrays;
 import java.util.List;
 
 public class MacOSUtilities implements OSUtilities {
-    @Override
-    public List<String> getCliExecutableCommand(List<String> cmd) {
-        String cmdToString = String.join(" ", cmd);
-        return Arrays.asList("/bin/bash", "-c", cmdToString);
-    }
+  @Override
+  public List<String> getCliExecutableCommand(List<String> cmd) {
+    String cmdToString = String.join(" ", cmd);
+    return Arrays.asList("/bin/bash", "-c", cmdToString);
+  }
 
-    @Override
-    public String getDatabricksCliFileName() {
-        return "databricks";
-    }
+  @Override
+  public String getDatabricksCliPath() {
+    return OSUtils.findExecutable("databricks");
+  }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/MacOSUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/MacOSUtilities.java
@@ -1,9 +1,15 @@
 package com.databricks.sdk.core.utils;
 
+import com.databricks.sdk.core.DatabricksConfig;
+
 import java.util.Arrays;
 import java.util.List;
 
 public class MacOSUtilities implements OSUtilities {
+  private final DatabricksConfig config;
+  public MacOSUtilities(DatabricksConfig config) {
+    this.config = config;
+  }
   @Override
   public List<String> getCliExecutableCommand(List<String> cmd) {
     String cmdToString = String.join(" ", cmd);
@@ -12,6 +18,6 @@ public class MacOSUtilities implements OSUtilities {
 
   @Override
   public String getDatabricksCliPath() {
-    return OSUtils.findExecutable("databricks");
+    return OSUtils.findExecutable(config, "databricks");
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/MacOSUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/MacOSUtilities.java
@@ -1,14 +1,12 @@
 package com.databricks.sdk.core.utils;
 
-import com.databricks.sdk.core.DatabricksConfig;
-
 import java.util.Arrays;
 import java.util.List;
 
 public class MacOSUtilities implements OSUtilities {
-  private final DatabricksConfig config;
-  public MacOSUtilities(DatabricksConfig config) {
-    this.config = config;
+  private final Environment env;
+  public MacOSUtilities(Environment env) {
+    this.env = env;
   }
   @Override
   public List<String> getCliExecutableCommand(List<String> cmd) {
@@ -18,6 +16,6 @@ public class MacOSUtilities implements OSUtilities {
 
   @Override
   public String getDatabricksCliPath() {
-    return OSUtils.findExecutable(config, "databricks");
+    return OSUtils.findExecutable(env.getPath(), "databricks");
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtilities.java
@@ -2,6 +2,7 @@ package com.databricks.sdk.core.utils;
 
 import java.util.List;
 
+/** OS-specific functionality needed by the SDK. */
 public interface OSUtilities {
   /**
    * Returns a list of strings representing an executable command for the current operating system,

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtilities.java
@@ -1,0 +1,22 @@
+package com.databricks.sdk.core.utils;
+
+import java.util.List;
+
+public interface OSUtilities {
+    /**
+     * Returns a list of strings representing an executable command for the current operating system,
+     * based on the given list of command tokens.
+     *
+     * @param cmd a list of strings representing the command to be executed.
+     * @return a List of strings representing the executable command for the current operating system.
+     *     On Windows, the command will be wrapped in "cmd.exe /c" and on other operating systems, it
+     *     will be wrapped in "/bin/bash -c".
+     */
+    List<String> getCliExecutableCommand(List<String> cmd);
+
+    /**
+     * Returns the file name of the Databricks CLI for the given OS.
+     * @return
+     */
+    String getDatabricksCliFileName();
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtilities.java
@@ -3,20 +3,21 @@ package com.databricks.sdk.core.utils;
 import java.util.List;
 
 public interface OSUtilities {
-    /**
-     * Returns a list of strings representing an executable command for the current operating system,
-     * based on the given list of command tokens.
-     *
-     * @param cmd a list of strings representing the command to be executed.
-     * @return a List of strings representing the executable command for the current operating system.
-     *     On Windows, the command will be wrapped in "cmd.exe /c" and on other operating systems, it
-     *     will be wrapped in "/bin/bash -c".
-     */
-    List<String> getCliExecutableCommand(List<String> cmd);
+  /**
+   * Returns a list of strings representing an executable command for the current operating system,
+   * based on the given list of command tokens.
+   *
+   * @param cmd a list of strings representing the command to be executed.
+   * @return a List of strings representing the executable command for the current operating system.
+   *     On Windows, the command will be wrapped in "cmd.exe /c" and on other operating systems, it
+   *     will be wrapped in "/bin/bash -c".
+   */
+  List<String> getCliExecutableCommand(List<String> cmd);
 
-    /**
-     * Returns the file name of the Databricks CLI for the given OS.
-     * @return
-     */
-    String getDatabricksCliFileName();
+  /**
+   * Returns the path of the Databricks CLI for the given OS.
+   *
+   * @return
+   */
+  String getDatabricksCliPath();
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
@@ -23,10 +23,7 @@ public class OSUtils {
    *     for Windows, "mac" for macOS, and "linux" for Linux-based operating systems.
    */
   static String getOS(Environment env) {
-    String systemName = env.get("OS_NAME");
-    if (systemName == null || systemName.isEmpty()) {
-      systemName = System.getProperty("os.name").toLowerCase();
-    }
+    String systemName = env.getSystemName();
     if (systemName.startsWith("win")) {
       return "win";
     } else if (systemName.startsWith("mac")) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
@@ -23,7 +23,7 @@ public class OSUtils {
    *     for Windows, "mac" for macOS, and "linux" for Linux-based operating systems.
    */
   static String getOS(Environment env) {
-    String systemName = env.getSystemName();
+    String systemName = env.getSystemName().toLowerCase();
     if (systemName.startsWith("win")) {
       return "win";
     } else if (systemName.startsWith("mac")) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
@@ -1,15 +1,22 @@
 package com.databricks.sdk.core.utils;
 
+import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.core.DatabricksException;
-
-import java.util.Arrays;
-import java.util.List;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.StringTokenizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * OSUtils is an interface that provides utility methods for determining the current operating
  * system and returning executable command based on the operating system.
  */
 public class OSUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(OSUtils.class);
 
   /**
    * Returns the name of the current operating system.
@@ -17,8 +24,11 @@ public class OSUtils {
    * @return a String representing the name of the current operating system. The value will be "win"
    *     for Windows, "mac" for macOS, and "linux" for Linux-based operating systems.
    */
-  public static String getOS() {
-    String systemName = System.getProperty("os.name").toLowerCase();
+  static String getOS(DatabricksConfig cfg) {
+    String systemName = cfg.getAllEnv().get("OS_NAME");
+    if (systemName == null || systemName.isEmpty()) {
+      systemName = System.getProperty("os.name").toLowerCase();
+    }
     if (systemName.startsWith("win")) {
       return "win";
     } else if (systemName.startsWith("mac")) {
@@ -27,19 +37,42 @@ public class OSUtils {
     return "linux";
   }
 
-  /**
-   * Returns the OS-specific utilities for the current operating system.
-   */
-  public static OSUtilities get() {
-    String os = getOS();
-      switch (os) {
-          case "win":
-              return new WindowsUtilities();
-          case "mac":
-              return new MacOSUtilities();
-          case "linux":
-              return new LinuxUtilities();
-      }
+  /** Returns the OS-specific utilities for the current operating system. */
+  public static OSUtilities get(DatabricksConfig cfg) {
+    String os = getOS(cfg);
+    switch (os) {
+      case "win":
+        return new WindowsUtilities();
+      case "mac":
+        return new MacOSUtilities();
+      case "linux":
+        return new LinuxUtilities();
+    }
     throw new DatabricksException("Unsupported OS: " + os);
+  }
+
+  public static String findExecutable(String name) {
+    String pathVal = System.getenv("PATH");
+    StringTokenizer stringTokenizer = new StringTokenizer(pathVal, File.pathSeparator);
+    while (stringTokenizer.hasMoreTokens()) {
+      Path path = Paths.get(stringTokenizer.nextToken(), name).toAbsolutePath().normalize();
+      if (!Files.isRegularFile(path)) {
+        continue;
+      }
+      long size;
+      try {
+        size = Files.size(path);
+      } catch (IOException e) {
+        LOG.warn("Unable to get size of databricks cli: " + e.getMessage());
+        return null;
+      }
+      if (size < 1024 * 1024) {
+        LOG.info("Databricks CLI version <0.100.0 detected");
+        return null;
+      }
+      return path.toString();
+    }
+    LOG.debug("Failed to find executable named " + name + " in PATH");
+    return null;
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
@@ -24,8 +24,8 @@ public class OSUtils {
    * @return a String representing the name of the current operating system. The value will be "win"
    *     for Windows, "mac" for macOS, and "linux" for Linux-based operating systems.
    */
-  static String getOS(DatabricksConfig cfg) {
-    String systemName = cfg.getAllEnv().get("OS_NAME");
+  static String getOS(Environment env) {
+    String systemName = env.get("OS_NAME");
     if (systemName == null || systemName.isEmpty()) {
       systemName = System.getProperty("os.name").toLowerCase();
     }
@@ -38,21 +38,20 @@ public class OSUtils {
   }
 
   /** Returns the OS-specific utilities for the current operating system. */
-  public static OSUtilities get(DatabricksConfig cfg) {
-    String os = getOS(cfg);
+  public static OSUtilities get(Environment env) {
+    String os = getOS(env);
     switch (os) {
       case "win":
-        return new WindowsUtilities(cfg);
+        return new WindowsUtilities(env);
       case "mac":
-        return new MacOSUtilities(cfg);
+        return new MacOSUtilities(env);
       case "linux":
-        return new LinuxUtilities(cfg);
+        return new LinuxUtilities(env);
     }
     throw new DatabricksException("Unsupported OS: " + os);
   }
 
-  public static String findExecutable(DatabricksConfig config, String name) {
-    String pathVal = config.getAllEnv().get("PATH");
+  public static String findExecutable(String pathVal, String name) {
     StringTokenizer stringTokenizer = new StringTokenizer(pathVal, File.pathSeparator);
     while (stringTokenizer.hasMoreTokens()) {
       Path path = Paths.get(stringTokenizer.nextToken(), name).toAbsolutePath().normalize();

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
@@ -70,10 +70,10 @@ public class OSUtils {
         continue;
       }
       String pathStr = path.toString();
-      LOG.debug("Found executable named " + name + " in PATH: " + pathStr);
+      LOG.debug("Found executable named '" + name + "' in PATH: " + pathStr);
       return pathStr;
     }
-    LOG.debug("Failed to find executable named " + name + " in PATH");
+    LOG.debug("Failed to find executable named '" + name + "' in PATH");
     return null;
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
@@ -1,13 +1,11 @@
 package com.databricks.sdk.core.utils;
 
-import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.core.DatabricksException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.StringTokenizer;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,10 +49,10 @@ public class OSUtils {
     throw new DatabricksException("Unsupported OS: " + os);
   }
 
-  public static String findExecutable(String pathVal, String name) {
-    StringTokenizer stringTokenizer = new StringTokenizer(pathVal, File.pathSeparator);
-    while (stringTokenizer.hasMoreTokens()) {
-      Path path = Paths.get(stringTokenizer.nextToken(), name).toAbsolutePath().normalize();
+  public static String findExecutable(List<String> paths, String name) {
+    LOG.debug("Searching for executable named '" + name + "' in : " + String.join(", ", paths));
+    for (String dir : paths) {
+      Path path = Paths.get(dir, name).toAbsolutePath().normalize();
       if (!Files.isRegularFile(path)) {
         continue;
       }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/OSUtils.java
@@ -1,5 +1,7 @@
 package com.databricks.sdk.core.utils;
 
+import com.databricks.sdk.core.DatabricksException;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -7,7 +9,7 @@ import java.util.List;
  * OSUtils is an interface that provides utility methods for determining the current operating
  * system and returning executable command based on the operating system.
  */
-public interface OSUtils {
+public class OSUtils {
 
   /**
    * Returns the name of the current operating system.
@@ -15,30 +17,29 @@ public interface OSUtils {
    * @return a String representing the name of the current operating system. The value will be "win"
    *     for Windows, "mac" for macOS, and "linux" for Linux-based operating systems.
    */
-  default String getOS() {
-    if (System.getProperty("os.name").toLowerCase().startsWith("win")) {
+  public static String getOS() {
+    String systemName = System.getProperty("os.name").toLowerCase();
+    if (systemName.startsWith("win")) {
       return "win";
-    } else if (System.getProperty("os.name").toLowerCase().startsWith("mac")) {
+    } else if (systemName.startsWith("mac")) {
       return "mac";
     }
     return "linux";
   }
 
   /**
-   * Returns a list of strings representing an executable command for the current operating system,
-   * based on the given list of command tokens.
-   *
-   * @param cmd a list of strings representing the command to be executed.
-   * @return a List of strings representing the executable command for the current operating system.
-   *     On Windows, the command will be wrapped in "cmd.exe /c" and on other operating systems, it
-   *     will be wrapped in "/bin/bash -c".
+   * Returns the OS-specific utilities for the current operating system.
    */
-  default List<String> getCliExecutableCommand(List<String> cmd) {
-    String cmdToString = String.join(" ", cmd);
-    if (getOS().equals("win")) {
-      return Arrays.asList("cmd.exe", "/c", cmdToString);
-    } else {
-      return Arrays.asList("/bin/bash", "-c", cmdToString);
-    }
+  public static OSUtilities get() {
+    String os = getOS();
+      switch (os) {
+          case "win":
+              return new WindowsUtilities();
+          case "mac":
+              return new MacOSUtilities();
+          case "linux":
+              return new LinuxUtilities();
+      }
+    throw new DatabricksException("Unsupported OS: " + os);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/WindowsUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/WindowsUtilities.java
@@ -1,0 +1,17 @@
+package com.databricks.sdk.core.utils;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class WindowsUtilities implements OSUtilities {
+    @Override
+    public List<String> getCliExecutableCommand(List<String> cmd) {
+        String cmdToString = String.join(" ", cmd);
+        return Arrays.asList("cmd.exe", "/c", cmdToString);
+    }
+
+    @Override
+    public String getDatabricksCliFileName() {
+        return "databricks.exe";
+    }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/WindowsUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/WindowsUtilities.java
@@ -6,9 +6,9 @@ import java.util.Arrays;
 import java.util.List;
 
 public class WindowsUtilities implements OSUtilities {
-  private final DatabricksConfig config;
-  public WindowsUtilities(DatabricksConfig config) {
-    this.config = config;
+  private final Environment env;
+  public WindowsUtilities(Environment env) {
+    this.env = env;
   }
 
   @Override
@@ -19,9 +19,9 @@ public class WindowsUtilities implements OSUtilities {
 
   @Override
   public String getDatabricksCliPath() {
-    String path = OSUtils.findExecutable(config, "databricks");
+    String path = OSUtils.findExecutable(env.getPath(), "databricks");
     if (path == null) {
-      path = OSUtils.findExecutable(config, "databricks.exe");
+      path = OSUtils.findExecutable(env.getPath(), "databricks.exe");
     }
     return path;
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/WindowsUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/WindowsUtilities.java
@@ -1,12 +1,12 @@
 package com.databricks.sdk.core.utils;
 
-import com.databricks.sdk.core.DatabricksConfig;
-
 import java.util.Arrays;
 import java.util.List;
 
+/** Windows specific utilities. */
 public class WindowsUtilities implements OSUtilities {
   private final Environment env;
+
   public WindowsUtilities(Environment env) {
     this.env = env;
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/WindowsUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/WindowsUtilities.java
@@ -4,14 +4,18 @@ import java.util.Arrays;
 import java.util.List;
 
 public class WindowsUtilities implements OSUtilities {
-    @Override
-    public List<String> getCliExecutableCommand(List<String> cmd) {
-        String cmdToString = String.join(" ", cmd);
-        return Arrays.asList("cmd.exe", "/c", cmdToString);
-    }
+  @Override
+  public List<String> getCliExecutableCommand(List<String> cmd) {
+    String cmdToString = String.join(" ", cmd);
+    return Arrays.asList("cmd.exe", "/c", cmdToString);
+  }
 
-    @Override
-    public String getDatabricksCliFileName() {
-        return "databricks.exe";
+  @Override
+  public String getDatabricksCliPath() {
+    String path = OSUtils.findExecutable("databricks");
+    if (path == null) {
+      path = OSUtils.findExecutable("databricks.exe");
     }
+    return path;
+  }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/WindowsUtilities.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/WindowsUtilities.java
@@ -1,9 +1,16 @@
 package com.databricks.sdk.core.utils;
 
+import com.databricks.sdk.core.DatabricksConfig;
+
 import java.util.Arrays;
 import java.util.List;
 
 public class WindowsUtilities implements OSUtilities {
+  private final DatabricksConfig config;
+  public WindowsUtilities(DatabricksConfig config) {
+    this.config = config;
+  }
+
   @Override
   public List<String> getCliExecutableCommand(List<String> cmd) {
     String cmdToString = String.join(" ", cmd);
@@ -12,9 +19,9 @@ public class WindowsUtilities implements OSUtilities {
 
   @Override
   public String getDatabricksCliPath() {
-    String path = OSUtils.findExecutable("databricks");
+    String path = OSUtils.findExecutable(config, "databricks");
     if (path == null) {
-      path = OSUtils.findExecutable("databricks.exe");
+      path = OSUtils.findExecutable(config, "databricks.exe");
     }
     return path;
   }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ConfigResolving.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ConfigResolving.java
@@ -16,7 +16,7 @@ public interface ConfigResolving {
     if (pathStr != null) {
       path.addAll(Arrays.asList(pathStr.split(":")));
     }
-    Environment env = new Environment(envGetter.get(), path);
+    Environment env = new Environment(envGetter.get(), path, System.getProperty("os.name"));
     config.resolve(env);
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ConfigResolving.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ConfigResolving.java
@@ -1,14 +1,14 @@
 package com.databricks.sdk.core;
 
 import com.databricks.sdk.core.utils.Environment;
-
 import java.util.Map;
 import java.util.function.Supplier;
 
 public interface ConfigResolving {
 
   default void resolveConfig(DatabricksConfig config, Supplier<Map<String, String>> envGetter) {
-    Environment env = new Environment(envGetter.get(), envGetter.get().get("PATH"));
+    String[] path = envGetter.get().get("PATH").split(":");
+    Environment env = new Environment(envGetter.get(), path);
     config.resolve(env);
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ConfigResolving.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ConfigResolving.java
@@ -1,7 +1,6 @@
 package com.databricks.sdk.core;
 
 import com.databricks.sdk.core.utils.Environment;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ConfigResolving.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ConfigResolving.java
@@ -1,11 +1,14 @@
 package com.databricks.sdk.core;
 
+import com.databricks.sdk.core.utils.Environment;
+
 import java.util.Map;
 import java.util.function.Supplier;
 
 public interface ConfigResolving {
 
   default void resolveConfig(DatabricksConfig config, Supplier<Map<String, String>> envGetter) {
-    config.resolve(envGetter);
+    Environment env = new Environment(envGetter.get(), envGetter.get().get("PATH"));
+    config.resolve(env);
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ConfigResolving.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ConfigResolving.java
@@ -1,13 +1,21 @@
 package com.databricks.sdk.core;
 
 import com.databricks.sdk.core.utils.Environment;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
 public interface ConfigResolving {
 
   default void resolveConfig(DatabricksConfig config, Supplier<Map<String, String>> envGetter) {
-    String[] path = envGetter.get().get("PATH").split(":");
+    String pathStr = envGetter.get().get("PATH");
+    List<String> path = new ArrayList<>();
+    if (pathStr != null) {
+      path.addAll(Arrays.asList(pathStr.split(":")));
+    }
     Environment env = new Environment(envGetter.get(), path);
     config.resolve(env);
   }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/TestOSUtils.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/TestOSUtils.java
@@ -8,10 +8,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * TestOSUtils is an interface that extends the OSUtils interface and provides utility methods for
- * testing on various operating systems.
+ * TestOSUtils provides utility methods for testing on various operating systems.
  */
-public class TestOSUtils implements OSUtils {
+public class TestOSUtils {
 
   Logger LOG = LoggerFactory.getLogger(TestOSUtils.class);
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/TestOSUtils.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/TestOSUtils.java
@@ -7,9 +7,7 @@ import java.net.URL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * TestOSUtils provides utility methods for testing on various operating systems.
- */
+/** TestOSUtils provides utility methods for testing on various operating systems. */
 public class TestOSUtils {
 
   Logger LOG = LoggerFactory.getLogger(TestOSUtils.class);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/utils/OSUtilsTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/utils/OSUtilsTest.java
@@ -1,0 +1,76 @@
+package com.databricks.sdk.utils;
+
+import com.databricks.sdk.core.utils.Environment;
+import com.databricks.sdk.core.utils.OSUtils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class OSUtilsTest {
+  /**
+   * Helper class to create a temporary directory with a databricks executable in it.
+   *
+   * <p>We generate these files dynamically as the test is run because our check for the
+   * `databricks` executable is based on the size of the file, but we don't need to check a large
+   * file into our repository.
+   */
+  static class PathHelper implements AutoCloseable {
+    private List<Path> paths;
+    private String executableName;
+
+    public PathHelper(String osName, String executableName) {
+      this.executableName = executableName;
+      this.paths = new ArrayList<>();
+      try {
+        // Random UUID
+        String base = "databricks-sdk-java-test_" + osName + "_" + UUID.randomUUID();
+        Path noDatabricksDir = Files.createTempDirectory(base);
+        paths.add(noDatabricksDir);
+        Path smallDatabricksDir = Files.createTempDirectory(base);
+        Files.write(smallDatabricksDir.resolve(executableName), new byte[0]);
+        paths.add(smallDatabricksDir);
+        Path bigDatabricksDir = Files.createTempDirectory(base);
+        Files.write(bigDatabricksDir.resolve(executableName), new byte[2000000]);
+        paths.add(bigDatabricksDir);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    public List<String> getPath() {
+      return paths.stream().map(Path::toString).collect(Collectors.toList());
+    }
+
+    @Override
+    public void close() throws Exception {
+      for (Path path : paths) {
+        Files.deleteIfExists(path.resolve(executableName));
+        Files.deleteIfExists(path);
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "windows, databricks.exe, true",
+    "windows, databricks, true",
+    "windows, somethingElse, false",
+    "macos, databricks, true",
+    "linux, databricks, true"
+  })
+  public void testGetDatabricksCliPath(String osName, String executableName, Boolean expectFound)
+      throws Exception {
+    Map<String, String> envMap = new HashMap<>();
+    envMap.put("OS_NAME", osName);
+
+    try (PathHelper pathHelper = new PathHelper(osName, executableName)) {
+      Environment env = new Environment(envMap, pathHelper.getPath());
+      String executable = OSUtils.get(env).getDatabricksCliPath();
+      assert (executable != null) == expectFound;
+    }
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/utils/OSUtilsTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/utils/OSUtilsTest.java
@@ -64,11 +64,8 @@ public class OSUtilsTest {
   })
   public void testGetDatabricksCliPath(String osName, String executableName, Boolean expectFound)
       throws Exception {
-    Map<String, String> envMap = new HashMap<>();
-    envMap.put("OS_NAME", osName);
-
     try (PathHelper pathHelper = new PathHelper(osName, executableName)) {
-      Environment env = new Environment(envMap, pathHelper.getPath());
+      Environment env = new Environment(new HashMap<>(), pathHelper.getPath(), osName);
       String executable = OSUtils.get(env).getDatabricksCliPath();
       assert (executable != null) == expectFound;
     }

--- a/examples/cli-auth-demo/pom.xml
+++ b/examples/cli-auth-demo/pom.xml
@@ -19,12 +19,18 @@
         <dependency>
             <groupId>com.databricks</groupId>
             <artifactId>databricks-sdk-java</artifactId>
-            <version>0.0.1</version>
+            <version>0.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
             <version>2.0.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.databricks</groupId>
+            <artifactId>databricks-sdk-java</artifactId>
+            <version>0.12.0</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/examples/cli-auth-demo/src/main/java/com/databricks/example/CliAuthWorkspace.java
+++ b/examples/cli-auth-demo/src/main/java/com/databricks/example/CliAuthWorkspace.java
@@ -30,9 +30,9 @@ public class CliAuthWorkspace {
      Authenticate and retrieve the list of clusters from the workspace
      */
     public static void main(String[] args) {
-        // DatabricksConfig config = getConfig();
+        DatabricksConfig config = getConfig();
 
-        WorkspaceClient workspace = new WorkspaceClient();
+        WorkspaceClient workspace = new WorkspaceClient(config);
         for (ClusterDetails c : workspace.clusters().list(new ListClustersRequest())) {
             System.out.println(c.getClusterName());
         }

--- a/examples/cli-auth-demo/src/main/java/com/databricks/example/CliAuthWorkspace.java
+++ b/examples/cli-auth-demo/src/main/java/com/databricks/example/CliAuthWorkspace.java
@@ -30,9 +30,9 @@ public class CliAuthWorkspace {
      Authenticate and retrieve the list of clusters from the workspace
      */
     public static void main(String[] args) {
-        DatabricksConfig config = getConfig();
+        // DatabricksConfig config = getConfig();
 
-        WorkspaceClient workspace = new WorkspaceClient(config);
+        WorkspaceClient workspace = new WorkspaceClient();
         for (ClusterDetails c : workspace.clusters().list(new ListClustersRequest())) {
             System.out.println(c.getClusterName());
         }


### PR DESCRIPTION
## Changes
There are two problems with respect to the Java SDK's auth pathways:
1. The logic to find the `.databrickscfg` file only works on *nix, as it hard-codes the path using forward-slashes. I've rewritten this to use `Paths.get`.
2. The databricks binary on Windows is called `databricks.exe`, not `databricks`, so we need to search for the binary with OS-specific filename.

To make this change unit-testable, I introduce an `Environment` class to abstract over environment variables, the search path for the databricks CLI executable, and the operating system name. This is needed because there are both differences in the environment variable name (`PATH` in Linux/Mac vs `Path` in Windows) and in the path separator (`:` in Linux/Mac vs `;` in Windows). The only system-independent way to get the path seems to be `System.getenv("PATH")` which works even on Windows. Note that `System.getenv().get("PATH")` doesn't work on Windows. Additionally, determining the OS depends on `System.getProperty`, so this can be initialized directly in DatabricksConfig and mocked in unit tests.

## Tests
Manually tested on a Windows machine:
1. Installed the Databricks CLI and ran `.\datarbricks.exe auth login --host <HOST>`.
2. Added the Databricks CLI to the PATH system environment variable.
3. Ran the CLIWorkspaceAuth example and was able to list clusters.

As a side note: when we make auth permutations test harnesses, we should have a Windows variant to catch these errors.