### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Version changelog
 
+## 0.16.0
+
+* Update to OpenAPI spec ([#204](https://github.com/databricks/databricks-sdk-java/pull/204)).
+
+API Changes:
+
+ * Changed `list()` method for `workspaceClient.externalLocations()` service to require request of `com.databricks.sdk.service.catalog.ListExternalLocationsRequest` class.
+ * Changed `list()` method for `workspaceClient.storageCredentials()` service to require request of `com.databricks.sdk.service.catalog.ListStorageCredentialsRequest` class.
+ * Added `nextPageToken` field for `com.databricks.sdk.service.catalog.ListExternalLocationsResponse`.
+ * Added `maxResults` field for `com.databricks.sdk.service.catalog.ListFunctionsRequest`.
+ * Added `pageToken` field for `com.databricks.sdk.service.catalog.ListFunctionsRequest`.
+ * Added `nextPageToken` field for `com.databricks.sdk.service.catalog.ListFunctionsResponse`.
+ * Added `maxResults` field for `com.databricks.sdk.service.catalog.ListSchemasRequest`.
+ * Added `pageToken` field for `com.databricks.sdk.service.catalog.ListSchemasRequest`.
+ * Added `nextPageToken` field for `com.databricks.sdk.service.catalog.ListSchemasResponse`.
+ * Added `nextPageToken` field for `com.databricks.sdk.service.catalog.ListStorageCredentialsResponse`.
+ * Added `omitColumns` field for `com.databricks.sdk.service.catalog.ListTablesRequest`.
+ * Added `omitProperties` field for `com.databricks.sdk.service.catalog.ListTablesRequest`.
+ * Added `com.databricks.sdk.service.catalog.ListExternalLocationsRequest` class.
+ * Added `com.databricks.sdk.service.catalog.ListStorageCredentialsRequest` class.
+ * Changed `list()` method for `workspaceClient.tokens()` service to return `com.databricks.sdk.service.settings.ListPublicTokensResponse` class.
+ * Added `com.databricks.sdk.service.settings.ListPublicTokensResponse` class.
+ * Added `com.databricks.sdk.service.dashboards` package.
+ * Added `com.databricks.sdk.service.vectorsearch` package.
+
+OpenAPI SHA: a7a9dc025bb80303e676bf3708942c6aa06689f1, Date: 2024-01-04
+
+
 ## 0.15.0
 
 * Better Java examples ([#200](https://github.com/databricks/databricks-sdk-java/pull/200)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 * Update to OpenAPI spec ([#204](https://github.com/databricks/databricks-sdk-java/pull/204)).
 
+Note: This release contains breaking changes, please see below.
+
 API Changes:
 
- * Changed `list()` method for `workspaceClient.externalLocations()` service to require request of `com.databricks.sdk.service.catalog.ListExternalLocationsRequest` class, `workspaceClient.storageCredentials()` service to require request of `com.databricks.sdk.service.catalog.ListStorageCredentialsRequest` class and `workspaceClient.tokens()` service to return `com.databricks.sdk.service.settings.ListPublicTokensResponse` class and `com.databricks.sdk.service.catalog.ListSchemasResponse`.
+ * [Breaking] Changed `list()` method for `workspaceClient.externalLocations()` service to require request of `com.databricks.sdk.service.catalog.ListExternalLocationsRequest` class, `workspaceClient.storageCredentials()` service to require request of `com.databricks.sdk.service.catalog.ListStorageCredentialsRequest` class and `workspaceClient.tokens()` service to return `com.databricks.sdk.service.settings.ListPublicTokensResponse` class and `com.databricks.sdk.service.catalog.ListSchemasResponse`.
  * Added `nextPageToken` field for `com.databricks.sdk.service.catalog.ListExternalLocationsResponse`, `com.databricks.sdk.service.catalog.ListFunctionsResponse`, `com.databricks.sdk.service.catalog.ListSchemasResponse` and `com.databricks.sdk.service.catalog.ListStorageCredentialsResponse`.
  * Added `maxResults` field for `com.databricks.sdk.service.catalog.ListFunctionsRequest` and `com.databricks.sdk.service.catalog.ListSchemasRequest`.
  * Added `pageToken` field for `com.databricks.sdk.service.catalog.ListFunctionsRequest` and `com.databricks.sdk.service.catalog.ListSchemasRequest`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,24 +6,13 @@
 
 API Changes:
 
- * Changed `list()` method for `workspaceClient.externalLocations()` service to require request of `com.databricks.sdk.service.catalog.ListExternalLocationsRequest` class.
- * Changed `list()` method for `workspaceClient.storageCredentials()` service to require request of `com.databricks.sdk.service.catalog.ListStorageCredentialsRequest` class.
- * Added `nextPageToken` field for `com.databricks.sdk.service.catalog.ListExternalLocationsResponse`.
- * Added `maxResults` field for `com.databricks.sdk.service.catalog.ListFunctionsRequest`.
- * Added `pageToken` field for `com.databricks.sdk.service.catalog.ListFunctionsRequest`.
- * Added `nextPageToken` field for `com.databricks.sdk.service.catalog.ListFunctionsResponse`.
- * Added `maxResults` field for `com.databricks.sdk.service.catalog.ListSchemasRequest`.
- * Added `pageToken` field for `com.databricks.sdk.service.catalog.ListSchemasRequest`.
- * Added `nextPageToken` field for `com.databricks.sdk.service.catalog.ListSchemasResponse`.
- * Added `nextPageToken` field for `com.databricks.sdk.service.catalog.ListStorageCredentialsResponse`.
- * Added `omitColumns` field for `com.databricks.sdk.service.catalog.ListTablesRequest`.
- * Added `omitProperties` field for `com.databricks.sdk.service.catalog.ListTablesRequest`.
- * Added `com.databricks.sdk.service.catalog.ListExternalLocationsRequest` class.
- * Added `com.databricks.sdk.service.catalog.ListStorageCredentialsRequest` class.
- * Changed `list()` method for `workspaceClient.tokens()` service to return `com.databricks.sdk.service.settings.ListPublicTokensResponse` class.
- * Added `com.databricks.sdk.service.settings.ListPublicTokensResponse` class.
- * Added `com.databricks.sdk.service.dashboards` package.
- * Added `com.databricks.sdk.service.vectorsearch` package.
+ * Changed `list()` method for `workspaceClient.externalLocations()` service to require request of `com.databricks.sdk.service.catalog.ListExternalLocationsRequest` class, `workspaceClient.storageCredentials()` service to require request of `com.databricks.sdk.service.catalog.ListStorageCredentialsRequest` class and `workspaceClient.tokens()` service to return `com.databricks.sdk.service.settings.ListPublicTokensResponse` class and `com.databricks.sdk.service.catalog.ListSchemasResponse`.
+ * Added `nextPageToken` field for `com.databricks.sdk.service.catalog.ListExternalLocationsResponse`, `com.databricks.sdk.service.catalog.ListFunctionsResponse`, `com.databricks.sdk.service.catalog.ListSchemasResponse` and `com.databricks.sdk.service.catalog.ListStorageCredentialsResponse`.
+ * Added `maxResults` field for `com.databricks.sdk.service.catalog.ListFunctionsRequest` and `com.databricks.sdk.service.catalog.ListSchemasRequest`.
+ * Added `pageToken` field for `com.databricks.sdk.service.catalog.ListFunctionsRequest` and `com.databricks.sdk.service.catalog.ListSchemasRequest`.
+ * Added `omitColumns` and `omitProperties` field for `com.databricks.sdk.service.catalog.ListTablesRequest`.
+ * Added class: `com.databricks.sdk.service.catalog.ListExternalLocationsRequest`, `com.databricks.sdk.service.catalog.ListStorageCredentialsRequest` and `com.databricks.sdk.service.settings.ListPublicTokensResponse` class.
+ * Added package: `com.databricks.sdk.service.dashboards` and `com.databricks.sdk.service.vectorsearch`.
 
 OpenAPI SHA: a7a9dc025bb80303e676bf3708942c6aa06689f1, Date: 2024-01-04
 

--- a/databricks-sdk-java/pom.xml
+++ b/databricks-sdk-java/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.databricks</groupId>
     <artifactId>databricks-sdk-parent</artifactId>
-    <version>0.15.0</version>
+    <version>0.16.0</version>
   </parent>
   <artifactId>databricks-sdk-java</artifactId>
   <properties>

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -13,7 +13,7 @@ public class UserAgent {
   // TODO: check if reading from
   // /META-INF/maven/com.databricks/databrics-sdk-java/pom.properties
   // or getClass().getPackage().getImplementationVersion() is enough.
-  private static final String version = "0.15.0";
+  private static final String version = "0.16.0";
 
   public static void withProduct(String product, String productVersion) {
     UserAgent.product = product;

--- a/examples/docs/pom.xml
+++ b/examples/docs/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>com.databricks</groupId>
       <artifactId>databricks-sdk-java</artifactId>
-      <version>0.15.0</version>
+      <version>0.16.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/examples/spring-boot-oauth-u2m-demo/pom.xml
+++ b/examples/spring-boot-oauth-u2m-demo/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.databricks</groupId>
       <artifactId>databricks-sdk-java</artifactId>
-      <version>0.15.0</version>
+      <version>0.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.databricks</groupId>
   <artifactId>databricks-sdk-parent</artifactId>
-  <version>0.15.0</version>
+  <version>0.16.0</version>
   <packaging>pom</packaging>
   <name>Databricks SDK for Java</name>
   <description>The Databricks SDK for Java includes functionality to accelerate development with Java for


### PR DESCRIPTION
* Update to OpenAPI spec ([#204](https://github.com/databricks/databricks-sdk-java/pull/204)).

Note: This release contains breaking changes, please see below.

API Changes:

 * [Breaking] Changed `list()` method for `workspaceClient.externalLocations()` service to require request of `com.databricks.sdk.service.catalog.ListExternalLocationsRequest` class, `workspaceClient.storageCredentials()` service to require request of `com.databricks.sdk.service.catalog.ListStorageCredentialsRequest` class and `workspaceClient.tokens()` service to return `com.databricks.sdk.service.settings.ListPublicTokensResponse` class and `com.databricks.sdk.service.catalog.ListSchemasResponse`.
 * Added `nextPageToken` field for `com.databricks.sdk.service.catalog.ListExternalLocationsResponse`, `com.databricks.sdk.service.catalog.ListFunctionsResponse`, `com.databricks.sdk.service.catalog.ListSchemasResponse` and `com.databricks.sdk.service.catalog.ListStorageCredentialsResponse`.
 * Added `maxResults` field for `com.databricks.sdk.service.catalog.ListFunctionsRequest` and `com.databricks.sdk.service.catalog.ListSchemasRequest`.
 * Added `pageToken` field for `com.databricks.sdk.service.catalog.ListFunctionsRequest` and `com.databricks.sdk.service.catalog.ListSchemasRequest`.
 * Added `omitColumns` and `omitProperties` field for `com.databricks.sdk.service.catalog.ListTablesRequest`.
 * Added class: `com.databricks.sdk.service.catalog.ListExternalLocationsRequest`, `com.databricks.sdk.service.catalog.ListStorageCredentialsRequest` and `com.databricks.sdk.service.settings.ListPublicTokensResponse` class.
 * Added package: `com.databricks.sdk.service.dashboards` and `com.databricks.sdk.service.vectorsearch`.

OpenAPI SHA: a7a9dc025bb80303e676bf3708942c6aa06689f1, Date: 2024-01-04