### PR TITLE
Fix Databricks OAuth U2M on GCP

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksCliCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksCliCredentialsProvider.java
@@ -38,7 +38,7 @@ public class DatabricksCliCredentialsProvider implements CredentialsProvider {
   @Override
   public HeaderFactory configure(DatabricksConfig config) {
     String host = config.getHost();
-    if (host == null || !config.isAws()) {
+    if (host == null) {
       return null;
     }
 


### PR DESCRIPTION
## Changes

## Tests

Manually tested with a profile that uses `databricks-cli` with a GCP workspace



