### PR TITLE
Fix getWorkspaceClient() for GCP

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -566,7 +566,13 @@ public class DatabricksConfig {
 
   public DatabricksConfig newWithWorkspaceHost(String host) {
     Set<String> fieldsToSkip =
-        new HashSet<>(Arrays.asList("host", "accountId", "azureWorkspaceResourceId"));
+        new HashSet<>(Arrays.asList(
+            // The config for WorkspaceClient has a different host and Azure Workspace resource ID, and also omits
+            // the account ID.
+            "host", "accountId", "azureWorkspaceResourceId",
+            // For cloud-native OAuth, we need to reauthenticate as the audience has changed, so don't cache the
+            // header factory.
+            "authType", "headerFactory"));
     DatabricksConfig newConfig = new DatabricksConfig();
     for (Field f : DatabricksConfig.class.getDeclaredFields()) {
       if (fieldsToSkip.contains(f.getName())) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -566,13 +566,19 @@ public class DatabricksConfig {
 
   public DatabricksConfig newWithWorkspaceHost(String host) {
     Set<String> fieldsToSkip =
-        new HashSet<>(Arrays.asList(
-            // The config for WorkspaceClient has a different host and Azure Workspace resource ID, and also omits
-            // the account ID.
-            "host", "accountId", "azureWorkspaceResourceId",
-            // For cloud-native OAuth, we need to reauthenticate as the audience has changed, so don't cache the
-            // header factory.
-            "authType", "headerFactory"));
+        new HashSet<>(
+            Arrays.asList(
+                // The config for WorkspaceClient has a different host and Azure Workspace resource
+                // ID, and also omits
+                // the account ID.
+                "host",
+                "accountId",
+                "azureWorkspaceResourceId",
+                // For cloud-native OAuth, we need to reauthenticate as the audience has changed, so
+                // don't cache the
+                // header factory.
+                "authType",
+                "headerFactory"));
     DatabricksConfig newConfig = new DatabricksConfig();
     for (Field f : DatabricksConfig.class.getDeclaredFields()) {
       if (fieldsToSkip.contains(f.getName())) {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountClientIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountClientIT.java
@@ -3,26 +3,23 @@ package com.databricks.sdk.integration;
 import com.databricks.sdk.AccountClient;
 import com.databricks.sdk.WorkspaceClient;
 import com.databricks.sdk.integration.framework.EnvContext;
+import com.databricks.sdk.integration.framework.EnvOrSkip;
 import com.databricks.sdk.integration.framework.EnvTest;
 import com.databricks.sdk.service.provisioning.Workspace;
 import java.util.Iterator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static java.lang.Long.parseLong;
+
 @EnvContext("account")
 @ExtendWith(EnvTest.class)
 public class AccountClientIT {
   @Test
-  public void getWorkspaceClient(AccountClient a) {
-    // Skip test in GCP and Azure until fixed
-    if (!a.config().isAzure() && !a.config().isGcp()) {
-      Iterator<Workspace> workspaces = a.workspaces().list().iterator();
-      if (!workspaces.hasNext()) {
-        return;
-      }
-      Workspace workspace = workspaces.next();
-      WorkspaceClient w = a.getWorkspaceClient(workspace);
-      assert w.currentUser().me().getActive();
-    }
+  public void getWorkspaceClient(AccountClient a, @EnvOrSkip("TEST_WORKSPACE_ID") String workspaceIdStr) {
+    long workspaceId = Long.parseLong(workspaceIdStr);
+    Workspace workspace = a.workspaces().get(workspaceId);
+    WorkspaceClient w = a.getWorkspaceClient(workspace);
+    assert w.currentUser().me().getActive();
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountClientIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountClientIT.java
@@ -6,17 +6,15 @@ import com.databricks.sdk.integration.framework.EnvContext;
 import com.databricks.sdk.integration.framework.EnvOrSkip;
 import com.databricks.sdk.integration.framework.EnvTest;
 import com.databricks.sdk.service.provisioning.Workspace;
-import java.util.Iterator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import static java.lang.Long.parseLong;
 
 @EnvContext("account")
 @ExtendWith(EnvTest.class)
 public class AccountClientIT {
   @Test
-  public void getWorkspaceClient(AccountClient a, @EnvOrSkip("TEST_WORKSPACE_ID") String workspaceIdStr) {
+  public void getWorkspaceClient(
+      AccountClient a, @EnvOrSkip("TEST_WORKSPACE_ID") String workspaceIdStr) {
     long workspaceId = Long.parseLong(workspaceIdStr);
     Workspace workspace = a.workspaces().get(workspaceId);
     WorkspaceClient w = a.getWorkspaceClient(workspace);


### PR DESCRIPTION
## Changes
The current implementation of getWorkspaceClient() copies the entire config, critically reusing the cached header factory so as to use the same auth mechanism when getting a workspace client. However, at least in GCP, account-level OAuth tokens can't be used to authenticate to a workspace (probably because the audience for the account-level and workspace-level tokens is different).

This PR fixes this by copying all fields except for the auth type and header factory. Subsequent use of the config in WorkspaceClient will trigger config resolution. For GCP, this means creating a new token source using the correct host as the audience.

This ports https://github.com/databricks/databricks-sdk-go/pull/803 to the Java SDK.

## Tests
Manually ran this integration test in all non-UC (Azure, AWS, GCP) and UC (AWS, GCP) account-level environments.



