### PR TITLE
Reading headers should be done in a case-insensitive manner

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/http/Response.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/http/Response.java
@@ -86,11 +86,16 @@ public class Response {
   }
 
   public List<String> getHeaders(String key) {
-    return headers.get(key);
+    for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+      if (entry.getKey().equalsIgnoreCase(key)) {
+        return entry.getValue();
+      }
+    }
+    return null;
   }
 
   public String getFirstHeader(String key) {
-    List<String> hs = headers.get(key);
+    List<String> hs = getHeaders(key);
     if (hs == null || hs.isEmpty()) {
       return null;
     }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/FilesIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/FilesIT.java
@@ -48,8 +48,8 @@ public class FilesIT {
     // Check header deserialization
     GetMetadataResponse metadata = workspace.files().getMetadata(fileName);
     Assertions.assertEquals("application/octet-stream", metadata.getContentType());
-    // Read the file back from DBFS.
     Assertions.assertEquals(10240, metadata.getContentLength());
+    // Read the file back from DBFS.
     try (InputStream readContents = workspace.files().download(fileName).getContents()) {
       byte[] result = new byte[fileContents.length];
       int bytesRead = readContents.read(result);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/FilesIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/FilesIT.java
@@ -49,6 +49,7 @@ public class FilesIT {
     GetMetadataResponse metadata = workspace.files().getMetadata(fileName);
     Assertions.assertEquals("application/octet-stream", metadata.getContentType());
     // Read the file back from DBFS.
+    Assertions.assertEquals(10240, metadata.getContentLength());
     try (InputStream readContents = workspace.files().download(fileName).getContents()) {
       byte[] result = new byte[fileContents.length];
       int bytesRead = readContents.read(result);


### PR DESCRIPTION
## Changes
This makes reading the header case insensitive

## Tests
Ran the tests against a test environment:
<img width="339" alt="image" src="https://github.com/databricks/databricks-sdk-java/assets/36550428/6ed885c6-590e-4bb6-aa88-1cc8a75b2397">

