### PR TITLE
Add basic support for HTTP proxies

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
@@ -53,6 +53,7 @@ public class CommonsHttpClient implements HttpClient {
     return HttpClientBuilder.create()
         .setConnectionManager(connectionManager)
         .setDefaultRequestConfig(makeRequestConfig())
+        .useSystemProperties()
         .build();
   }
 

--- a/examples/docs/src/main/java/com/databricks/example/HttpProxyExample.java
+++ b/examples/docs/src/main/java/com/databricks/example/HttpProxyExample.java
@@ -1,0 +1,36 @@
+package com.databricks.example;
+
+import com.databricks.sdk.WorkspaceClient;
+import com.databricks.sdk.service.compute.ClusterDetails;
+import com.databricks.sdk.service.compute.ListClustersRequest;
+
+/**
+ * This example demonstrates how to use the Databricks Java SDK with an HTTP proxy.
+ *
+ * To run this example, you must set the following system properties:
+ * -Dhttps.proxyHost=<proxy host>
+ *   The host name of the HTTP proxy server.
+ * -Dhttps.proxyPort=<proxy port>
+ *   The port number of the HTTP proxy server.
+ */
+class HttpProxyExample {
+  public static void main(String[] args) {
+    validateProxySettings();
+    WorkspaceClient w = new WorkspaceClient();
+
+    for (ClusterDetails c : w.clusters().list(new ListClustersRequest())) {
+      System.out.println(c.getClusterName());
+    }
+  }
+
+  private static void validateProxySettings() {
+    String httpProxyHost = System.getProperty("https.proxyHost");
+    String httpProxyPort = System.getProperty("https.proxyPort");
+    if (httpProxyHost == null) {
+      throw new IllegalArgumentException("https.proxyHost must be set");
+    }
+    if (httpProxyPort == null) {
+      throw new IllegalArgumentException("https.proxyPort must be set");
+    }
+  }
+}


### PR DESCRIPTION
## Changes
This PR sets `useSystemProperties()` when building the Commons HTTP client. This allows users to configure an HTTP proxy by setting the `https.proxyHost` and `https.proxyPort` parameters (see https://docs.oracle.com/javase/6/docs/technotes/guides/net/proxies.html). 

Closes #111.

## Tests
Added an example. Started the HTTP proxy from https://github.com/databricks/databricks-sdk-go/pull/825, created a run configuration for the new example that sets `https.proxyHost` to `localhost` and `https.proxyPort` to `8443`, and run. I see the proxy server handling a request and the example completes successfully.

