### PR TITLE
Properly escape multi-segment path parameters

### DIFF
--- a/.codegen/impl.java.tmpl
+++ b/.codegen/impl.java.tmpl
@@ -9,6 +9,7 @@ import java.util.HashMap;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Encoding;
 import com.databricks.sdk.support.Generated;
 
 {{range .Package.ImportedEntities}}
@@ -25,9 +26,7 @@ class {{.PascalName}}Impl implements {{.PascalName}}Service {
 	{{range .Methods}}
   @Override
   public {{if not .Response.IsEmpty -}}{{template "type" .Response}}{{else}}void{{end}} {{.CamelName}}{{if .IsNameReserved}}Content{{end}}({{if .Request}}{{template "type" .Request}} request{{end}}) {
-    String path = {{if .PathParts -}}
-      String.format("{{range  .PathParts}}{{.Prefix}}{{if or .Field .IsAccountId}}%s{{end}}{{ end }}"{{ range .PathParts }}{{if .Field}}, request.get{{.Field.PascalName}}(){{ else if .IsAccountId }}, apiClient.configuredAccountID(){{end}}{{ end }})
-    {{- else}}"{{.Path}}"{{end}};
+    String path = {{ template "path" . }};
     {{ template "headers" . -}}
     {{ if .Response.IsEmpty -}}
     {{ template "api-call" . }}
@@ -38,6 +37,23 @@ class {{.PascalName}}Impl implements {{.PascalName}}Service {
   }
   {{end}}
 }
+
+{{- define "path" -}}
+{{- if .PathParts -}}
+  String.format("{{range  .PathParts -}}
+    {{- .Prefix -}}
+    {{- if or .Field .IsAccountId -}}%s{{- end -}}
+  {{- end -}}"
+  {{- range .PathParts -}}
+    {{- if and .Field .Field.IsPathMultiSegment -}}, Encoding.encodeMultiSegmentPathParameter(request.get{{.Field.PascalName}}())
+    {{- else if .Field -}}, request.get{{.Field.PascalName}}()
+    {{- else if .IsAccountId -}}, apiClient.configuredAccountID()
+    {{- end -}}
+  {{- end -}})
+{{- else -}}
+  "{{.Path}}"
+{{- end -}}
+{{- end -}}
 
 {{ define "api-call" }}
 apiClient.{{.Verb}}(path

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/http/Encoding.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/http/Encoding.java
@@ -1,0 +1,104 @@
+package com.databricks.sdk.core.http;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.BitSet;
+
+/**
+ * Utility class for encoding strings for use in URLs.
+ *
+ * <p>Adapted from URLEncodingUtils.java from Apache's HttpClient library.
+ */
+public class Encoding {
+
+  /**
+   * Unreserved characters, i.e. alphanumeric, plus: {@code _ - ! . ~ ' ( ) *}
+   *
+   * <p>This list is the same as the {@code unreserved} list in <a
+   * href="http://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>
+   */
+  private static final BitSet UNRESERVED = new BitSet(256);
+
+  /**
+   * Characters which are safe to use in a path, excluding /, i.e. {@link #UNRESERVED} plus punctuation
+   * plus @
+   */
+  private static final BitSet PATHSAFE = new BitSet(256);
+
+  /**
+   * Characters which are safe to use in a path, including /.
+   */
+  private static final BitSet PATH_SPECIAL = new BitSet(256);
+
+  static {
+    // unreserved chars
+    // alpha characters
+    for (int i = 'a'; i <= 'z'; i++) {
+      UNRESERVED.set(i);
+    }
+    for (int i = 'A'; i <= 'Z'; i++) {
+      UNRESERVED.set(i);
+    }
+    // numeric characters
+    for (int i = '0'; i <= '9'; i++) {
+      UNRESERVED.set(i);
+    }
+    UNRESERVED.set('_'); // these are the characters of the "mark" list
+    UNRESERVED.set('-');
+    UNRESERVED.set('.');
+    UNRESERVED.set('*');
+    UNRESERVED.set('!');
+    UNRESERVED.set('~');
+    UNRESERVED.set('\'');
+    UNRESERVED.set('(');
+    UNRESERVED.set(')');
+
+    // URL path safe
+    PATHSAFE.or(UNRESERVED);
+    PATHSAFE.set(';'); // param separator
+    PATHSAFE.set(':'); // RFC 2396
+    PATHSAFE.set('@');
+    PATHSAFE.set('&');
+    PATHSAFE.set('=');
+    PATHSAFE.set('+');
+    PATHSAFE.set('$');
+    PATHSAFE.set(',');
+
+    PATH_SPECIAL.or(PATHSAFE);
+    PATH_SPECIAL.set('/');
+  }
+
+  private static final int RADIX = 16;
+
+  private static String urlEncode(
+      final String content,
+      final Charset charset,
+      final BitSet safechars,
+      final boolean blankAsPlus) {
+    if (content == null) {
+      return null;
+    }
+    final StringBuilder buf = new StringBuilder();
+    final ByteBuffer bb = charset.encode(content);
+    while (bb.hasRemaining()) {
+      final int b = bb.get() & 0xff;
+      if (safechars.get(b)) {
+        buf.append((char) b);
+      } else if (blankAsPlus && b == ' ') {
+        buf.append('+');
+      } else {
+        buf.append("%");
+        final char hex1 = Character.toUpperCase(Character.forDigit((b >> 4) & 0xF, RADIX));
+        final char hex2 = Character.toUpperCase(Character.forDigit(b & 0xF, RADIX));
+        buf.append(hex1);
+        buf.append(hex2);
+      }
+    }
+    return buf.toString();
+  }
+
+  public static String encodeMultiSegmentPathParameter(String param) {
+    return urlEncode(param, StandardCharsets.UTF_8, PATH_SPECIAL, false);
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/http/Encoding.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/http/Encoding.java
@@ -21,14 +21,12 @@ public class Encoding {
   private static final BitSet UNRESERVED = new BitSet(256);
 
   /**
-   * Characters which are safe to use in a path, excluding /, i.e. {@link #UNRESERVED} plus punctuation
-   * plus @
+   * Characters which are safe to use in a path, excluding /, i.e. {@link #UNRESERVED} plus
+   * punctuation plus @
    */
   private static final BitSet PATHSAFE = new BitSet(256);
 
-  /**
-   * Characters which are safe to use in a path, including /.
-   */
+  /** Characters which are safe to use in a path, including /. */
   private static final BitSet PATH_SPECIAL = new BitSet(256);
 
   static {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/FilesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/FilesImpl.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.files;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.http.Encoding;
 import com.databricks.sdk.support.Generated;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,28 +18,38 @@ class FilesImpl implements FilesService {
 
   @Override
   public void createDirectory(CreateDirectoryRequest request) {
-    String path = String.format("/api/2.0/fs/directories%s", request.getDirectoryPath());
+    String path =
+        String.format(
+            "/api/2.0/fs/directories%s",
+            Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
     Map<String, String> headers = new HashMap<>();
     apiClient.PUT(path, null, CreateDirectoryResponse.class, headers);
   }
 
   @Override
   public void delete(DeleteFileRequest request) {
-    String path = String.format("/api/2.0/fs/files%s", request.getFilePath());
+    String path =
+        String.format(
+            "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
     Map<String, String> headers = new HashMap<>();
     apiClient.DELETE(path, request, DeleteResponse.class, headers);
   }
 
   @Override
   public void deleteDirectory(DeleteDirectoryRequest request) {
-    String path = String.format("/api/2.0/fs/directories%s", request.getDirectoryPath());
+    String path =
+        String.format(
+            "/api/2.0/fs/directories%s",
+            Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
     Map<String, String> headers = new HashMap<>();
     apiClient.DELETE(path, request, DeleteDirectoryResponse.class, headers);
   }
 
   @Override
   public DownloadResponse download(DownloadRequest request) {
-    String path = String.format("/api/2.0/fs/files%s", request.getFilePath());
+    String path =
+        String.format(
+            "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/octet-stream");
     return apiClient.GET(path, request, DownloadResponse.class, headers);
@@ -46,21 +57,29 @@ class FilesImpl implements FilesService {
 
   @Override
   public void getDirectoryMetadata(GetDirectoryMetadataRequest request) {
-    String path = String.format("/api/2.0/fs/directories%s", request.getDirectoryPath());
+    String path =
+        String.format(
+            "/api/2.0/fs/directories%s",
+            Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
     Map<String, String> headers = new HashMap<>();
     apiClient.HEAD(path, request, GetDirectoryMetadataResponse.class, headers);
   }
 
   @Override
   public GetMetadataResponse getMetadata(GetMetadataRequest request) {
-    String path = String.format("/api/2.0/fs/files%s", request.getFilePath());
+    String path =
+        String.format(
+            "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
     Map<String, String> headers = new HashMap<>();
     return apiClient.HEAD(path, request, GetMetadataResponse.class, headers);
   }
 
   @Override
   public ListDirectoryResponse listDirectoryContents(ListDirectoryContentsRequest request) {
-    String path = String.format("/api/2.0/fs/directories%s", request.getDirectoryPath());
+    String path =
+        String.format(
+            "/api/2.0/fs/directories%s",
+            Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     return apiClient.GET(path, request, ListDirectoryResponse.class, headers);
@@ -68,7 +87,9 @@ class FilesImpl implements FilesService {
 
   @Override
   public void upload(UploadRequest request) {
-    String path = String.format("/api/2.0/fs/files%s", request.getFilePath());
+    String path =
+        String.format(
+            "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
     Map<String, String> headers = new HashMap<>();
     headers.put("Content-Type", "application/octet-stream");
     apiClient.PUT(path, request.getContents(), UploadResponse.class, headers);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/http/EncodingTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/http/EncodingTest.java
@@ -1,0 +1,13 @@
+package com.databricks.sdk.core.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EncodingTest {
+  @Test
+  public void encodeMultiSegmentPathParameter() {
+    assertEquals("/foo/bar", Encoding.encodeMultiSegmentPathParameter("/foo/bar"));
+    assertEquals("a%3Fb%23c", Encoding.encodeMultiSegmentPathParameter("a?b#c"));
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/http/EncodingTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/http/EncodingTest.java
@@ -1,8 +1,8 @@
 package com.databricks.sdk.core.http;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 public class EncodingTest {
   @Test

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/FilesIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/FilesIT.java
@@ -28,7 +28,7 @@ public class FilesIT {
         workspace,
         (volumePath) -> {
           // Generate a random file name and random contents of 10 KiB.
-          String fileName = NameUtils.uniqueName(volumePath + "/test");
+          String fileName = NameUtils.uniqueName(volumePath + "/test-with-?-and-#");
           byte[] fileContents = new byte[1024 * 10];
           for (int i = 0; i < fileContents.length; i++) {
             fileContents[i] = (byte) (i & 0xFF);


### PR DESCRIPTION
## Changes
Ports https://github.com/databricks/databricks-sdk-go/pull/869 to Java SDK.

Currently, path parameters are directly interpolated into the request URL without escaping. This means that characters like `/`, `?` and `#` will not be percent-encoded and will affect the semantics of the URL, starting a new path segment, query parameters, or fragment, respectively. This means that it is impossible for users of the Files API to upload/download objects that contain `?` or `#` in their name. `/` is allowed in the path of the Files API, so it does not need to be escaped.

The Files API is currently marked with `x-databricks-multi-segment`, indicating that it should be permitted to have `/` characters but other characters need to be percent-encoded. This PR implements this.

## Tests
- [x] Unit test for multi-segment path escaping behavior.
- [x] Updated integration test to use # and ? symbols in the file name.