### PR TITLE
fix to set `filter` to `null` when `next_page_token` is returned from previous call

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -342,13 +342,17 @@ public class DatabricksConfig {
     return this;
   }
 
-  /** @deprecated Use {@link #getAzureUseMsi()} instead. */
+  /**
+   * @deprecated Use {@link #getAzureUseMsi()} instead.
+   */
   @Deprecated()
   public boolean getAzureUseMSI() {
     return azureUseMsi;
   }
 
-  /** @deprecated Use {@link #setAzureUseMsi(boolean)} instead. */
+  /**
+   * @deprecated Use {@link #setAzureUseMsi(boolean)} instead.
+   */
   @Deprecated
   public DatabricksConfig setAzureUseMSI(boolean azureUseMsi) {
     this.azureUseMsi = azureUseMsi;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesAPI.java
@@ -223,7 +223,7 @@ public class PipelinesAPI {
           if (token == null) {
             return null;
           }
-          return request.setPageToken(token);
+          return request.setPageToken(token).setFilter(null);
         });
   }
 
@@ -242,7 +242,7 @@ public class PipelinesAPI {
           if (token == null) {
             return null;
           }
-          return request.setPageToken(token);
+          return request.setPageToken(token).setFilter(null);
         });
   }
 


### PR DESCRIPTION
## Changes
clear `request.filter` when preivous call returns next_page_token to avoid error when with filter request
```bash
databricks.sdk.errors.platform.InvalidParameterValue: When providing a page token and a filter, the filter must match the filter represented by the page token.
```
similar fix in https://github.com/databricks/databricks-sdk-py/pull/605, https://github.com/databricks/databricks-sdk-go/pull/875
## Tests
- [x] make test run locally
- [x] make fmt applied

