### PR TITLE
Support post with no body for APIs

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -142,6 +142,14 @@ public class ApiClient {
     }
   }
 
+  public <O> O POST(String path, Class<O> target, Map<String, String> headers) {
+    try {
+      return execute(prepareRequest("POST", path, null, headers), target);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
+  }
+
   public <I, O> O POST(String path, I in, Class<O> target, Map<String, String> headers) {
     try {
       return execute(prepareRequest("POST", path, in, headers), target);


### PR DESCRIPTION
## Changes
The upcoming Marketplace API introduces an API to create an analytics dashboard. This creation request is kind of a singleton, as it has no parameters. To support this, we introduce a `POST()` method with no body specified so that this resource can be created.

## Tests
<!-- How is this tested? -->

