### PR TITLE
Fix remaining Java integration tests

### DIFF
--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/PrivateAccessIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/PrivateAccessIT.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @EnvContext("account")
 @DisabledIfEnvironmentVariable(named = "ARM_CLIENT_ID", matches = ".*")
+// VPC Endpoints need to be enabled in our GCP E2 account.
+@DisabledIfEnvironmentVariable(named = "GOOGLE_CREDENTIALS", matches = ".*")
 @ExtendWith(EnvTest.class)
 public class PrivateAccessIT {
   @Test

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/QueriesIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/QueriesIT.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class QueriesIT {
   @Test
   void listsQueries(WorkspaceClient w) {
-    Iterable<Query> list = w.queries().list(new ListQueriesRequest().setPageSize(2L));
+    Iterable<Query> list = w.queries().list(new ListQueriesRequest().setPageSize(1000L));
 
     java.util.List<Query> all = CollectionUtils.asList(list);
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/VpcEndpointsIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/VpcEndpointsIT.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @EnvContext("account")
 @DisabledIfEnvironmentVariable(named = "ARM_CLIENT_ID", matches = ".*")
+// VPC Endpoints need to be enabled in our GCP E2 account.
+@DisabledIfEnvironmentVariable(named = "GOOGLE_CREDENTIALS", matches = ".*")
 @ExtendWith(EnvTest.class)
 public class VpcEndpointsIT {
   @Test


### PR DESCRIPTION
## Changes
After migrating GCP to a new E2 account, several private preview APIs need to be enabled before we can run integration tests on them. This PR disables those tests until then (PrivateAccessIT, VPCEndpointsIT).

Also, I noticed that QueriesIT was very slow due to using a very small page size (2), resulting in it making 1000s of requests serially. This caused integration tests to take over 2 hours to complete. I increased this to 1000 which should cause the test to finish a bit more quickly (on the order of minutes).

## Tests
<!-- How is this tested? -->

