### PR TITLE
Fix one-shot list APIs to not return null

### DIFF
--- a/.codegen/api.java.tmpl
+++ b/.codegen/api.java.tmpl
@@ -146,47 +146,55 @@ public class {{.PascalName}}API {
 {{- end}}
 
 {{define "method-call-paginated" -}}
-  {{- if .Pagination.MultiRequest -}}
-    {{- if and .Pagination.Offset (not (eq .Path "/api/2.0/clusters/events")) -}}
-    request.set{{.Pagination.Offset.PascalName}}(
-    {{- if eq .Pagination.Increment 1 -}}
-      1
-    {{- else if contains .Path "/scim/v2/" -}}
-      1
-    {{- else -}}
-      0
-    {{- end}}L);{{end -}}
-    {{if and .Pagination.Limit (contains .Path "/scim/v2/")}}
-    if (request.get{{.Pagination.Limit.PascalName}}() == null) {
-       request.set{{.Pagination.Limit.PascalName}}(100L);
-    }{{end -}}
-    return new Paginator<>(request, impl::{{template "java-name" .}}, {{template "type" .Response}}::get{{.Pagination.Results.PascalName}}, response -> {
-      {{if eq .Path "/api/2.0/clusters/events" -}}
-      return response.getNextPage();
-      {{- else if .Pagination.Token -}}
-      String token = response.get{{.Pagination.Token.Bind.PascalName}}();
-      if (token == null) {
-        return null;
-      }
-      return request.set{{.Pagination.Token.PollField.PascalName}}(token);
-      {{- else if eq .Pagination.Increment 1 -}}
-      Long page = request.get{{.Pagination.Offset.PascalName}}();
-      if (page == null) {
-        page = 1L; // redash uses 1-based pagination
-      }
-      return request.set{{.Pagination.Offset.PascalName}}(page+1L);
-      {{- else -}}
-      Long offset = request.get{{.Pagination.Offset.PascalName}}();
-      if (offset == null) {
-        offset = 0L;
-      }
-      offset += response.get{{.Pagination.Results.PascalName}}().size();
-      return request.set{{.Pagination.Offset.PascalName}}(offset);
-      {{- end}}
-    }){{if .NeedsOffsetDedupe -}}.withDedupe({{.Pagination.Entity.PascalName}}::get{{.IdentifierField.PascalName}}){{end}};
+  {{- if and .Pagination.Offset (not (eq .Path "/api/2.0/clusters/events")) -}}
+  request.set{{.Pagination.Offset.PascalName}}(
+  {{- if eq .Pagination.Increment 1 -}}
+    1
+  {{- else if contains .Path "/scim/v2/" -}}
+    1
   {{- else -}}
-    return impl.{{template "java-name" .}}({{if .Request}}request{{end}}){{with .Pagination.Results}}.get{{.PascalName}}(){{end}};
-  {{- end -}}
+    0
+  {{- end}}L);{{end -}}
+  {{if and .Pagination.Limit (contains .Path "/scim/v2/")}}
+  if (request.get{{.Pagination.Limit.PascalName}}() == null) {
+     request.set{{.Pagination.Limit.PascalName}}(100L);
+  }{{end -}}
+  return new Paginator<>(
+    {{ if .Request }}request{{ else }}null{{ end }},
+    {{ if .Request }}impl::{{template "java-name" .}}{{ else }}(Void v) -> impl.{{template "java-name" .}}(){{ end }},
+    {{template "type" .Response}}::get{{.Pagination.Results.PascalName}},
+    response ->
+      {{ if not .Pagination.MultiRequest }}
+      null
+      {{- else if eq .Path "/api/2.0/clusters/events" -}}
+      response.getNextPage()
+      {{- else if .Pagination.Token -}}
+      {
+        String token = response.get{{.Pagination.Token.Bind.PascalName}}();
+        if (token == null) {
+          return null;
+        }
+        return request.set{{.Pagination.Token.PollField.PascalName}}(token);
+      }
+      {{- else if eq .Pagination.Increment 1 -}}
+      {
+        Long page = request.get{{.Pagination.Offset.PascalName}}();
+        if (page == null) {
+          page = 1L; // redash uses 1-based pagination
+        }
+        return request.set{{.Pagination.Offset.PascalName}}(page+1L);
+      }
+      {{- else -}}
+      {
+        Long offset = request.get{{.Pagination.Offset.PascalName}}();
+        if (offset == null) {
+          offset = 0L;
+        }
+        offset += response.get{{.Pagination.Results.PascalName}}().size();
+        return request.set{{.Pagination.Offset.PascalName}}(offset);
+      }
+      {{- end}}
+  ){{if .NeedsOffsetDedupe -}}.withDedupe({{.Pagination.Entity.PascalName}}::get{{.IdentifierField.PascalName}}){{end}};
 {{- end}}
 
 {{define "method-call-retried" -}}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 databricks-sdk-java/src/main/java/com/databricks/sdk/AccountClient.java linguist-generated=true
 databricks-sdk-java/src/main/java/com/databricks/sdk/WorkspaceClient.java linguist-generated=true
 databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ErrorMapper.java linguist-generated=true
+databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ErrorOverrides.java linguist-generated=true
 databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/platform/Aborted.java linguist-generated=true
 databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/platform/AlreadyExists.java linguist-generated=true
 databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/platform/BadRequest.java linguist-generated=true

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BudgetsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BudgetsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.billing;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,7 +74,7 @@ public class BudgetsAPI {
    * that the budget is configured to include.
    */
   public Iterable<BudgetWithStatus> list() {
-    return impl.list().getBudgets();
+    return new Paginator<>(null, (Void v) -> impl.list(), BudgetList::getBudgets, response -> null);
   }
 
   public void update(String budgetId, Budget budget) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/LogDeliveryAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/LogDeliveryAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.billing;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,7 +129,11 @@ public class LogDeliveryAPI {
    * <p>Gets all Databricks log delivery configurations associated with an account specified by ID.
    */
   public Iterable<LogDeliveryConfiguration> list(ListLogDeliveryRequest request) {
-    return impl.list(request).getLogDeliveryConfigurations();
+    return new Paginator<>(
+        request,
+        impl::list,
+        WrappedLogDeliveryConfigurations::getLogDeliveryConfigurations,
+        response -> null);
   }
 
   public void patchStatus(String logDeliveryConfigurationId, LogDeliveryConfigStatus status) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoreAssignmentsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoreAssignmentsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,11 @@ public class AccountMetastoreAssignmentsAPI {
    * <p>Gets a list of all Databricks workspace IDs that have been assigned to given metastore.
    */
   public Iterable<Long> list(ListAccountMetastoreAssignmentsRequest request) {
-    return impl.list(request).getWorkspaceIds();
+    return new Paginator<>(
+        request,
+        impl::list,
+        ListAccountMetastoreAssignmentsResponse::getWorkspaceIds,
+        response -> null);
   }
 
   public void update(long workspaceId, String metastoreId) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoresAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoresAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +68,8 @@ public class AccountMetastoresAPI {
    * <p>Gets all Unity Catalog metastores associated with an account specified by ID.
    */
   public Iterable<MetastoreInfo> list() {
-    return impl.list().getMetastores();
+    return new Paginator<>(
+        null, (Void v) -> impl.list(), ListMetastoresResponse::getMetastores, response -> null);
   }
 
   public AccountsMetastoreInfo update(String metastoreId) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/CatalogsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/CatalogsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +83,8 @@ public class CatalogsAPI {
    * specific ordering of the elements in the array.
    */
   public Iterable<CatalogInfo> list(ListCatalogsRequest request) {
-    return impl.list(request).getCatalogs();
+    return new Paginator<>(
+        request, impl::list, ListCatalogsResponse::getCatalogs, response -> null);
   }
 
   public CatalogInfo update(String name) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ConnectionsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ConnectionsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +85,8 @@ public class ConnectionsAPI {
    * <p>List all connections.
    */
   public Iterable<ConnectionInfo> list() {
-    return impl.list().getConnections();
+    return new Paginator<>(
+        null, (Void v) -> impl.list(), ListConnectionsResponse::getConnections, response -> null);
   }
 
   public ConnectionInfo update(String name, Map<String, String> options) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/MetastoresAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/MetastoresAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,7 +115,8 @@ public class MetastoresAPI {
    * the array.
    */
   public Iterable<MetastoreInfo> list() {
-    return impl.list().getMetastores();
+    return new Paginator<>(
+        null, (Void v) -> impl.list(), ListMetastoresResponse::getMetastores, response -> null);
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/SystemSchemasAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/SystemSchemasAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +67,8 @@ public class SystemSchemasAPI {
    * metastore admin.
    */
   public Iterable<SystemSchemaInfo> list(ListSystemSchemasRequest request) {
-    return impl.list(request).getSchemas();
+    return new Paginator<>(
+        request, impl::list, ListSystemSchemasResponse::getSchemas, response -> null);
   }
 
   public SystemSchemasService impl() {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClusterPoliciesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClusterPoliciesAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,7 +134,8 @@ public class ClusterPoliciesAPI {
    * <p>Returns a list of policies accessible by the requesting user.
    */
   public Iterable<Policy> list(ListClusterPoliciesRequest request) {
-    return impl.list(request).getPolicies();
+    return new Paginator<>(
+        request, impl::list, ListPoliciesResponse::getPolicies, response -> null);
   }
 
   public ClusterPolicyPermissions setPermissions(String clusterPolicyId) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClustersAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClustersAPI.java
@@ -232,12 +232,7 @@ public class ClustersAPI {
    */
   public Iterable<ClusterEvent> events(GetEvents request) {
     return new Paginator<>(
-        request,
-        impl::events,
-        GetEventsResponse::getEvents,
-        response -> {
-          return response.getNextPage();
-        });
+        request, impl::events, GetEventsResponse::getEvents, response -> response.getNextPage());
   }
 
   public ClusterDetails get(String clusterId) {
@@ -294,7 +289,8 @@ public class ClustersAPI {
    * the 30 most recently terminated job clusters.
    */
   public Iterable<ClusterDetails> list(ListClustersRequest request) {
-    return impl.list(request).getClusters();
+    return new Paginator<>(
+        request, impl::list, ListClustersResponse::getClusters, response -> null);
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/GlobalInitScriptsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/GlobalInitScriptsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,8 @@ public class GlobalInitScriptsAPI {
    * a global init script](:method:globalinitscripts/get) operation.
    */
   public Iterable<GlobalInitScriptDetails> list() {
-    return impl.list().getScripts();
+    return new Paginator<>(
+        null, (Void v) -> impl.list(), ListGlobalInitScriptsResponse::getScripts, response -> null);
   }
 
   public void update(String scriptId, String name, String script) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstancePoolsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstancePoolsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,7 +134,8 @@ public class InstancePoolsAPI {
    * <p>Gets a list of instance pools with their statistics.
    */
   public Iterable<InstancePoolAndStats> list() {
-    return impl.list().getInstancePools();
+    return new Paginator<>(
+        null, (Void v) -> impl.list(), ListInstancePools::getInstancePools, response -> null);
   }
 
   public InstancePoolPermissions setPermissions(String instancePoolId) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstanceProfilesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstanceProfilesAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +78,11 @@ public class InstanceProfilesAPI {
    * <p>This API is available to all users.
    */
   public Iterable<InstanceProfile> list() {
-    return impl.list().getInstanceProfiles();
+    return new Paginator<>(
+        null,
+        (Void v) -> impl.list(),
+        ListInstanceProfilesResponse::getInstanceProfiles,
+        response -> null);
   }
 
   public void remove(String instanceProfileArn) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/LibrariesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/LibrariesAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,7 +78,8 @@ public class LibrariesAPI {
    * marked for removal. Within this group there is no order guarantee.
    */
   public Iterable<LibraryFullStatus> clusterStatus(ClusterStatusRequest request) {
-    return impl.clusterStatus(request).getLibraryStatuses();
+    return new Paginator<>(
+        request, impl::clusterStatus, ClusterLibraryStatuses::getLibraryStatuses, response -> null);
   }
 
   public void install(String clusterId, Collection<Library> libraries) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/DbfsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/DbfsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.files;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,7 +138,7 @@ public class DbfsAPI {
    * same functionality without timing out.
    */
   public Iterable<FileInfo> list(ListDbfsRequest request) {
-    return impl.list(request).getFiles();
+    return new Paginator<>(request, impl::list, ListStatusResponse::getFiles, response -> null);
   }
 
   public void mkdirs(String path) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/WorkspaceAssignmentAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/WorkspaceAssignmentAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +69,8 @@ public class WorkspaceAssignmentAPI {
    * workspace.
    */
   public Iterable<PermissionAssignment> list(ListWorkspaceAssignmentRequest request) {
-    return impl.list(request).getPermissionAssignments();
+    return new Paginator<>(
+        request, impl::list, PermissionAssignments::getPermissionAssignments, response -> null);
   }
 
   public PermissionAssignment update(

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ml/ModelRegistryAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ml/ModelRegistryAPI.java
@@ -232,7 +232,11 @@ public class ModelRegistryAPI {
    * <p>Gets the latest version of a registered model.
    */
   public Iterable<ModelVersion> getLatestVersions(GetLatestVersionsRequest request) {
-    return impl.getLatestVersions(request).getModelVersions();
+    return new Paginator<>(
+        request,
+        impl::getLatestVersions,
+        GetLatestVersionsResponse::getModelVersions,
+        response -> null);
   }
 
   public GetModelResponse getModel(String name) {
@@ -341,7 +345,11 @@ public class ModelRegistryAPI {
    * <p>Gets a list of all open stage transition requests for the model version.
    */
   public Iterable<Activity> listTransitionRequests(ListTransitionRequestsRequest request) {
-    return impl.listTransitionRequests(request).getRequests();
+    return new Paginator<>(
+        request,
+        impl::listTransitionRequests,
+        ListTransitionRequestsResponse::getRequests,
+        response -> null);
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/CustomAppIntegrationAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/CustomAppIntegrationAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +76,8 @@ public class CustomAppIntegrationAPI {
    * <p>Get the list of custom oauth app integrations for the specified Databricks account
    */
   public Iterable<GetCustomAppIntegrationOutput> list() {
-    return impl.list().getApps();
+    return new Paginator<>(
+        null, (Void v) -> impl.list(), GetCustomAppIntegrationsOutput::getApps, response -> null);
   }
 
   public void update(String integrationId) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/PublishedAppIntegrationAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/PublishedAppIntegrationAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +73,11 @@ public class PublishedAppIntegrationAPI {
    * <p>Get the list of published oauth app integrations for the specified Databricks account
    */
   public Iterable<GetPublishedAppIntegrationOutput> list() {
-    return impl.list().getApps();
+    return new Paginator<>(
+        null,
+        (Void v) -> impl.list(),
+        GetPublishedAppIntegrationsOutput::getApps,
+        response -> null);
   }
 
   public void update(String integrationId) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/ServicePrincipalSecretsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/ServicePrincipalSecretsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,8 @@ public class ServicePrincipalSecretsAPI {
    * information about the secrets themselves and does not include the secret values.
    */
   public Iterable<SecretInfo> list(ListServicePrincipalSecretsRequest request) {
-    return impl.list(request).getSecrets();
+    return new Paginator<>(
+        request, impl::list, ListServicePrincipalSecretsResponse::getSecrets, response -> null);
   }
 
   public ServicePrincipalSecretsService impl() {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.serving;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import com.databricks.sdk.support.Wait;
 import java.time.Duration;
 import java.util.Arrays;
@@ -183,7 +184,8 @@ public class ServingEndpointsAPI {
 
   /** Get all serving endpoints. */
   public Iterable<ServingEndpoint> list() {
-    return impl.list().getEndpoints();
+    return new Paginator<>(
+        null, (Void v) -> impl.list(), ListEndpointsResponse::getEndpoints, response -> null);
   }
 
   public ServerLogsResponse logs(String name, String servedModelName) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AccountIpAccessListsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AccountIpAccessListsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,7 +102,11 @@ public class AccountIpAccessListsAPI {
    * <p>Gets all IP access lists for the specified account.
    */
   public Iterable<IpAccessListInfo> list() {
-    return impl.list().getIpAccessLists();
+    return new Paginator<>(
+        null,
+        (Void v) -> impl.list(),
+        GetIpAccessListsResponse::getIpAccessLists,
+        response -> null);
   }
 
   public void replace(String ipAccessListId, String label, ListType listType, boolean enabled) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/IpAccessListsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/IpAccessListsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,7 +102,11 @@ public class IpAccessListsAPI {
    * <p>Gets all IP access lists for the specified workspace.
    */
   public Iterable<IpAccessListInfo> list() {
-    return impl.list().getIpAccessLists();
+    return new Paginator<>(
+        null,
+        (Void v) -> impl.list(),
+        ListIpAccessListResponse::getIpAccessLists,
+        response -> null);
   }
 
   public void replace(String ipAccessListId, String label, ListType listType, boolean enabled) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokenManagementAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokenManagementAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +90,8 @@ public class TokenManagementAPI {
    * <p>Lists all tokens associated with the specified workspace or user.
    */
   public Iterable<TokenInfo> list(ListTokenManagementRequest request) {
-    return impl.list(request).getTokenInfos();
+    return new Paginator<>(
+        request, impl::list, ListTokensResponse::getTokenInfos, response -> null);
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokensAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokensAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +60,8 @@ public class TokensAPI {
    * <p>Lists all the valid tokens for a user-workspace pair.
    */
   public Iterable<PublicTokenInfo> list() {
-    return impl.list().getTokenInfos();
+    return new Paginator<>(
+        null, (Void v) -> impl.list(), ListPublicTokensResponse::getTokenInfos, response -> null);
   }
 
   public TokensService impl() {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/ProvidersAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/ProvidersAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.sharing;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +77,8 @@ public class ProvidersAPI {
    * response. There is no guarantee of a specific ordering of the elements in the array.
    */
   public Iterable<ProviderInfo> list(ListProvidersRequest request) {
-    return impl.list(request).getProviders();
+    return new Paginator<>(
+        request, impl::list, ListProvidersResponse::getProviders, response -> null);
   }
 
   public Iterable<ProviderShare> listShares(String name) {
@@ -91,7 +93,8 @@ public class ProvidersAPI {
    * <p>* the caller is a metastore admin, or * the caller is the owner.
    */
   public Iterable<ProviderShare> listShares(ListSharesRequest request) {
-    return impl.listShares(request).getShares();
+    return new Paginator<>(
+        request, impl::listShares, ListProviderSharesResponse::getShares, response -> null);
   }
 
   public ProviderInfo update(String name) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/RecipientsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/RecipientsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.sharing;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,7 +91,8 @@ public class RecipientsAPI {
    * specific ordering of the elements in the array.
    */
   public Iterable<RecipientInfo> list(ListRecipientsRequest request) {
-    return impl.list(request).getRecipients();
+    return new Paginator<>(
+        request, impl::list, ListRecipientsResponse::getRecipients, response -> null);
   }
 
   public RecipientInfo rotateToken(String name, long existingTokenExpireInSeconds) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/SharesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/SharesAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.sharing;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,8 @@ public class SharesAPI {
    * array.
    */
   public Iterable<ShareInfo> list() {
-    return impl.list().getShares();
+    return new Paginator<>(
+        null, (Void v) -> impl.list(), ListSharesResponse::getShares, response -> null);
   }
 
   public com.databricks.sdk.service.catalog.PermissionsList sharePermissions(String name) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import com.databricks.sdk.support.Wait;
 import java.time.Duration;
 import java.util.Arrays;
@@ -218,7 +219,8 @@ public class WarehousesAPI {
    * <p>Lists all SQL warehouses that a user has manager permissions on.
    */
   public Iterable<EndpointInfo> list(ListWarehousesRequest request) {
-    return impl.list(request).getWarehouses();
+    return new Paginator<>(
+        request, impl::list, ListWarehousesResponse::getWarehouses, response -> null);
   }
 
   public WarehousePermissions setPermissions(String warehouseId) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/GitCredentialsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/GitCredentialsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.workspace;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +77,8 @@ public class GitCredentialsAPI {
    * <p>Lists the calling user's Git credentials. One credential per user is supported.
    */
   public Iterable<CredentialInfo> list() {
-    return impl.list().getCredentials();
+    return new Paginator<>(
+        null, (Void v) -> impl.list(), GetCredentialsResponse::getCredentials, response -> null);
   }
 
   public void update(long credentialId) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/SecretsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/SecretsAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.workspace;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -149,7 +150,7 @@ public class SecretsAPI {
    * if the user does not have permission to make this API call.
    */
   public Iterable<AclItem> listAcls(ListAclsRequest request) {
-    return impl.listAcls(request).getItems();
+    return new Paginator<>(request, impl::listAcls, ListAclsResponse::getItems, response -> null);
   }
 
   /**
@@ -160,7 +161,8 @@ public class SecretsAPI {
    * <p>Throws `PERMISSION_DENIED` if the user does not have permission to make this API call.
    */
   public Iterable<SecretScope> listScopes() {
-    return impl.listScopes().getScopes();
+    return new Paginator<>(
+        null, (Void v) -> impl.listScopes(), ListScopesResponse::getScopes, response -> null);
   }
 
   public Iterable<SecretMetadata> listSecrets(String scope) {
@@ -179,7 +181,8 @@ public class SecretsAPI {
    * user does not have permission to make this API call.
    */
   public Iterable<SecretMetadata> listSecrets(ListSecretsRequest request) {
-    return impl.listSecrets(request).getSecrets();
+    return new Paginator<>(
+        request, impl::listSecrets, ListSecretsResponse::getSecrets, response -> null);
   }
 
   public void putAcl(String scope, String principal, AclPermission permission) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/WorkspaceAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/WorkspaceAPI.java
@@ -3,6 +3,7 @@ package com.databricks.sdk.service.workspace;
 
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.support.Generated;
+import com.databricks.sdk.support.Paginator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,7 +143,7 @@ public class WorkspaceAPI {
    * does not exist, this call returns an error `RESOURCE_DOES_NOT_EXIST`.
    */
   public Iterable<ObjectInfo> list(ListWorkspaceRequest request) {
-    return impl.list(request).getObjects();
+    return new Paginator<>(request, impl::list, ListResponse::getObjects, response -> null);
   }
 
   public void mkdirs(String path) {

--- a/examples/docs/src/main/java/com/databricks/example/M2MAuthExample.java
+++ b/examples/docs/src/main/java/com/databricks/example/M2MAuthExample.java
@@ -1,0 +1,48 @@
+package com.databricks.example;
+
+import com.databricks.sdk.AccountClient;
+import com.databricks.sdk.WorkspaceClient;
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.service.compute.ClusterDetails;
+import com.databricks.sdk.service.compute.ListClustersRequest;
+import com.databricks.sdk.service.provisioning.Workspace;
+
+/**
+ Example for authenticating with Databricks Account through CLI.
+ The authentication type can be set to either "databricks-cli" or "azure-cli".
+ For details on authenticating via bricks cli, please see: <a href="https://docs.databricks.com/dev-tools/cli/auth-commands.html">...</a>
+ */
+public class M2MWorkspaceAuthExample {
+    /**
+     Get config used for authenticating with Databricks.
+     @return DatabricksConfig object used for authentication
+     */
+    private static DatabricksConfig getConfig() {
+        return new DatabricksConfig()
+            .setHost("https://accounts.cloud.databricks.com")
+            .setAccountId("4d9d3bc8-66c3-4e5a-8a0a-551f564257f0")
+            .setClientId("be8a7e9d-609d-4719-a574-614067b6fc3f")
+            .setClientSecret("dosea225161b0f804998f0cf2d97e1088d89");
+    }
+
+    /**
+     Authenticate and retrieve the list of workspaces from account
+     */
+    public static void main(String[] args) {
+        DatabricksConfig config = getConfig();
+
+        AccountClient account = new AccountClient(config);
+        Workspace firstWorkspace = null;
+        for (Workspace w : account.workspaces().list()) {
+            if (w.getDeploymentName().equals("dbc-a39a1eb1-ef95")) {
+                firstWorkspace = w;
+            }
+            System.out.println(w.getWorkspaceName());
+        }
+
+        WorkspaceClient w = account.getWorkspaceClient(firstWorkspace);
+        for (ClusterDetails c : w.clusters().list(new ListClustersRequest())) {
+            System.out.println(c.getClusterName());
+        }
+    }
+}


### PR DESCRIPTION
## Changes
Currently, non-paginated list APIs in the Java SDK simply return the field in the response with the listed items. However, when there are no items in the collection being listed. This PR changes all list APIs to return a Paginator so that the API response is never `null`.

Resolves #197.

## Tests
Tested listing clusters using an SP with no access to any clusters, which passed:
```
10:12 [DEBUG] > GET /api/2.0/clusters/list
< 200 OK
< { }
```
