### PR TITLE
Fix one shot pagination

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/support/Paginator.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/support/Paginator.java
@@ -48,11 +48,11 @@ public class Paginator<RQ, RS, T> implements Iterable<T> {
     this.itemsFn = itemsFn;
     this.nextPageFn = nextPageFn;
     all = outerIterator();
-    flipNextPage(request);
+    flipNextPage(request, true);
   }
 
-  private boolean flipNextPage(RQ request) {
-    if (request == null) {
+  private boolean flipNextPage(RQ request, boolean firstRequest) {
+    if (!firstRequest && request == null) {
       return false;
     }
     response = requestFn.apply(request);
@@ -77,7 +77,7 @@ public class Paginator<RQ, RS, T> implements Iterable<T> {
         if (currentPage.hasNext()) {
           return true;
         }
-        return flipNextPage(nextPageFn.apply(response));
+        return flipNextPage(nextPageFn.apply(response), false);
       }
 
       @Override

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/SecretsIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/SecretsIT.java
@@ -1,5 +1,6 @@
 package com.databricks.sdk.integration;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.databricks.sdk.WorkspaceClient;
@@ -39,9 +40,8 @@ public class SecretsIT {
 
         assertTrue(foundSecret);
 
-        // TODO: Uncomment once secrets.get is enabled
-        // String responseValue = secretResource.secretsExt.get(scope, key);
-        // assertEquals(value, responseValue);
+        String responseValue = secretsExt.get(scope, key);
+        assertEquals(value, responseValue);
       }
     }
   }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/SecretsIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/SecretsIT.java
@@ -1,6 +1,5 @@
 package com.databricks.sdk.integration;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.databricks.sdk.WorkspaceClient;
@@ -40,8 +39,9 @@ public class SecretsIT {
 
         assertTrue(foundSecret);
 
-        String responseValue = secretsExt.get(scope, key);
-        assertEquals(value, responseValue);
+        // TODO: Uncomment once secrets.get is enabled
+        // String responseValue = secretResource.secretsExt.get(scope, key);
+        // assertEquals(value, responseValue);
       }
     }
   }


### PR DESCRIPTION
## Changes
#266 unintentionally broke one-shot list APIs because the single page would never be fetched. This PR forces that first page to be fetched, restoring the original behavior.

## Tests

- [x] Ran SecretsIT locally, and it worked.
