### PR TITLE
Throw exception if current thread is interrupted

### DIFF
--- a/.codegen/api.java.tmpl
+++ b/.codegen/api.java.tmpl
@@ -95,7 +95,7 @@ public class {{.PascalName}}API {
         try {
             Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            throw new DatabricksException("Current thread was interrupted", e);
         }
         attempt++;
     }


### PR DESCRIPTION
## Changes
Current implementation does not work well when client interrupts a thread where SDK code is running. Once interrupted, the logic continues to run till the timeout (default 20mins) without sleeping at all. Each time thread.sleep is called, it throws interrupt exception and this results in calling the status API continuously. 

Through this PR, I am trying to change the handling to throw DatabricksException when the thread is interrupted so that clients can stop the processing and handle the exception as they wish.

## Tests
All unit tests are successful. 

