### PR TITLE
Fix interrupt handling

### DIFF
--- a/.codegen/api.java.tmpl
+++ b/.codegen/api.java.tmpl
@@ -96,6 +96,7 @@ public class {{.PascalName}}API {
             Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            throw new DatabricksException("Current thread was interrupted", e);
         }
         attempt++;
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -288,6 +288,7 @@ public class ApiClient {
         timer.sleep(sleepMillis);
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", ex);
       }
     }
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClustersAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClustersAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.support.Generated;
 import com.databricks.sdk.support.Paginator;
 import com.databricks.sdk.support.Wait;
@@ -90,6 +91,7 @@ public class ClustersAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }
@@ -134,6 +136,7 @@ public class ClustersAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/CommandExecutionAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/CommandExecutionAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.support.Generated;
 import com.databricks.sdk.support.Wait;
 import java.time.Duration;
@@ -84,6 +85,7 @@ public class CommandExecutionAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }
@@ -144,6 +146,7 @@ public class CommandExecutionAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }
@@ -194,6 +197,7 @@ public class CommandExecutionAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/JobsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/JobsAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.jobs;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.support.Generated;
 import com.databricks.sdk.support.Paginator;
 import com.databricks.sdk.support.Wait;
@@ -91,6 +92,7 @@ public class JobsAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.pipelines;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.support.Generated;
 import com.databricks.sdk.support.Paginator;
 import com.databricks.sdk.support.Wait;
@@ -81,6 +82,7 @@ public class PipelinesAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }
@@ -125,6 +127,7 @@ public class PipelinesAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/WorkspacesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/WorkspacesAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.provisioning;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.support.Generated;
 import com.databricks.sdk.support.Wait;
 import java.time.Duration;
@@ -74,6 +75,7 @@ public class WorkspacesAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.serving;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.support.Generated;
 import com.databricks.sdk.support.Paginator;
 import com.databricks.sdk.support.Wait;
@@ -82,6 +83,7 @@ public class ServingEndpointsAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.support.Generated;
 import com.databricks.sdk.support.Paginator;
 import com.databricks.sdk.support.Wait;
@@ -74,6 +75,7 @@ public class WarehousesAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }
@@ -115,6 +117,7 @@ public class WarehousesAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/vectorsearch/VectorSearchEndpointsAPI.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/vectorsearch/VectorSearchEndpointsAPI.java
@@ -2,6 +2,7 @@
 package com.databricks.sdk.service.vectorsearch;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.support.Generated;
 import com.databricks.sdk.support.Paginator;
 import com.databricks.sdk.support.Wait;
@@ -71,6 +72,7 @@ public class VectorSearchEndpointsAPI {
         Thread.sleep((long) (sleep * 1000L + Math.random() * 1000));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new DatabricksException("Current thread was interrupted", e);
       }
       attempt++;
     }


### PR DESCRIPTION
## Changes
Current implementation does not work well when client interrupts a thread where SDK code is running. Once interrupted, the logic continues to run till the timeout (default 20mins) without sleeping at all. Each time thread.sleep is called, it throws interrupt exception and this results in calling the status API continuously without delay. 

The PR is changing the handling to throw DatabricksException when the thread is interrupted so that clients can stop the processing and handle the exception as they wish.

## Tests
All unit tests are successful. 

