### PR TITLE
Release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Version changelog
 
+## 0.24.0
+
+* [PECO-1008] Add retry strategy based on idempotency of requests ([#264](https://github.com/databricks/databricks-sdk-java/pull/264)).
+* Fix remaining Java integration tests ([#265](https://github.com/databricks/databricks-sdk-java/pull/265)).
+* Fix one-shot list APIs to not return null ([#266](https://github.com/databricks/databricks-sdk-java/pull/266)).
+* Remove unnecessary secret from example ([#267](https://github.com/databricks/databricks-sdk-java/pull/267)).
+* Fix one shot pagination ([#268](https://github.com/databricks/databricks-sdk-java/pull/268)).
+* Update SDK to OpenAPI spec ([#269](https://github.com/databricks/databricks-sdk-java/pull/269)).
+* [PECO-1542] Add a way to provide proxy details to SDK ([#271](https://github.com/databricks/databricks-sdk-java/pull/271)).
+
+API Changes:
+
+ * Added `schemaId` field for `com.databricks.sdk.service.catalog.SchemaInfo`.
+ * Removed `awsOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
+ * Removed `azureOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
+ * Removed `gcpOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
+ * Added `operation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
+ * Removed `com.databricks.sdk.service.catalog.ValidationResultAwsOperation` class.
+ * Removed `com.databricks.sdk.service.catalog.ValidationResultAzureOperation` class.
+ * Removed `com.databricks.sdk.service.catalog.ValidationResultGcpOperation` class.
+ * Added `com.databricks.sdk.service.catalog.ValidationResultOperation` class.
+ * Changed `clusterStatus()` method for `workspaceClient.libraries()` service . New request type is `com.databricks.sdk.service.compute.ClusterStatus` class.
+ * Changed `clusterStatus()` method for `workspaceClient.libraries()` service to return `com.databricks.sdk.service.compute.ClusterStatusResponse` class.
+ * Removed `com.databricks.sdk.service.compute.ClusterStatusRequest` class.
+ * Added `requirements` field for `com.databricks.sdk.service.compute.Library`.
+ * Changed `status` field for `com.databricks.sdk.service.compute.LibraryFullStatus` to `com.databricks.sdk.service.compute.LibraryInstallStatus` class.
+ * Removed `com.databricks.sdk.service.compute.LibraryFullStatusStatus` class.
+ * Added `com.databricks.sdk.service.compute.ClusterStatus` class.
+ * Added `com.databricks.sdk.service.compute.ClusterStatusResponse` class.
+ * Added `com.databricks.sdk.service.compute.LibraryInstallStatus` class.
+ * Added `warehouseId` field for `com.databricks.sdk.service.jobs.NotebookTask`.
+ * Added `runAs` field for `com.databricks.sdk.service.jobs.SubmitRun`.
+ * Added `deployment` field for `com.databricks.sdk.service.pipelines.CreatePipeline`.
+ * Added `deployment` field for `com.databricks.sdk.service.pipelines.EditPipeline`.
+ * Added `deployment` field for `com.databricks.sdk.service.pipelines.PipelineSpec`.
+ * Added `com.databricks.sdk.service.pipelines.DeploymentKind` class.
+ * Added `com.databricks.sdk.service.pipelines.PipelineDeployment` class.
+
+OpenAPI SHA: 06d330f43d92c1be864d4638c672cd0723e20a51, Date: 2024-04-22
+
+
 ## 0.23.0
 
 ### Improvements and Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,41 +2,39 @@
 
 ## 0.24.0
 
-* [PECO-1008] Add retry strategy based on idempotency of requests ([#264](https://github.com/databricks/databricks-sdk-java/pull/264)).
-* Fix remaining Java integration tests ([#265](https://github.com/databricks/databricks-sdk-java/pull/265)).
-* Fix one-shot list APIs to not return null ([#266](https://github.com/databricks/databricks-sdk-java/pull/266)).
-* Remove unnecessary secret from example ([#267](https://github.com/databricks/databricks-sdk-java/pull/267)).
-* Fix one shot pagination ([#268](https://github.com/databricks/databricks-sdk-java/pull/268)).
-* Update SDK to OpenAPI spec ([#269](https://github.com/databricks/databricks-sdk-java/pull/269)).
-* [PECO-1542] Add a way to provide proxy details to SDK ([#271](https://github.com/databricks/databricks-sdk-java/pull/271)).
+* Added retry strategy based on idempotency of requests ([#264](https://github.com/databricks/databricks-sdk-java/pull/264)).
+* Fixde remaining Java integration tests ([#265](https://github.com/databricks/databricks-sdk-java/pull/265)).
+* Fixed one-shot list APIs to not return null ([#266](https://github.com/databricks/databricks-sdk-java/pull/266)).
+* Removed unnecessary secret from example ([#267](https://github.com/databricks/databricks-sdk-java/pull/267)).
+* Fixed one shot pagination ([#268](https://github.com/databricks/databricks-sdk-java/pull/268)).
+* Updated SDK to OpenAPI spec ([#269](https://github.com/databricks/databricks-sdk-java/pull/269)).
+* Added a way to provide proxy details to SDK ([#271](https://github.com/databricks/databricks-sdk-java/pull/271)).
 
 API Changes:
 
+ * Added `deployment` field for `com.databricks.sdk.service.pipelines.CreatePipeline`, `com.databricks.sdk.service.pipelines.EditPipeline`, `com.databricks.sdk.service.pipelines.PipelineSpec`.
  * Added `schemaId` field for `com.databricks.sdk.service.catalog.SchemaInfo`.
- * Removed `awsOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
- * Removed `azureOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
- * Removed `gcpOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
  * Added `operation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
- * Removed `com.databricks.sdk.service.catalog.ValidationResultAwsOperation` class.
- * Removed `com.databricks.sdk.service.catalog.ValidationResultAzureOperation` class.
- * Removed `com.databricks.sdk.service.catalog.ValidationResultGcpOperation` class.
- * Added `com.databricks.sdk.service.catalog.ValidationResultOperation` class.
- * Changed `clusterStatus()` method for `workspaceClient.libraries()` service . New request type is `com.databricks.sdk.service.compute.ClusterStatus` class.
- * Changed `clusterStatus()` method for `workspaceClient.libraries()` service to return `com.databricks.sdk.service.compute.ClusterStatusResponse` class.
- * Removed `com.databricks.sdk.service.compute.ClusterStatusRequest` class.
  * Added `requirements` field for `com.databricks.sdk.service.compute.Library`.
- * Changed `status` field for `com.databricks.sdk.service.compute.LibraryFullStatus` to `com.databricks.sdk.service.compute.LibraryInstallStatus` class.
- * Removed `com.databricks.sdk.service.compute.LibraryFullStatusStatus` class.
+ * Added `warehouseId` field for `com.databricks.sdk.service.jobs.NotebookTask`.
+ * Added `runAs` field for `com.databricks.sdk.service.jobs.SubmitRun`.
+ * Added `com.databricks.sdk.service.catalog.ValidationResultOperation` class.
  * Added `com.databricks.sdk.service.compute.ClusterStatus` class.
  * Added `com.databricks.sdk.service.compute.ClusterStatusResponse` class.
  * Added `com.databricks.sdk.service.compute.LibraryInstallStatus` class.
- * Added `warehouseId` field for `com.databricks.sdk.service.jobs.NotebookTask`.
- * Added `runAs` field for `com.databricks.sdk.service.jobs.SubmitRun`.
- * Added `deployment` field for `com.databricks.sdk.service.pipelines.CreatePipeline`.
- * Added `deployment` field for `com.databricks.sdk.service.pipelines.EditPipeline`.
- * Added `deployment` field for `com.databricks.sdk.service.pipelines.PipelineSpec`.
  * Added `com.databricks.sdk.service.pipelines.DeploymentKind` class.
  * Added `com.databricks.sdk.service.pipelines.PipelineDeployment` class.
+ * Removed `awsOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
+ * Removed `azureOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
+ * Removed `gcpOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
+ * Removed `com.databricks.sdk.service.catalog.ValidationResultAwsOperation` class.
+ * Removed `com.databricks.sdk.service.catalog.ValidationResultAzureOperation` class.
+ * Removed `com.databricks.sdk.service.catalog.ValidationResultGcpOperation` class.
+ * Removed `com.databricks.sdk.service.compute.ClusterStatusRequest` class.
+ * Removed `com.databricks.sdk.service.compute.LibraryFullStatusStatus` class.
+ * Changed `clusterStatus()` method for `workspaceClient.libraries()` service . New request type is `com.databricks.sdk.service.compute.ClusterStatus` class.
+ * Changed `clusterStatus()` method for `workspaceClient.libraries()` service to return `com.databricks.sdk.service.compute.ClusterStatusResponse` class.
+ * Changed `status` field for `com.databricks.sdk.service.compute.LibraryFullStatus` to `com.databricks.sdk.service.compute.LibraryInstallStatus` class.
 
 OpenAPI SHA: 06d330f43d92c1be864d4638c672cd0723e20a51, Date: 2024-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Updated SDK to OpenAPI spec ([#269](https://github.com/databricks/databricks-sdk-java/pull/269)).
 * Added a way to provide proxy details to SDK ([#271](https://github.com/databricks/databricks-sdk-java/pull/271)).
 
+Note: This release contains breaking changes, please see the API changes below for more details. 
+
 API Changes:
 
  * Added `deployment` field for `com.databricks.sdk.service.pipelines.CreatePipeline`, `com.databricks.sdk.service.pipelines.EditPipeline`, `com.databricks.sdk.service.pipelines.PipelineSpec`.

--- a/databricks-sdk-java/pom.xml
+++ b/databricks-sdk-java/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.databricks</groupId>
     <artifactId>databricks-sdk-parent</artifactId>
-    <version>0.23.0</version>
+    <version>0.24.0</version>
   </parent>
   <artifactId>databricks-sdk-java</artifactId>
   <properties>

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -13,7 +13,7 @@ public class UserAgent {
   // TODO: check if reading from
   // /META-INF/maven/com.databricks/databrics-sdk-java/pom.properties
   // or getClass().getPackage().getImplementationVersion() is enough.
-  private static final String version = "0.23.0";
+  private static final String version = "0.24.0";
 
   public static void withProduct(String product, String productVersion) {
     UserAgent.product = product;

--- a/examples/docs/pom.xml
+++ b/examples/docs/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>com.databricks</groupId>
       <artifactId>databricks-sdk-java</artifactId>
-      <version>0.23.0</version>
+      <version>0.24.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/examples/spring-boot-oauth-u2m-demo/pom.xml
+++ b/examples/spring-boot-oauth-u2m-demo/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.databricks</groupId>
       <artifactId>databricks-sdk-java</artifactId>
-      <version>0.23.0</version>
+      <version>0.24.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.databricks</groupId>
   <artifactId>databricks-sdk-parent</artifactId>
-  <version>0.23.0</version>
+  <version>0.24.0</version>
   <packaging>pom</packaging>
   <name>Databricks SDK for Java</name>
   <description>The Databricks SDK for Java includes functionality to accelerate development with Java for


### PR DESCRIPTION
## 0.24.0

* Added retry strategy based on idempotency of requests ([#264](https://github.com/databricks/databricks-sdk-java/pull/264)).
* Fixde remaining Java integration tests ([#265](https://github.com/databricks/databricks-sdk-java/pull/265)).
* Fixed one-shot list APIs to not return null ([#266](https://github.com/databricks/databricks-sdk-java/pull/266)).
* Removed unnecessary secret from example ([#267](https://github.com/databricks/databricks-sdk-java/pull/267)).
* Fixed one shot pagination ([#268](https://github.com/databricks/databricks-sdk-java/pull/268)).
* Updated SDK to OpenAPI spec ([#269](https://github.com/databricks/databricks-sdk-java/pull/269)).
* Added a way to provide proxy details to SDK ([#271](https://github.com/databricks/databricks-sdk-java/pull/271)).

Note: This release contains breaking changes, please see the API changes below for more details. 

API Changes:

 * Added `deployment` field for `com.databricks.sdk.service.pipelines.CreatePipeline`, `com.databricks.sdk.service.pipelines.EditPipeline`, `com.databricks.sdk.service.pipelines.PipelineSpec`.
 * Added `schemaId` field for `com.databricks.sdk.service.catalog.SchemaInfo`.
 * Added `operation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
 * Added `requirements` field for `com.databricks.sdk.service.compute.Library`.
 * Added `warehouseId` field for `com.databricks.sdk.service.jobs.NotebookTask`.
 * Added `runAs` field for `com.databricks.sdk.service.jobs.SubmitRun`.
 * Added `com.databricks.sdk.service.catalog.ValidationResultOperation` class.
 * Added `com.databricks.sdk.service.compute.ClusterStatus` class.
 * Added `com.databricks.sdk.service.compute.ClusterStatusResponse` class.
 * Added `com.databricks.sdk.service.compute.LibraryInstallStatus` class.
 * Added `com.databricks.sdk.service.pipelines.DeploymentKind` class.
 * Added `com.databricks.sdk.service.pipelines.PipelineDeployment` class.
 * Removed `awsOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
 * Removed `azureOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
 * Removed `gcpOperation` field for `com.databricks.sdk.service.catalog.ValidationResult`.
 * Removed `com.databricks.sdk.service.catalog.ValidationResultAwsOperation` class.
 * Removed `com.databricks.sdk.service.catalog.ValidationResultAzureOperation` class.
 * Removed `com.databricks.sdk.service.catalog.ValidationResultGcpOperation` class.
 * Removed `com.databricks.sdk.service.compute.ClusterStatusRequest` class.
 * Removed `com.databricks.sdk.service.compute.LibraryFullStatusStatus` class.
 * Changed `clusterStatus()` method for `workspaceClient.libraries()` service . New request type is `com.databricks.sdk.service.compute.ClusterStatus` class.
 * Changed `clusterStatus()` method for `workspaceClient.libraries()` service to return `com.databricks.sdk.service.compute.ClusterStatusResponse` class.
 * Changed `status` field for `com.databricks.sdk.service.compute.LibraryFullStatus` to `com.databricks.sdk.service.compute.LibraryInstallStatus` class.

OpenAPI SHA: 06d330f43d92c1be864d4638c672cd0723e20a51, Date: 2024-04-22