### PR TITLE
Fix NullPointerException when reading error response body

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ApiErrors.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ApiErrors.java
@@ -66,8 +66,7 @@ public class ApiErrors {
       if (in == null) {
         ApiErrorBody errorBody = new ApiErrorBody();
         errorBody.setMessage(
-          String.format(
-            "Status response from server: %s", response.getStatus()));
+            String.format("Status response from server: %s", response.getStatus()));
         return errorBody;
       }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ApiErrors.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ApiErrors.java
@@ -62,9 +62,18 @@ public class ApiErrors {
    */
   private static ApiErrorBody parseApiError(Response response) {
     try {
+      InputStream in = response.getBody();
+      if (in == null) {
+        ApiErrorBody errorBody = new ApiErrorBody();
+        errorBody.setMessage(
+          String.format(
+            "Status response from server: %s", response.getStatus()));
+        return errorBody;
+      }
+
       // Read the body now, so we can try to parse as JSON and then fallback to old error handling
       // logic.
-      String body = IOUtils.toString(response.getBody(), StandardCharsets.UTF_8);
+      String body = IOUtils.toString(in, StandardCharsets.UTF_8);
       try {
         return MAPPER.readValue(body, ApiErrorBody.class);
       } catch (IOException e) {


### PR DESCRIPTION
## Changes
Fix NullPointerException when reading error response body

Fixes the following exception

```
Caused by: java.lang.NullPointerException
        at java.io.Reader.<init>(Reader.java:78)
        at java.io.InputStreamReader.<init>(InputStreamReader.java:113)
        at org.apache.commons.io.IOUtils.copy(IOUtils.java:921)
        at org.apache.commons.io.IOUtils.toString(IOUtils.java:2681)
        at com.databricks.sdk.core.error.ApiErrors.parseApiError(ApiErrors.java:70)
        at com.databricks.sdk.core.error.ApiErrors.readErrorFromResponse(ApiErrors.java:34)
        at com.databricks.sdk.core.error.ApiErrors.checkForRetry(ApiErrors.java:26)
      ...
```

