### PR TITLE
Fix OIDC Endpoint Fetching in DatabricksConfig for Workspace Clients

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -572,7 +572,7 @@ public class DatabricksConfig {
       return new OpenIDConnectEndpoints(
           realAuthUrl.replaceAll("/authorize", "/token"), realAuthUrl);
     }
-    if (getAccountId() != null) {
+    if (isAccountClient() && getAccountId() != null) {
       String prefix = getHost() + "/oidc/accounts/" + getAccountId();
       return new OpenIDConnectEndpoints(prefix + "/v1/token", prefix + "/v1/authorize");
     }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -1,9 +1,10 @@
 package com.databricks.sdk.core;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DatabricksConfigTest {
   @Test
@@ -48,5 +49,34 @@ public class DatabricksConfigTest {
   public void testIsAzureUsGov() {
     assertTrue(
         new DatabricksConfig().setHost("https://adb-1234567890.0.databricks.azure.us/").isAzure());
+  }
+
+  @Test
+  public void testWorkspaceLevelOidcEndpointsWithAccountId() throws IOException {
+    try (FixtureServer server = new FixtureServer().with(
+        "GET",
+        "/oidc/.well-known/oauth-authorization-server",
+        "{\"authorization_endpoint\":\"https://test-workspace.cloud.databricks.com/oidc/v1/authorize\"}"
+    )) {
+      DatabricksConfig c = new DatabricksConfig()
+          .setHost(server.getUrl())
+          .setAccountId("1234567890");
+      c.resolve();
+      assertEquals(
+          c.getOidcEndpoints().getAuthorizationEndpoint(),
+          "https://test-workspace.cloud.databricks.com/oidc/v1/authorize"
+      );
+    }
+  }
+
+  @Test
+  public void testAccountLevelOidcEndpoints() throws IOException {
+    assertEquals(
+        new DatabricksConfig()
+            .setHost("https://accounts.cloud.databricks.com")
+            .setAccountId("1234567890")
+            .getOidcEndpoints().getAuthorizationEndpoint(),
+        "https://accounts.cloud.databricks.com/oidc/accounts/1234567890/v1/authorize"
+    );
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -1,10 +1,9 @@
 package com.databricks.sdk.core;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class DatabricksConfigTest {
   @Test
@@ -53,19 +52,18 @@ public class DatabricksConfigTest {
 
   @Test
   public void testWorkspaceLevelOidcEndpointsWithAccountId() throws IOException {
-    try (FixtureServer server = new FixtureServer().with(
-        "GET",
-        "/oidc/.well-known/oauth-authorization-server",
-        "{\"authorization_endpoint\":\"https://test-workspace.cloud.databricks.com/oidc/v1/authorize\"}"
-    )) {
-      DatabricksConfig c = new DatabricksConfig()
-          .setHost(server.getUrl())
-          .setAccountId("1234567890");
+    try (FixtureServer server =
+        new FixtureServer()
+            .with(
+                "GET",
+                "/oidc/.well-known/oauth-authorization-server",
+                "{\"authorization_endpoint\":\"https://test-workspace.cloud.databricks.com/oidc/v1/authorize\"}")) {
+      DatabricksConfig c =
+          new DatabricksConfig().setHost(server.getUrl()).setAccountId("1234567890");
       c.resolve();
       assertEquals(
           c.getOidcEndpoints().getAuthorizationEndpoint(),
-          "https://test-workspace.cloud.databricks.com/oidc/v1/authorize"
-      );
+          "https://test-workspace.cloud.databricks.com/oidc/v1/authorize");
     }
   }
 
@@ -75,8 +73,8 @@ public class DatabricksConfigTest {
         new DatabricksConfig()
             .setHost("https://accounts.cloud.databricks.com")
             .setAccountId("1234567890")
-            .getOidcEndpoints().getAuthorizationEndpoint(),
-        "https://accounts.cloud.databricks.com/oidc/accounts/1234567890/v1/authorize"
-    );
+            .getOidcEndpoints()
+            .getAuthorizationEndpoint(),
+        "https://accounts.cloud.databricks.com/oidc/accounts/1234567890/v1/authorize");
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
@@ -93,16 +93,15 @@ public class ExternalBrowserCredentialsProviderTest {
 
   @Test
   void openIDConnectEndPointsTestAccounts() throws IOException {
-    String testHost = "https://localhost:8080";
     DatabricksConfig config =
         new DatabricksConfig()
             .setAuthType("external-browser")
-            .setHost("https://localhost:8080")
+            .setHost("https://accounts.cloud.databricks.com")
             .setHttpClient(new CommonsHttpClient(30))
             .setAccountId("testAccountId");
     config.resolve();
 
-    String prefix = testHost + "/oidc/accounts/" + config.getAccountId();
+    String prefix = "https://accounts.cloud.databricks.com/oidc/accounts/" + config.getAccountId();
     assertEquals(prefix + "/v1/token", config.getOidcEndpoints().getTokenEndpoint());
     assertEquals(prefix + "/v1/authorize", config.getOidcEndpoints().getAuthorizationEndpoint());
   }


### PR DESCRIPTION
## Changes
The logic for determining OIDC endpoints depends on whether a user is authenticating to the workspace or account. The Java SDK uses presence of account ID to make this decision, which is actually incorrect: logic for determining whether a client is configured at the workspace or account-level is based on the hostname. This PR fixes this logic to match the Python SDK. As a result, users are able to set the account ID configuration for Workspace clients and will still be able to authenticate with OAuth.

## Tests
- [x] Some unit tests added to verify this behavior.
- [x] Manually verified the old behavior, and verified that this doesn't recur post-fix.

