### PR TITLE
Incorporate host in request after `authenticate()` call

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -231,11 +231,10 @@ public class ApiClient {
   }
 
   private Response getResponse(Request in) {
-    in.withUrl(config.getHost() + in.getUrl());
-    return executeInner(in);
+    return executeInner(in, in.getUrl());
   }
 
-  private Response executeInner(Request in) {
+  private Response executeInner(Request in, String path) {
     RetryStrategy retryStrategy = retryStrategyPicker.getRetryStrategy(in);
     int attemptNumber = 0;
     while (true) {
@@ -246,6 +245,10 @@ public class ApiClient {
 
       // Authenticate the request. Failures should not be retried.
       in.withHeaders(config.authenticate());
+
+      // Prepend host to URL only after config.authenticate().
+      // This call may configure the host (e.g. in case of notebook native auth).
+      in.withUrl(config.getHost() + path);
 
       // Set User-Agent with auth type info, which is available only
       // after the first invocation to config.authenticate()

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
@@ -42,7 +42,8 @@ public class ApiClientTest {
     }
   }
 
-  private ApiClient getApiClient(DatabricksConfig config, Request request, List<ResponseProvider> responses) {
+  private ApiClient getApiClient(
+      DatabricksConfig config, Request request, List<ResponseProvider> responses) {
     DummyHttpClient hc = new DummyHttpClient();
     for (ResponseProvider response : responses) {
       hc.with(request, response);
@@ -53,17 +54,12 @@ public class ApiClientTest {
   private ApiClient getApiClient(Request request, List<ResponseProvider> responses) {
     String host = request.getUri().getScheme() + "://" + request.getUri().getHost();
     DatabricksConfig config =
-            new DatabricksConfig()
-                    .setHost(host)
-                    .setCredentialsProvider(new DummyCredentialsProvider());
+        new DatabricksConfig().setHost(host).setCredentialsProvider(new DummyCredentialsProvider());
     return getApiClient(config, request, responses);
   }
 
   private <T> void runApiClientTest(
-          ApiClient client,
-          Request request,
-          Class<? extends T> clazz,
-          T expectedResponse) {
+      ApiClient client, Request request, Class<? extends T> clazz, T expectedResponse) {
     T response;
     if (request.getMethod().equals(Request.GET)) {
       response = client.GET(request.getUri().getPath(), clazz, Collections.emptyMap());
@@ -76,10 +72,10 @@ public class ApiClientTest {
   }
 
   private <T> void runApiClientTest(
-          Request request,
-          List<ResponseProvider> responses,
-          Class<? extends T> clazz,
-          T expectedResponse) {
+      Request request,
+      List<ResponseProvider> responses,
+      Class<? extends T> clazz,
+      T expectedResponse) {
     ApiClient client = getApiClient(request, responses);
     runApiClientTest(client, request, clazz, expectedResponse);
   }
@@ -382,14 +378,13 @@ public class ApiClientTest {
   @Test
   void populateHostFromCredentialProvider() {
     Request req = getBasicRequest();
-    DatabricksConfig config = new DatabricksConfig()
+    DatabricksConfig config =
+        new DatabricksConfig()
             .setCredentialsProvider(new HostPopulatingCredentialsProvider("http://my.host"));
-    ApiClient client = getApiClient(config, req, Collections.singletonList(getSuccessResponse(req)));
+    ApiClient client =
+        getApiClient(config, req, Collections.singletonList(getSuccessResponse(req)));
     runApiClientTest(
-            client,
-            req,
-            MyEndpointResponse.class,
-            new MyEndpointResponse().setKey("value"));
+        client, req, MyEndpointResponse.class, new MyEndpointResponse().setKey("value"));
   }
 
   @Test


### PR DESCRIPTION
## Changes

Notebook native auth was not working because the API client accessed the host before the credential provider had a chance to set it. This change postpones reading the host until after the `config.authenticate()` call.

Fixes #230.

## Tests

* The new API client test adds coverage for this case.
* I manually confirmed that notebook native auth now works out of the box on DBR.