### PR TITLE
Fix NPE in string function on DatabricksConfig

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigLoader.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigLoader.java
@@ -1,5 +1,6 @@
 package com.databricks.sdk.core;
 
+import com.databricks.sdk.core.utils.Environment;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -8,8 +9,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.*;
-
-import com.databricks.sdk.core.utils.Environment;
 import org.ini4j.Ini;
 import org.ini4j.Profile;
 import org.slf4j.Logger;
@@ -238,7 +237,7 @@ public class ConfigLoader {
       } else {
         buf.add(String.format("Env: <none>"));
       }
-      return String.join("; ", buf);
+      return String.join(". ", buf);
     } catch (IllegalAccessException e) {
       throw new DatabricksException(e.getMessage());
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigLoader.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigLoader.java
@@ -8,6 +8,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.*;
+
+import com.databricks.sdk.core.utils.Environment;
 import org.ini4j.Ini;
 import org.ini4j.Profile;
 import org.slf4j.Logger;
@@ -197,7 +199,13 @@ public class ConfigLoader {
       List<String> attrsUsed = new ArrayList<>();
       List<String> buf = new ArrayList<>();
 
-      Map<String, String> getEnvAllEnv = cfg.getEnv().getEnv();
+      Environment env = cfg.getEnv();
+      Map<String, String> getEnvAllEnv;
+      if (env != null) {
+        getEnvAllEnv = env.getEnv();
+      } else {
+        getEnvAllEnv = new HashMap<>();
+      }
 
       for (ConfigAttributeAccessor accessor : accessors) {
         String envVariable = accessor.getEnvVariable();
@@ -222,11 +230,15 @@ public class ConfigLoader {
       }
       if (!attrsUsed.isEmpty()) {
         buf.add(String.format("Config: %s", String.join(", ", attrsUsed)));
+      } else {
+        buf.add(String.format("Config: <empty>"));
       }
       if (!envsUsed.isEmpty()) {
         buf.add(String.format("Env: %s", String.join(", ", envsUsed)));
+      } else {
+        buf.add(String.format("Env: <none>"));
       }
-      return String.join(". ", buf);
+      return String.join("; ", buf);
     } catch (IllegalAccessException e) {
       throw new DatabricksException(e.getMessage());
     }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -3,6 +3,12 @@ package com.databricks.sdk.core;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.databricks.sdk.core.utils.Environment;
 import org.junit.jupiter.api.Test;
 
 public class DatabricksConfigTest {
@@ -48,6 +54,31 @@ public class DatabricksConfigTest {
   public void testIsAzureUsGov() {
     assertTrue(
         new DatabricksConfig().setHost("https://adb-1234567890.0.databricks.azure.us/").isAzure());
+  }
+
+  @Test
+  public void testToStringEmpty() {
+    DatabricksConfig config = new DatabricksConfig();
+    assertEquals("Config: <empty>; Env: <none>", config.toString());
+  }
+
+  @Test
+  public void testToStringWithSetter() {
+    DatabricksConfig config = new DatabricksConfig();
+    config.setHost("http://my.host");
+    assertEquals("Config: host=http://my.host; Env: <none>", config.toString());
+  }
+
+  @Test
+  public void testToStringWithEnv() {
+    Map<String, String> map = new HashMap<>();
+    map.put("DATABRICKS_HOST", "http://my.host");
+    List<String> path = new ArrayList<>();
+    String systemName = System.getProperty("os.name");
+
+    DatabricksConfig config = new DatabricksConfig();
+    config.resolve(new Environment(map, path, systemName));
+    assertEquals("Config: host=http://my.host; Env: DATABRICKS_HOST", config.toString());
   }
 
   @Test

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -2,13 +2,12 @@ package com.databricks.sdk.core;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.sdk.core.utils.Environment;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.databricks.sdk.core.utils.Environment;
 import org.junit.jupiter.api.Test;
 
 public class DatabricksConfigTest {
@@ -59,14 +58,14 @@ public class DatabricksConfigTest {
   @Test
   public void testToStringEmpty() {
     DatabricksConfig config = new DatabricksConfig();
-    assertEquals("Config: <empty>; Env: <none>", config.toString());
+    assertEquals("Config: <empty>. Env: <none>", config.toString());
   }
 
   @Test
   public void testToStringWithSetter() {
     DatabricksConfig config = new DatabricksConfig();
     config.setHost("http://my.host");
-    assertEquals("Config: host=http://my.host; Env: <none>", config.toString());
+    assertEquals("Config: host=http://my.host. Env: <none>", config.toString());
   }
 
   @Test
@@ -78,7 +77,7 @@ public class DatabricksConfigTest {
 
     DatabricksConfig config = new DatabricksConfig();
     config.resolve(new Environment(map, path, systemName));
-    assertEquals("Config: host=http://my.host; Env: DATABRICKS_HOST", config.toString());
+    assertEquals("Config: host=http://my.host. Env: DATABRICKS_HOST", config.toString());
   }
 
   @Test


### PR DESCRIPTION
## Changes

If the configuration isn't resolved, the `env` field will be `null`, and the `toString` function would throw an NPE. This change fixes that and adds a few tests. I changed the string output to always be non-empty, even if no properties are set.

## Tests

Unit tests.

