### PR TITLE
Fix test that was picking up configuration from the environment

### DIFF
--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -90,7 +90,8 @@ public class DatabricksConfigTest {
                 "{\"authorization_endpoint\":\"https://test-workspace.cloud.databricks.com/oidc/v1/authorize\"}")) {
       DatabricksConfig c =
           new DatabricksConfig().setHost(server.getUrl()).setAccountId("1234567890");
-      c.resolve(new Environment(new HashMap<>(), new ArrayList<String>(), System.getProperty("os.name")));
+      c.resolve(
+          new Environment(new HashMap<>(), new ArrayList<String>(), System.getProperty("os.name")));
       assertEquals(
           c.getOidcEndpoints().getAuthorizationEndpoint(),
           "https://test-workspace.cloud.databricks.com/oidc/v1/authorize");

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -2,7 +2,10 @@ package com.databricks.sdk.core;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.sdk.core.utils.Environment;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import org.junit.jupiter.api.Test;
 
 public class DatabricksConfigTest {
@@ -60,7 +63,7 @@ public class DatabricksConfigTest {
                 "{\"authorization_endpoint\":\"https://test-workspace.cloud.databricks.com/oidc/v1/authorize\"}")) {
       DatabricksConfig c =
           new DatabricksConfig().setHost(server.getUrl()).setAccountId("1234567890");
-      c.resolve();
+      c.resolve(new Environment(new HashMap<>(), new ArrayList<String>(), "system"));
       assertEquals(
           c.getOidcEndpoints().getAuthorizationEndpoint(),
           "https://test-workspace.cloud.databricks.com/oidc/v1/authorize");


### PR DESCRIPTION
## Changes

The test is written to specifically test one branch so it should be isolated from the environment. Resolve the configuration with an empty `Environment` instance to achieve this.

This test was added in #277.

## Tests

* Unit test passes.
* Confirmed it also passes when environment variables that are used in the nightlies are set.
