### PR TITLE
Better error message when private link enabled workspaces reject requests

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -1,6 +1,7 @@
 package com.databricks.sdk.core;
 
 import com.databricks.sdk.core.error.ApiErrors;
+import com.databricks.sdk.core.error.PrivateLinkInfo;
 import com.databricks.sdk.core.http.HttpClient;
 import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.core.http.Response;
@@ -261,9 +262,6 @@ public class ApiClient {
         if (LOG.isDebugEnabled()) {
           LOG.debug(makeLogRecord(in, out));
         }
-        if (out.getStatusCode() < 400) {
-          return out;
-        }
       } catch (IOException e) {
         err = e;
         LOG.debug("Request {} failed", in, e);
@@ -297,7 +295,10 @@ public class ApiClient {
   }
 
   private boolean isRequestSuccessful(Response response, Exception e) {
-    return e == null && response.getStatusCode() >= 200 && response.getStatusCode() < 300;
+    return e == null
+        && response.getStatusCode() >= 200
+        && response.getStatusCode() < 300
+        && !PrivateLinkInfo.isPrivateLinkRedirect(response);
   }
 
   public long getBackoffMillis(Response response, int attemptNumber) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -531,6 +531,9 @@ public class DatabricksConfig {
   }
 
   public boolean isAzure() {
+    if (azureWorkspaceResourceId != null) {
+      return true;
+    }
     return this.getDatabricksEnvironment().getCloud() == Cloud.AZURE;
   }
 
@@ -602,15 +605,7 @@ public class DatabricksConfig {
       return this.databricksEnvironment;
     }
 
-    if (this.host != null) {
-      for (DatabricksEnvironment env : DatabricksEnvironment.ALL_ENVIRONMENTS) {
-        if (this.host.endsWith(env.getDnsZone())) {
-          return env;
-        }
-      }
-    }
-
-    if (this.azureWorkspaceResourceId != null) {
+    if (this.host == null && this.azureWorkspaceResourceId != null) {
       String azureEnv = "PUBLIC";
       if (this.azureEnvironment != null) {
         azureEnv = this.azureEnvironment;
@@ -629,7 +624,7 @@ public class DatabricksConfig {
       }
     }
 
-    return DatabricksEnvironment.DEFAULT_ENVIRONMENT;
+    return DatabricksEnvironment.getEnvironmentFromHostname(this.host);
   }
 
   public DatabricksConfig newWithWorkspaceHost(String host) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksEnvironment.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksEnvironment.java
@@ -79,4 +79,16 @@ public class DatabricksEnvironment {
           new DatabricksEnvironment(Cloud.GCP, ".dev.gcp.databricks.com"),
           new DatabricksEnvironment(Cloud.GCP, ".staging.gcp.databricks.com"),
           new DatabricksEnvironment(Cloud.GCP, ".gcp.databricks.com"));
+
+  public static DatabricksEnvironment getEnvironmentFromHostname(String hostname) {
+    if (hostname == null) {
+      return DEFAULT_ENVIRONMENT;
+    }
+    for (DatabricksEnvironment env : ALL_ENVIRONMENTS) {
+      if (hostname.endsWith(env.getDnsZone())) {
+        return env;
+      }
+    }
+    return DEFAULT_ENVIRONMENT;
+  }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
@@ -109,7 +109,9 @@ public class CommonsHttpClient implements HttpClient {
       URI uri =
           new URI(
               targetHost.getSchemeName(),
+              null,
               targetHost.getHostName(),
+              targetHost.getPort(),
               request.getURI().getPath(),
               request.getURI().getQuery(),
               request.getURI().getFragment());

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
@@ -12,6 +12,9 @@ import com.databricks.sdk.core.utils.CustomCloseInputStream;
 import com.databricks.sdk.core.utils.ProxyUtils;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -20,6 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
 import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
 import org.apache.http.client.config.RequestConfig;
@@ -29,6 +33,8 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,21 +97,39 @@ public class CommonsHttpClient implements HttpClient {
       request.getParams().setParameter("http.protocol.handle-redirects", false);
     }
     in.getHeaders().forEach(request::setHeader);
-    CloseableHttpResponse response = hc.execute(request);
-    return computeResponse(in, request, response);
+    HttpContext context = new BasicHttpContext();
+    CloseableHttpResponse response = hc.execute(request, context);
+    return computeResponse(in, context, response);
   }
 
-  private Response computeResponse(
-      Request in, HttpUriRequest request, CloseableHttpResponse response) throws IOException {
+  private URL getTargetUrl(HttpContext context) {
+    try {
+      HttpHost targetHost = (HttpHost) context.getAttribute("http.target_host");
+      HttpUriRequest request = (HttpUriRequest) context.getAttribute("http.request");
+      URI uri =
+          new URI(
+              targetHost.getSchemeName(),
+              targetHost.getHostName(),
+              request.getURI().getPath(),
+              request.getURI().getQuery(),
+              request.getURI().getFragment());
+      return uri.toURL();
+    } catch (MalformedURLException | URISyntaxException e) {
+      throw new DatabricksException("Unable to get target URL", e);
+    }
+  }
+
+  private Response computeResponse(Request in, HttpContext context, CloseableHttpResponse response)
+      throws IOException {
     HttpEntity entity = response.getEntity();
     StatusLine statusLine = response.getStatusLine();
-    URL url = request.getURI().toURL();
     Map<String, List<String>> hs =
         Arrays.stream(response.getAllHeaders())
             .collect(
                 Collectors.groupingBy(
                     NameValuePair::getName,
                     Collectors.mapping(NameValuePair::getValue, Collectors.toList())));
+    URL url = getTargetUrl(context);
     if (entity == null) {
       response.close();
       return new Response(in, url, statusLine.getStatusCode(), statusLine.getReasonPhrase(), hs);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/AbstractErrorMapper.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/AbstractErrorMapper.java
@@ -42,6 +42,9 @@ abstract class AbstractErrorMapper {
     if (statusCodeMapping.containsKey(code)) {
       return statusCodeMapping.get(code).create(errorCode, message, details);
     }
+    if (PrivateLinkInfo.isPrivateLinkRedirect(resp)) {
+      return PrivateLinkInfo.createPrivateLinkValidationError(resp);
+    }
     return new DatabricksError(errorCode, message, code, details);
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/PrivateLinkInfo.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/PrivateLinkInfo.java
@@ -51,7 +51,7 @@ public class PrivateLinkInfo {
         serviceName, serviceName, endpointName, referencePage);
   }
 
-  static boolean isPrivateLinkRedirect(Response resp) {
+  public static boolean isPrivateLinkRedirect(Response resp) {
     return resp.getUrl().getPath().equals("/login.html")
         && resp.getUrl().getQuery().contains("error=private-link-validation-error");
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/PrivateLinkInfo.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/PrivateLinkInfo.java
@@ -1,0 +1,65 @@
+package com.databricks.sdk.core.error;
+
+import com.databricks.sdk.core.DatabricksEnvironment;
+import com.databricks.sdk.core.http.Response;
+import com.databricks.sdk.core.utils.Cloud;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PrivateLinkInfo {
+  private final String serviceName;
+  private final String endpointName;
+  private final String referencePage;
+
+  static final Map<Cloud, PrivateLinkInfo> PRIVATE_LINK_INFOS = loadPrivateLinkInfos();
+
+  static Map<Cloud, PrivateLinkInfo> loadPrivateLinkInfos() {
+    Map<Cloud, PrivateLinkInfo> privateLinkInfoMap = new HashMap<>();
+    privateLinkInfoMap.put(
+        Cloud.AWS,
+        new PrivateLinkInfo(
+            "AWS PrivateLink",
+            "AWS VPC endpoint",
+            "https://docs.databricks.com/en/security/network/classic/privatelink.html"));
+    privateLinkInfoMap.put(
+        Cloud.AZURE,
+        new PrivateLinkInfo(
+            "Azure Private Link",
+            "Azure Private Link endpoint",
+            "https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/private-link-standard#authentication-troubleshooting"));
+    privateLinkInfoMap.put(
+        Cloud.GCP,
+        new PrivateLinkInfo(
+            "Private Service Connect",
+            "GCP VPC endpoint",
+            "https://docs.gcp.databricks.com/en/security/network/classic/private-service-connect.html"));
+    return privateLinkInfoMap;
+  }
+
+  public PrivateLinkInfo(String serviceName, String endpointName, String referencePage) {
+    this.serviceName = serviceName;
+    this.endpointName = endpointName;
+    this.referencePage = referencePage;
+  }
+
+  public String errorMessage() {
+    return String.format(
+        "The requested workspace has %s enabled and is not accessible from the current network. "
+            + "Ensure that %s is properly configured and that your device has access to the %s. "
+            + "For more information, see %s.",
+        serviceName, serviceName, endpointName, referencePage);
+  }
+
+  static boolean isPrivateLinkRedirect(Response resp) {
+    return resp.getUrl().getPath().equals("/login.html")
+        && resp.getUrl().getQuery().contains("error=private-link-validation-error");
+  }
+
+  static PrivateLinkValidationError createPrivateLinkValidationError(Response resp) {
+    DatabricksEnvironment env =
+        DatabricksEnvironment.getEnvironmentFromHostname(resp.getUrl().getHost());
+    PrivateLinkInfo info = PRIVATE_LINK_INFOS.get(env.getCloud());
+    return new PrivateLinkValidationError(info.errorMessage(), Collections.emptyList());
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/PrivateLinkValidationError.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/PrivateLinkValidationError.java
@@ -1,0 +1,10 @@
+package com.databricks.sdk.core.error;
+
+import com.databricks.sdk.core.error.platform.PermissionDenied;
+import java.util.List;
+
+public class PrivateLinkValidationError extends PermissionDenied {
+  public PrivateLinkValidationError(String message, List<ErrorDetail> details) {
+    super("PRIVATE_LINK_VALIDATION_ERROR", message, details);
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
@@ -343,12 +343,12 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("HOME", TestOSUtils.resource("/testdata/azure"))
             .with("PATH", "testdata:/bin");
     DatabricksConfig config =
-        new DatabricksConfig().setHost("x").setAzureWorkspaceResourceId("/sub/rg/ws");
+        new DatabricksConfig().setHost("https://adb-123.4.azuredatabricks.net").setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
     config.authenticate();
 
     assertEquals("azure-cli", config.getAuthType());
-    assertEquals("https://x", config.getHost());
+    assertEquals("https://adb-123.4.azuredatabricks.net", config.getHost());
     assertTrue(config.isAzure());
   }
 
@@ -412,12 +412,12 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("HOME", TestOSUtils.resource("/testdata"))
             .with("PATH", "testdata:/bin");
     DatabricksConfig config =
-        new DatabricksConfig().setHost("x").setAzureWorkspaceResourceId("/sub/rg/ws");
+        new DatabricksConfig().setHost("https://adb-123.4.azuredatabricks.net").setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
     config.authenticate();
 
     assertEquals("azure-cli", config.getAuthType());
-    assertEquals("https://x", config.getHost());
+    assertEquals("https://adb-123.4.azuredatabricks.net", config.getHost());
     assertTrue(config.isAzure());
   }
 
@@ -430,12 +430,12 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("HOME", TestOSUtils.resource("/testdata/azure"))
             .with("PATH", "testdata:/bin");
     DatabricksConfig config =
-        new DatabricksConfig().setHost("x").setAzureWorkspaceResourceId("/sub/rg/ws");
+        new DatabricksConfig().setHost("https://adb-123.4.azuredatabricks.net").setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
     config.authenticate();
 
     assertEquals("azure-cli", config.getAuthType());
-    assertEquals("https://x", config.getHost());
+    assertEquals("https://adb-123.4.azuredatabricks.net", config.getHost());
     assertTrue(config.isAzure());
   }
 
@@ -448,10 +448,10 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("HOME", TestOSUtils.resource("/testdata/azure"))
             .with("PATH", "testdata:/bin");
     raises(
-        "validate: more than one authorization method configured: azure and basic. Config: host=x, username=x, azure_workspace_resource_id=/sub/rg/ws. Env: DATABRICKS_USERNAME",
+        "validate: more than one authorization method configured: azure and basic. Config: host=https://adb-123.4.azuredatabricks.net, username=x, azure_workspace_resource_id=/sub/rg/ws. Env: DATABRICKS_USERNAME",
         () -> {
           DatabricksConfig config =
-              new DatabricksConfig().setHost("x").setAzureWorkspaceResourceId("/sub/rg/ws");
+              new DatabricksConfig().setHost("https://adb-123.4.azuredatabricks.net").setAzureWorkspaceResourceId("/sub/rg/ws");
           resolveConfig(config, env);
           config.authenticate();
         });

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
@@ -343,7 +343,9 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("HOME", TestOSUtils.resource("/testdata/azure"))
             .with("PATH", "testdata:/bin");
     DatabricksConfig config =
-        new DatabricksConfig().setHost("https://adb-123.4.azuredatabricks.net").setAzureWorkspaceResourceId("/sub/rg/ws");
+        new DatabricksConfig()
+            .setHost("https://adb-123.4.azuredatabricks.net")
+            .setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
     config.authenticate();
 
@@ -412,7 +414,9 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("HOME", TestOSUtils.resource("/testdata"))
             .with("PATH", "testdata:/bin");
     DatabricksConfig config =
-        new DatabricksConfig().setHost("https://adb-123.4.azuredatabricks.net").setAzureWorkspaceResourceId("/sub/rg/ws");
+        new DatabricksConfig()
+            .setHost("https://adb-123.4.azuredatabricks.net")
+            .setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
     config.authenticate();
 
@@ -430,7 +434,9 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("HOME", TestOSUtils.resource("/testdata/azure"))
             .with("PATH", "testdata:/bin");
     DatabricksConfig config =
-        new DatabricksConfig().setHost("https://adb-123.4.azuredatabricks.net").setAzureWorkspaceResourceId("/sub/rg/ws");
+        new DatabricksConfig()
+            .setHost("https://adb-123.4.azuredatabricks.net")
+            .setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
     config.authenticate();
 
@@ -451,7 +457,9 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
         "validate: more than one authorization method configured: azure and basic. Config: host=https://adb-123.4.azuredatabricks.net, username=x, azure_workspace_resource_id=/sub/rg/ws. Env: DATABRICKS_USERNAME",
         () -> {
           DatabricksConfig config =
-              new DatabricksConfig().setHost("https://adb-123.4.azuredatabricks.net").setAzureWorkspaceResourceId("/sub/rg/ws");
+              new DatabricksConfig()
+                  .setHost("https://adb-123.4.azuredatabricks.net")
+                  .setAzureWorkspaceResourceId("/sub/rg/ws");
           resolveConfig(config, env);
           config.authenticate();
         });

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.databricks.sdk.core.error.ApiErrorBody;
 import com.databricks.sdk.core.error.ErrorDetail;
-import com.databricks.sdk.core.error.PrivateLinkInfo;
 import com.databricks.sdk.core.error.PrivateLinkValidationError;
 import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.core.http.Response;
@@ -12,7 +11,6 @@ import com.databricks.sdk.core.utils.FakeTimer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
@@ -405,11 +403,18 @@ public class ApiClientTest {
   @Test
   void privateLinkRedirectBecomesPrivateLinkValidationError() throws MalformedURLException {
     Request req = getBasicRequest();
-    URL url = new URL("https://databricks.com/login.html?error=private-link-validation-error:123456");
-    Response response = new Response(req, url, 200, "OK", Collections.emptyMap(), (String) "Garbage HTML");
-    ApiClient client = getApiClient(req, Collections.singletonList(new SuccessfulResponse(response)));
+    URL url =
+        new URL("https://databricks.com/login.html?error=private-link-validation-error:123456");
+    Response response =
+        new Response(req, url, 200, "OK", Collections.emptyMap(), (String) "Garbage HTML");
+    ApiClient client =
+        getApiClient(req, Collections.singletonList(new SuccessfulResponse(response)));
     PrivateLinkValidationError e =
-        assertThrows(PrivateLinkValidationError.class, () -> client.GET(req.getUri().getPath(), MyEndpointResponse.class, Collections.emptyMap()));
+        assertThrows(
+            PrivateLinkValidationError.class,
+            () ->
+                client.GET(
+                    req.getUri().getPath(), MyEndpointResponse.class, Collections.emptyMap()));
     assertTrue(e.getMessage().contains("AWS PrivateLink"));
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.databricks.sdk.core.error.ApiErrorBody;
 import com.databricks.sdk.core.error.ErrorDetail;
+import com.databricks.sdk.core.error.PrivateLinkInfo;
 import com.databricks.sdk.core.error.PrivateLinkValidationError;
 import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.core.http.Response;
@@ -407,6 +408,8 @@ public class ApiClientTest {
     URL url = new URL("https://databricks.com/login.html?error=private-link-validation-error:123456");
     Response response = new Response(req, url, 200, "OK", Collections.emptyMap(), (String) "Garbage HTML");
     ApiClient client = getApiClient(req, Collections.singletonList(new SuccessfulResponse(response)));
-    assertThrows(PrivateLinkValidationError.class, () -> client.GET(req.getUri().getPath(), MyEndpointResponse.class, Collections.emptyMap()));
+    PrivateLinkValidationError e =
+        assertThrows(PrivateLinkValidationError.class, () -> client.GET(req.getUri().getPath(), MyEndpointResponse.class, Collections.emptyMap()));
+    assertTrue(e.getMessage().contains("AWS PrivateLink"));
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
@@ -4,12 +4,16 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.databricks.sdk.core.error.ApiErrorBody;
 import com.databricks.sdk.core.error.ErrorDetail;
+import com.databricks.sdk.core.error.PrivateLinkValidationError;
 import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.core.http.Response;
 import com.databricks.sdk.core.utils.FakeTimer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.time.*;
 import java.util.*;
@@ -395,5 +399,14 @@ public class ApiClientTest {
 
     response = getTooManyRequestsResponse(req).getResponse();
     assertEquals(Optional.empty(), ApiClient.getBackoffFromRetryAfterHeader(response));
+  }
+
+  @Test
+  void privateLinkRedirectBecomesPrivateLinkValidationError() throws MalformedURLException {
+    Request req = getBasicRequest();
+    URL url = new URL("https://databricks.com/login.html?error=private-link-validation-error:123456");
+    Response response = new Response(req, url, 200, "OK", Collections.emptyMap(), (String) "Garbage HTML");
+    ApiClient client = getApiClient(req, Collections.singletonList(new SuccessfulResponse(response)));
+    assertThrows(PrivateLinkValidationError.class, () -> client.GET(req.getUri().getPath(), MyEndpointResponse.class, Collections.emptyMap()));
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/AzureCliCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/AzureCliCredentialsProviderTest.java
@@ -43,7 +43,7 @@ class AzureCliCredentialsProviderTest {
     AzureCliCredentialsProvider provider = getAzureCliCredentialsProvider(mockTokenSource());
     DatabricksConfig config =
         new DatabricksConfig()
-            .setHost(".azuredatabricks.")
+            .setHost(".azuredatabricks.net")
             .setCredentialsProvider(provider)
             .setAzureWorkspaceResourceId(WORKSPACE_RESOURCE_ID);
     ArgumentCaptor<List<String>> argument = ArgumentCaptor.forClass(List.class);
@@ -70,7 +70,7 @@ class AzureCliCredentialsProviderTest {
 
     DatabricksConfig config =
         new DatabricksConfig()
-            .setHost(".azuredatabricks.")
+            .setHost(".azuredatabricks.net")
             .setCredentialsProvider(provider)
             .setAzureWorkspaceResourceId(WORKSPACE_RESOURCE_ID);
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/FixtureServer.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/FixtureServer.java
@@ -10,6 +10,7 @@ import java.io.*;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
@@ -241,6 +242,11 @@ public class FixtureServer implements Closeable {
 
   public FixtureServer with(FixtureMapping fixture) {
     fixtures.add(fixture);
+    return this;
+  }
+
+  public FixtureServer with(Collection<FixtureMapping> fs) {
+    fixtures.addAll(fs);
     return this;
   }
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/commons/CommonsHttpClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/commons/CommonsHttpClientTest.java
@@ -90,24 +90,28 @@ class CommonsHttpClientTest {
 
   @Test
   public void testRedirection() throws IOException {
-    List<FixtureServer.FixtureMapping> fixtures = Arrays.asList(
-        new FixtureServer.FixtureMapping.Builder()
-            .validatePath("/redirect")
-            .validateMethod("GET")
-            .withRedirect("/login.html?error=private-link-validation-error", HttpURLConnection.HTTP_MOVED_TEMP)
-            .build(),
-        new FixtureServer.FixtureMapping.Builder()
-            .validatePath("/login.html?error=private-link-validation-error")
-            .validateMethod("GET")
-            .withResponse("login page")
-            .build()
-    );
+    List<FixtureServer.FixtureMapping> fixtures =
+        Arrays.asList(
+            new FixtureServer.FixtureMapping.Builder()
+                .validatePath("/redirect")
+                .validateMethod("GET")
+                .withRedirect(
+                    "/login.html?error=private-link-validation-error",
+                    HttpURLConnection.HTTP_MOVED_TEMP)
+                .build(),
+            new FixtureServer.FixtureMapping.Builder()
+                .validatePath("/login.html?error=private-link-validation-error")
+                .validateMethod("GET")
+                .withResponse("login page")
+                .build());
 
     try (FixtureServer server = new FixtureServer().with(fixtures)) {
       HttpClient httpClient = new CommonsHttpClient(30);
-      Request in = new Request("GET",  server.getUrl() + "/redirect");
+      Request in = new Request("GET", server.getUrl() + "/redirect");
       Response out = httpClient.execute(in);
-      assertEquals(server.getUrl() + "/login.html?error=private-link-validation-error", out.getUrl().toString());
+      assertEquals(
+          server.getUrl() + "/login.html?error=private-link-validation-error",
+          out.getUrl().toString());
     }
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/commons/CommonsHttpClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/commons/CommonsHttpClientTest.java
@@ -67,7 +67,7 @@ class CommonsHttpClientTest {
   }
 
   @Test
-  public void testRedirection() throws IOException {
+  public void testNoRedirection() throws IOException {
     FixtureServer.FixtureMapping fixture =
         new FixtureServer.FixtureMapping.Builder()
             .validatePath("/redirect")
@@ -85,6 +85,29 @@ class CommonsHttpClientTest {
       assertEquals(HttpURLConnection.HTTP_MOVED_TEMP, out.getStatusCode());
       assertTrue(out.getAllHeaders().containsKey("Location"));
       assertEquals("http://example.com", out.getHeaders("Location").get(0));
+    }
+  }
+
+  @Test
+  public void testRedirection() throws IOException {
+    List<FixtureServer.FixtureMapping> fixtures = Arrays.asList(
+        new FixtureServer.FixtureMapping.Builder()
+            .validatePath("/redirect")
+            .validateMethod("GET")
+            .withRedirect("/login.html?error=private-link-validation-error", HttpURLConnection.HTTP_MOVED_TEMP)
+            .build(),
+        new FixtureServer.FixtureMapping.Builder()
+            .validatePath("/login.html?error=private-link-validation-error")
+            .validateMethod("GET")
+            .withResponse("login page")
+            .build()
+    );
+
+    try (FixtureServer server = new FixtureServer().with(fixtures)) {
+      HttpClient httpClient = new CommonsHttpClient(30);
+      Request in = new Request("GET",  server.getUrl() + "/redirect");
+      Response out = httpClient.execute(in);
+      assertEquals(server.getUrl() + "/login.html?error=private-link-validation-error", out.getUrl().toString());
     }
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/error/ErrorMapperTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/error/ErrorMapperTest.java
@@ -101,7 +101,7 @@ public class ErrorMapperTest {
       throws JsonProcessingException {
     ErrorMapper mapper = new ErrorMapper();
     ApiErrorBody apiErrorBody = new ObjectMapper().readValue(errorBody, ApiErrorBody.class);
-    Request req = new Request("GET", "/a/b/c");
+    Request req = new Request("GET", "https://databricks.com/api/2.0/a/b/c");
     Response resp = new Response(req, statusCode, null, null);
     DatabricksError error = mapper.apply(resp, apiErrorBody);
     assert error.getClass().equals(expectedClass);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/AzureServicePrincipalCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/AzureServicePrincipalCredentialsProviderTest.java
@@ -8,6 +8,7 @@ import com.databricks.sdk.core.http.HttpClient;
 import com.databricks.sdk.core.http.Response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -29,8 +30,8 @@ class AzureServicePrincipalCredentialsProviderTest {
     String responseJson = new ObjectMapper().writeValueAsString(response);
     System.out.println(responseJson);
     Mockito.when(mockClient.execute(any()))
-        .thenReturn(new Response(responseJson))
-        .thenReturn(new Response(responseJson));
+        .thenReturn(new Response(responseJson, new URL("https://databricks.com/")))
+        .thenReturn(new Response(responseJson, new URL("https://databricks.com/")));
     DatabricksConfig config =
         new DatabricksConfig()
             .setHost(".azuredatabricks.net")

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
@@ -11,6 +11,7 @@ import com.databricks.sdk.core.http.HttpClient;
 import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.core.http.Response;
 import java.io.IOException;
+import java.net.URL;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -111,9 +112,10 @@ public class ExternalBrowserCredentialsProviderTest {
     HttpClient hc = Mockito.mock(HttpClient.class);
     String response =
         "{\"access_token\": \"accessTokenFromServer\", \"token_type\": \"tokenTypeFromServer\", \"expires_in\": \"10\", \"refresh_token\": \"refreshTokenFromServer\"}";
+    URL url = new URL("https://databricks.com/");
 
     // Mock because it's a POST Request to http client
-    Mockito.doReturn(new Response(response)).when(hc).execute(any(Request.class));
+    Mockito.doReturn(new Response(response, url)).when(hc).execute(any(Request.class));
 
     Consent testConsent =
         new Consent.Builder()
@@ -156,7 +158,8 @@ public class ExternalBrowserCredentialsProviderTest {
     HttpClient hc = Mockito.mock(HttpClient.class);
     String response =
         "{\"access_token\": \"accessTokenFromServer\", \"token_type\": \"tokenTypeFromServer\", \"expires_in\": \"10\", \"refresh_token\": \"refreshTokenFromServer\"}";
-    Mockito.doReturn(new Response(response)).when(hc).execute(any(Request.class));
+    URL url = new URL("https://databricks.com/");
+    Mockito.doReturn(new Response(response, url)).when(hc).execute(any(Request.class));
 
     ClientCredentials clientCredentials =
         new ClientCredentials.Builder()
@@ -175,7 +178,8 @@ public class ExternalBrowserCredentialsProviderTest {
     HttpClient hc = Mockito.mock(HttpClient.class);
     String response =
         "{\"access_token\": \"accessTokenFromServer\", \"token_type\": \"tokenTypeFromServer\", \"expires_in\": \"10\", \"refresh_token\": \"refreshTokenFromServer\"}";
-    Mockito.doReturn(new Response(response)).when(hc).execute(any(Request.class));
+    URL url = new URL("https://databricks.com/");
+    Mockito.doReturn(new Response(response, url)).when(hc).execute(any(Request.class));
 
     SessionCredentials sessionCredentials =
         new SessionCredentials.Builder()

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/ClustersExtTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/ClustersExtTest.java
@@ -8,6 +8,7 @@ import com.databricks.sdk.core.DummyHttpClient;
 import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.core.http.Response;
 import com.databricks.sdk.service.compute.*;
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.TimeoutException;
@@ -22,13 +23,12 @@ class ClustersExtTest {
   @Mock ClustersService clustersMock;
 
   @Test
-  void ensureClusterIsRunning() throws TimeoutException {
+  void ensureClusterIsRunning() throws TimeoutException, MalformedURLException {
+    Request req =
+        new Request("GET", "https://localhost/api/2.0/clusters/get")
+            .withQueryParam("cluster_id", "abc");
     DummyHttpClient httpClient =
-        new DummyHttpClient()
-            .with(
-                new Request("GET", "https://localhost/api/2.0/clusters/get")
-                    .withQueryParam("cluster_id", "abc"),
-                new Response("{}"));
+        new DummyHttpClient().with(req, new Response("{}", req.getUri().toURL()));
 
     DatabricksConfig config =
         new DatabricksConfig()


### PR DESCRIPTION
## Changes
Port of https://github.com/databricks/databricks-sdk-go/pull/924 to the Java SDK.

When a user tries to access a Private Link-enabled workspace configured with no public internet access from a different network than the VPC endpoint belongs to, the Private Link backend redirects the user to the login page, rather than outright rejecting the request. The login page, however, is not a JSON document and cannot be parsed by the SDK, resulting in this error message:

```
$ databricks current-user me
Error: unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:
GET /login.html?error=private-link-validation-error:<WSID>
> * Host: 
> * Accept: application/json
> * Authorization: REDACTED
> * Referer: https://adb-<WSID>.azuredatabricks.net/api/2.0/preview/scim/v2/Me
> * User-Agent: cli/0.0.0-dev+5ed10bb8ccc1 databricks-sdk-go/0.39.0 go/1.22.2 os/darwin cmd/current-user_me auth/pat
< HTTP/2.0 200 OK
< * Cache-Control: no-cache, no-store, must-revalidate
< * Content-Security-Policy: default-src *; font-src * data:; frame-src * blob:; img-src * blob: data:; media-src * data:; object-src 'none'; style-src * 'unsafe-inline'; worker-src * blob:; script-src 'self' 'unsafe-eval' 'unsafe-hashes' 'report-sample' https://*.databricks.com https://databricks.github.io/debug-bookmarklet/ https://widget.intercom.io https://js.intercomcdn.com https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js https://databricks-ui-assets.azureedge.net https://ui-serving-cdn-testing.azureedge.net https://uiserviceprodwestus-cdn-endpoint.azureedge.net https://databricks-ui-infra.s3.us-west-2.amazonaws.com 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-YOlue469P2BtTMZYUFLupA2aOUsgc6B/TDewH7/Qz7s=' 'sha256-Lh4yp7cr3YOJ3MOn6erNz3E3WI0JA20mWV+0RuuviFM=' 'sha256-0jMhpY6PB/BTRDLWtfcjdwiHOpE+6rFk3ohvY6fbuHU='; report-uri /ui-csp-reports; frame-ancestors *.vocareum.com *.docebosaas.com *.edx.org *.deloitte.com *.cloudlabs.ai *.databricks.com *.myteksi.net
< * Content-Type: text/html; charset=utf-8
< * Date: Fri, 17 May 2024 07:47:38 GMT
< * Server: databricks
< * Set-Cookie: enable-armeria-workspace-server-for-ui-flags=false; Max-Age=1800; Expires=Fri, 17 May 2024 08:17:38 GMT; Secure; HTTPOnly; SameSite=Strict
< * Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
< * X-Content-Type-Options: nosniff
< * X-Ui-Svc: true
< * X-Xss-Protection: 1; mode=block
< <!doctype html>
< <html>
<  <head>
<   <meta charset="utf-8">
<   <meta http-equiv="Content-Language" content="en">
<   <title>Databricks - Sign In</title>
<   <meta name="viewport" content="width=960">
<   <link rel="icon" type="image/png" href="https://databricks-ui-assets.azureedge.net/favicon.ico">
<   <meta http-equiv="content-type" content="text/html; charset=UTF8">
<   <script id="__databricks_react_script"></script>
<   <script>window.__DATABRICKS_SAFE_FLAGS__={"databricks.infra.showErrorModalOnFetchError":true,"databricks.fe.infra.useReact18":true,"databricks.fe.infra.useReact18NewAPI":false,"databricks.fe.infra.fixConfigPrefetch":true},window.__DATABRICKS_CONFIG__={"publicPath":{"mlflow":"https://databricks-ui-assets.azureedge.net/","dbsql":"https://databricks-ui-assets.azureedge.net/","feature-store":"https://databricks-ui-assets.azureedge.net/","monolith":"https://databricks-ui-assets.azureedge.net/","jaws":"https://databricks-ui-assets.azureedge.net/"}}</script>
<   <link rel="icon" href="https://databricks-ui-assets.azureedge.net/favicon.ico">
<   <script>
<   function setNoCdnAndReload() {
<       document.cookie = `x-databricks-cdn-inaccessible=true; path=/; max-age=86400`;
<       const metric = 'cdnFallbackOccurred';
<       const browserUserAgent = navigator.userAgent;
<       const browserTabId = window.browserTabId;
<       const performanceEntry = performance.getEntriesByType('resource').filter(e => e.initiatorType === 'script').slice(-1)[0]
<       sessionStorage.setItem('databricks-cdn-fallback-telemetry-key', JSON.stringify({ tags: { browserUserAgent, browserTabId }, performanceEntry}));
<       window.location.reload();
<   }
< </script>
<   <script>
<   // Set a manual timeout for dropped packets to CDN
<   function loadScriptWithTimeout(src, timeout) {
<      return new Promise((resolve, reject) => {
<         const script = document.createElement('script');
<           script.defer = true;
<           script.src = src;
<           script.onload = resolve;
<           script.onerror = reject;
<           document.head.appendChild(script);
<           setTimeout(() => {
<               reject(new Error('Script load timeout'));
<           }, timeout);
<       });
<   }
<   loadScriptWithTimeout('https://databricks-ui-assets.azureedge.net/static/js/login/login.8a983ca2.js', 10000).catch(setNoCdnAndReload);
< </script>
<  </head>
<  <body class="light-mode">
<   <uses-legacy-bootstrap>
<    <div id="login-page"></div>
<   </uses-legacy-bootstrap>
<  </body>
< </html>
```

To address this, I add one additional check in the error mapper logic to inspect whether the user was redirected to the login page with the private link validation error response code. If so, we return a synthetic error with error code `PRIVATE_LINK_VALIDATION_ERROR` that inherits from PermissionDenied and has a mock 403 status code.

After this change, users will see an error message like this:
```
Exception in thread "main" com.databricks.sdk.core.error.PrivateLinkValidationError: The requested workspace has Azure Private Link enabled and is not accessible from the current network. Ensure that Azure Private Link is properly configured and that your device has access to the Azure Private Link endpoint. For more information, see https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/private-link-standard#authentication-troubleshooting.
	at com.databricks.sdk.core.error.PrivateLinkInfo.createPrivateLinkValidationError(PrivateLinkInfo.java:63)
	at com.databricks.sdk.core.error.AbstractErrorMapper.apply(AbstractErrorMapper.java:46)
	at com.databricks.sdk.core.error.ApiErrors.getDatabricksError(ApiErrors.java:29)
	at com.databricks.sdk.core.ApiClient.executeInner(ApiClient.java:276)
	at com.databricks.sdk.core.ApiClient.getResponse(ApiClient.java:235)
	at com.databricks.sdk.core.ApiClient.execute(ApiClient.java:227)
	at com.databricks.sdk.core.ApiClient.GET(ApiClient.java:148)
	at com.databricks.sdk.service.compute.ClustersImpl.list(ClustersImpl.java:94)
	at com.databricks.sdk.support.Paginator.flipNextPage(Paginator.java:58)
	at com.databricks.sdk.support.Paginator.<init>(Paginator.java:51)
	at com.databricks.sdk.service.compute.ClustersAPI.list(ClustersAPI.java:295)
	at com.databricks.sdk.examples.ListClustersExample.main(ListClustersExample.java:11)
```

The error message is tuned to the specific cloud so that we can redirect users to the appropriate documentation, the cloud being inferred from the request URI.

## Tests
Unit tests cover the private link error message mapping.
To manually test this, I created a private link workspace in Azure, created an access token, restricted access to the workspace, then ran the `ListClustersExample` example using the host & token:
```
<SNIP>
14:41 [DEBUG] > GET /api/2.0/clusters/list
< 200 OK
< <!doctype html>
< <html>
<  <head>
<   <meta charset="utf-8">
<   <meta http-equiv="Content-Language" content="en">
<   <title>Databricks - Sign In</title>
<   <meta name="viewport" content="width=960">
<   <link rel="icon" type="image/png" href="https://databricks-ui-assets.azureedge.net/favicon.ico">
<   <meta http-equiv="content-type" content="text/html; charset=UTF8">
<   <script id="__databricks_react_script"></script>
<   <script>window.__DATABRICKS_SAFE_FLAGS__={"databricks.infra.showErrorModalOnFetchError":true,"databricks.fe.infra.useReact18":true,"databricks.fe.infra.useReact18NewAPI":false,"databricks.fe.infra.fixConfigPrefetch":true},window.__DATABRICKS_CONFIG__={"publicPath":{"mlflow":"https://databricks-ui-assets.azureedge.net/","dbsql":"https://databricks-ui-assets.azureedge.net/","feature-store":"https://databricks-ui-assets.azureedge.net/","monolith":"https://databricks-ui-assets.azureedge.net/","jaws":"https://databricks-ui-assets.azureedge.net/"}}</script>
<   <link rel="icon" href="https://databricks-ui-assets.... (1420 more bytes)
Exception in thread "main" com.databricks.sdk.core.error.PrivateLinkValidationError: The requested workspace has Azure Private Link enabled and is not accessible from the current network. Ensure that Azure Private Link is properly configured and that your device has access to the Azure Private Link endpoint. For more information, see https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/private-link-standard#authentication-troubleshooting.
	at com.databricks.sdk.core.error.PrivateLinkInfo.createPrivateLinkValidationError(PrivateLinkInfo.java:63)
	at com.databricks.sdk.core.error.AbstractErrorMapper.apply(AbstractErrorMapper.java:46)
	at com.databricks.sdk.core.error.ApiErrors.getDatabricksError(ApiErrors.java:29)
	at com.databricks.sdk.core.ApiClient.executeInner(ApiClient.java:276)
	at com.databricks.sdk.core.ApiClient.getResponse(ApiClient.java:235)
	at com.databricks.sdk.core.ApiClient.execute(ApiClient.java:227)
	at com.databricks.sdk.core.ApiClient.GET(ApiClient.java:148)
	at com.databricks.sdk.service.compute.ClustersImpl.list(ClustersImpl.java:94)
	at com.databricks.sdk.support.Paginator.flipNextPage(Paginator.java:58)
	at com.databricks.sdk.support.Paginator.<init>(Paginator.java:51)
	at com.databricks.sdk.service.compute.ClustersAPI.list(ClustersAPI.java:295)
	at com.databricks.sdk.examples.ListClustersExample.main(ListClustersExample.java:11)
Disconnected from the target VM, address: '127.0.0.1:55559', transport: 'socket'

Process finished with exit code 1
exit status 2
```