### PR TITLE
Support partners in SDK

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -1,6 +1,8 @@
 package com.databricks.sdk.core;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -10,6 +12,8 @@ public class UserAgent {
 
   private static final Map<String, String> otherInfo = new HashMap<>();
 
+  private static final List<String> partners = new ArrayList<>();
+
   // TODO: check if reading from
   // /META-INF/maven/com.databricks/databrics-sdk-java/pom.properties
   // or getClass().getPackage().getImplementationVersion() is enough.
@@ -18,6 +22,10 @@ public class UserAgent {
   public static void withProduct(String product, String productVersion) {
     UserAgent.product = product;
     UserAgent.productVersion = productVersion;
+  }
+
+  public static void withPartner(String partner) {
+    partners.add(partner);
   }
 
   public static void withOtherInfo(String key, String value) {
@@ -43,12 +51,15 @@ public class UserAgent {
   }
 
   public static String asString() {
-    String otherInfo =
-        UserAgent.otherInfo.entrySet().stream()
-            .map(e -> String.format(" %s/%s", e.getKey(), e.getValue()))
-            .collect(Collectors.joining());
-    return String.format(
-        "%s/%s databricks-sdk-java/%s jvm/%s os/%s%s",
-        product, productVersion, version, jvmVersion(), osName(), otherInfo);
+    List<String> segments = new ArrayList<>();
+    segments.add(String.format("%s/%s", product, productVersion));
+    segments.add(String.format("databricks-sdk-java/%s", version));
+    segments.add(String.format("jvm/%s", jvmVersion()));
+    segments.add(String.format("os/%s", osName()));
+    segments.addAll(
+        otherInfo.entrySet().stream()
+            .map(e -> String.format("%s/%s", e.getKey(), e.getValue())).collect(Collectors.toSet()));
+    segments.addAll(partners.stream().map(p -> "partner/" + p).collect(Collectors.toSet()));
+    return segments.stream().collect(Collectors.joining(" "));
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -51,11 +51,12 @@ public class UserAgent {
   private static final Pattern regexpAlphanumInverse = Pattern.compile("[^0-9A-Za-z_\\.\\+-]");
 
   /**
-   * Replaces all non-alphanumeric characters with a hyphen. Use this to ensure that the user agent value is valid. This
-   * is useful when the value is not ensured to be valid at compile time.
-   * <p>
-   * Note: Semver strings are comprised of alphanumeric characters, hyphens, periods
-   * and plus signs. This function will not remove these characters.
+   * Replaces all non-alphanumeric characters with a hyphen. Use this to ensure that the user agent
+   * value is valid. This is useful when the value is not ensured to be valid at compile time.
+   *
+   * <p>Note: Semver strings are comprised of alphanumeric characters, hyphens, periods and plus
+   * signs. This function will not remove these characters.
+   *
    * @param s The string to sanitize.
    * @return The sanitized string.
    */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -1,9 +1,7 @@
 package com.databricks.sdk.core;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -43,9 +41,11 @@ public class UserAgent {
 
   // Regular expression copied from https://semver.org/.
   private static final String semVerCore = "(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)";
-  private static final String semVerPrerelease = "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?";
+  private static final String semVerPrerelease =
+      "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?";
   private static final String semVerBuildmetadata = "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?";
-  private static final Pattern regexpSemVer = Pattern.compile("^" + semVerCore + semVerPrerelease + semVerBuildmetadata + "$");
+  private static final Pattern regexpSemVer =
+      Pattern.compile("^" + semVerCore + semVerPrerelease + semVerBuildmetadata + "$");
 
   // Sanitize replaces all non-alphanumeric characters with a hyphen. Use this to
   // ensure that the user agent value is valid. This is useful when the value is not
@@ -123,7 +123,8 @@ public class UserAgent {
     segments.add(String.format("os/%s", osName()));
     segments.addAll(
         otherInfo.stream()
-            .map(e -> String.format("%s/%s", e.getKey(), e.getValue())).collect(Collectors.toSet()));
+            .map(e -> String.format("%s/%s", e.getKey(), e.getValue()))
+            .collect(Collectors.toSet()));
     return segments.stream().collect(Collectors.joining(" "));
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -10,9 +10,25 @@ public class UserAgent {
   private static String product = "unknown";
   private static String productVersion = "0.0.0";
 
-  private static final Map<String, String> otherInfo = new HashMap<>();
+  private static class Info {
+    private String key;
+    private String value;
 
-  private static final List<String> partners = new ArrayList<>();
+    public Info(String key, String value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+
+  private static final ArrayList<Info> otherInfo = new ArrayList<>();
 
   // TODO: check if reading from
   // /META-INF/maven/com.databricks/databrics-sdk-java/pom.properties
@@ -25,11 +41,11 @@ public class UserAgent {
   }
 
   public static void withPartner(String partner) {
-    partners.add(partner);
+    withOtherInfo("partner", partner);
   }
 
   public static void withOtherInfo(String key, String value) {
-    otherInfo.put(key, value);
+    otherInfo.add(new Info(key, value));
   }
 
   private static String osName() {
@@ -57,9 +73,8 @@ public class UserAgent {
     segments.add(String.format("jvm/%s", jvmVersion()));
     segments.add(String.format("os/%s", osName()));
     segments.addAll(
-        otherInfo.entrySet().stream()
+        otherInfo.stream()
             .map(e -> String.format("%s/%s", e.getKey(), e.getValue())).collect(Collectors.toSet()));
-    segments.addAll(partners.stream().map(p -> "partner/" + p).collect(Collectors.toSet()));
     return segments.stream().collect(Collectors.joining(" "));
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -47,21 +47,18 @@ public class UserAgent {
   private static final Pattern regexpSemVer =
       Pattern.compile("^" + semVerCore + semVerPrerelease + semVerBuildmetadata + "$");
 
-  // Sanitize replaces all non-alphanumeric characters with a hyphen. Use this to
-  // ensure that the user agent value is valid. This is useful when the value is not
-  // ensured to be valid at compile time.
-  //
-  // Example: You want to avoid having '/' and ' ' in the value because it will
-  // make downstream applications fail.
-  //
-  // Note: Semver strings are comprised of alphanumeric characters, hyphens, periods
-  // and plus signs. This function will not remove these characters.
-  // see:
-  // 1. https://semver.org/#spec-item-9
-  // 2. https://semver.org/#spec-item-10
   private static final Pattern regexpAlphanum = Pattern.compile("^[0-9A-Za-z_\\.\\+-]+$");
   private static final Pattern regexpAlphanumInverse = Pattern.compile("[^0-9A-Za-z_\\.\\+-]");
 
+  /**
+   * Replaces all non-alphanumeric characters with a hyphen. Use this to ensure that the user agent value is valid. This
+   * is useful when the value is not ensured to be valid at compile time.
+   * <p>
+   * Note: Semver strings are comprised of alphanumeric characters, hyphens, periods
+   * and plus signs. This function will not remove these characters.
+   * @param s The string to sanitize.
+   * @return The sanitized string.
+   */
   public static String sanitize(String s) {
     return regexpAlphanumInverse.matcher(s).replaceAll("-");
   }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -31,4 +31,25 @@ public class UserAgentTest {
     Assertions.assertTrue(userAgent.contains("key1/value1"));
     Assertions.assertTrue(userAgent.contains("key2/value2"));
   }
+
+  @Test
+  public void testUserAgentWithInvalidKey() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      UserAgent.withOtherInfo("key1!", "value1");
+    });
+  }
+
+  @Test
+  public void testUserAgentWithInvalidValue() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      UserAgent.withOtherInfo("key1", "value1!");
+    });
+  }
+
+  @Test
+  public void testUserAgentWithSemverValue() {
+    UserAgent.withOtherInfo("key1", "1.0.0-dev+metadata");
+    String userAgent = UserAgent.asString();
+    Assertions.assertTrue(userAgent.contains("key1/1.0.0-dev+metadata"));
+  }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -1,0 +1,34 @@
+package com.databricks.sdk.core;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UserAgentTest {
+  @Test
+  public void testUserAgent() {
+    UserAgent.withProduct("product", "productVersion");
+    String userAgent = UserAgent.asString();
+    Assertions.assertTrue(userAgent.contains("product/productVersion"));
+    Assertions.assertTrue(userAgent.contains("databricks-sdk-java/"));
+    Assertions.assertTrue(userAgent.contains("os/"));
+    Assertions.assertTrue(userAgent.contains("jvm/"));
+  }
+
+  @Test
+  public void testUserAgentWithPartner() {
+    UserAgent.withPartner("partner1");
+    UserAgent.withPartner("partner2");
+    String userAgent = UserAgent.asString();
+    Assertions.assertTrue(userAgent.contains("partner/partner1"));
+    Assertions.assertTrue(userAgent.contains("partner/partner2"));
+  }
+
+  @Test
+  public void testUserAgentWithOtherInfo() {
+    UserAgent.withOtherInfo("key1", "value1");
+    UserAgent.withOtherInfo("key2", "value2");
+    String userAgent = UserAgent.asString();
+    Assertions.assertTrue(userAgent.contains("key1/value1"));
+    Assertions.assertTrue(userAgent.contains("key2/value2"));
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -34,16 +34,20 @@ public class UserAgentTest {
 
   @Test
   public void testUserAgentWithInvalidKey() {
-    Assertions.assertThrows(IllegalArgumentException.class, () -> {
-      UserAgent.withOtherInfo("key1!", "value1");
-    });
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          UserAgent.withOtherInfo("key1!", "value1");
+        });
   }
 
   @Test
   public void testUserAgentWithInvalidValue() {
-    Assertions.assertThrows(IllegalArgumentException.class, () -> {
-      UserAgent.withOtherInfo("key1", "value1!");
-    });
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          UserAgent.withOtherInfo("key1", "value1!");
+        });
   }
 
   @Test


### PR DESCRIPTION
## Changes
This PR is a port of https://github.com/databricks/databricks-sdk-go/pull/925 to the Java SDK.

Partners of Databricks need a mechanism to register themselves in libraries or applications that they write. In this way, requests made by users of those libraries will include sufficient information to link those requests to the original users.

This PR adds a new function `withPartner` that can be used by a partner to add partner information to the User-Agent header for requests made by the SDK. The new header will have the form `partner/<parther id>`. The partner identifier is opaque for the SDK, but it must be alphanumeric.

This PR also lifts the requirement that there may only be a single copy of an entry in the user agent. This allows multiple partners to register themselves in the same library or application.

Additionally, this PR adds validation on keys and values of entries in the user agent to match the Go SDK: alphanumeric keys and alphanumeric or semver values.

## Tests
Unit tests cover the implementation of the `UserAgent` class.

