### PR TITLE
Retry failed integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,9 @@
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.2.5</version>
+        <configuration>
+          <rerunFailingTestsCount>2</rerunFailingTestsCount>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
## Changes
Retry failed integration tests

## Tests
Increase the retry count to 20, and replaced all tests by this test:
```
@Test
  void randomlyFail(WorkspaceClient w) {
    int randomNum = (int) (Math.random() * (5));
    assert randomNum == 2;
  }
```

Then run:
```
mvn verify
```

Results:
```
[INFO] Results:
[INFO] 
[WARNING] Flakes: 
[WARNING] com.databricks.sdk.integration.TestIT.randomlyFail(WorkspaceClient)
[ERROR]   Run 1: TestIT.randomlyFail:15
[ERROR]   Run 2:TestIT.randomlyFail:15
[ERROR]   Run 3: TestIT.randomlyFail:15
[ERROR]   Run 4: TestIT.randomlyFail:15
[ERROR]   Run 5: TestIT.randomlyFail:15
[ERROR]   Run 6: TestIT.randomlyFail:15
[INFO]   Run 7: PASS
[INFO] 
[INFO] 
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Flakes: 1
[INFO] 
[INFO] 
[INFO] --- failsafe:3.2.5:verify (default) @ databricks-sdk-java ---
[INFO] 
[INFO] --- jacoco:0.8.10:report (report) @ databricks-sdk-java ---
[INFO] Loading execution data file /Users/hector.castejon/databricks-sdk-java/databricks-sdk-java/target/jacoco.exec
[INFO] Analyzed bundle 'databricks-sdk-java' with 86 classes
[INFO] 
[INFO] --- jacoco:0.8.10:check (check) @ databricks-sdk-java ---
[INFO] Loading execution data file /Users/hector.castejon/databricks-sdk-java/databricks-sdk-java/target/jacoco.exec
[INFO] Analyzed bundle 'databricks-sdk-java' with 86 classes
[INFO] All coverage checks have been met.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Databricks SDK for Java 0.26.0:
[INFO] 
[INFO] Databricks SDK for Java ............................ SUCCESS [  0.422 s]
[INFO] databricks-sdk-java ................................ SUCCESS [  7.317 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.809 s
[INFO] Finished at: 2024-06-11T15:49:49+02:00
[INFO] ------------------------------------------------------------------------
```
