### PR TITLE
Add `serverless_compute_id` field to the config

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -58,6 +58,9 @@ public class DatabricksConfig {
   @ConfigAttribute(env = "DATABRICKS_CLUSTER_ID")
   private String clusterId;
 
+  @ConfigAttribute(env = "DATABRICKS_SERVERLESS_COMPUTE_ID")
+  private String serverlessComputeId;
+
   @ConfigAttribute(env = "DATABRICKS_GOOGLE_SERVICE_ACCOUNT", auth = "google")
   private String googleServiceAccount;
 
@@ -254,6 +257,13 @@ public class DatabricksConfig {
 
   public DatabricksConfig setClusterId(String clusterId) {
     this.clusterId = clusterId;
+    return this;
+  }
+
+  public String getServerlessComputeId() { return serverlessComputeId; }
+
+  public DatabricksConfig setServerlessComputeId(String serverlessComputeId) {
+    this.serverlessComputeId = serverlessComputeId;
     return this;
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -260,7 +260,9 @@ public class DatabricksConfig {
     return this;
   }
 
-  public String getServerlessComputeId() { return serverlessComputeId; }
+  public String getServerlessComputeId() {
+    return serverlessComputeId;
+  }
 
   public DatabricksConfig setServerlessComputeId(String serverlessComputeId) {
     this.serverlessComputeId = serverlessComputeId;


### PR DESCRIPTION
## Changes
Adding `serverless_compute_id` field to the config following [the same change](https://github.com/databricks/databricks-sdk-py/pull/685) in databricks-sdk-py

## Tests

Tested locally: SDK can read values from the config, getter and setter work.
