### PR TITLE
Add `CachedTokenSource` to replace `RefreshableTokenSource`

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/CachedTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/CachedTokenSource.java
@@ -1,0 +1,65 @@
+package com.databricks.sdk.core.oauth;
+
+import com.databricks.sdk.core.utils.ClockSupplier;
+import com.databricks.sdk.core.utils.SystemClockSupplier;
+import java.time.LocalDateTime;
+
+/**
+ * A {@link TokenSource} that wraps another {@link TokenSource} to only request a new {@link Token}
+ * when the last one is invalid.
+ */
+public class CachedTokenSource implements TokenSource {
+
+  private final ClockSupplier clockSupplier;
+  private final TokenSource tokenSource;
+  private Token token;
+
+  /**
+   * Constructs a new {@code CachedTokenSource} that wraps the provided {@link TokenSource} and uses
+   * a {@code SystemClockSupplier} to verify the tokens' validity.
+   *
+   * @param tokenSource the underlying token source to wrap
+   */
+  public CachedTokenSource(TokenSource tokenSource) {
+    this(new SystemClockSupplier(), tokenSource);
+  }
+
+  /**
+   * Constructs a new {@code CachedTokenSource} that wraps the provided {@link TokenSource}.
+   *
+   * @param clockSupplier the clock supplier to check token validity
+   * @param tokenSource the underlying token source to wrap
+   */
+  public CachedTokenSource(ClockSupplier clockSupplier, TokenSource tokenSource) {
+    this.clockSupplier = clockSupplier;
+    this.tokenSource = tokenSource;
+  }
+
+  /**
+   * Returns a valid {@link Token}. If the current token is null or invalid, this method will obtain
+   * a new token from the underlying {@link TokenSource}.
+   *
+   * @return a valid {@link Token}
+   */
+  public synchronized Token getToken() {
+    if (!isValid(clockSupplier, token)) {
+      token = tokenSource.getToken();
+    }
+    return token;
+  }
+
+  private static boolean isValid(ClockSupplier clockSupplier, Token token) {
+    if (token == null || token.getAccessToken() == null) {
+      return false;
+    }
+    if (token.getExpiry() == null) {
+      return true;
+    }
+
+    // Azure Databricks rejects tokens that expire within 30 seconds. We add a buffer
+    // of 10 seconds to reduce the risk of sending tokens that will be rejected.
+    LocalDateTime expiry = token.getExpiry().minusSeconds(30 + 10);
+    LocalDateTime now = LocalDateTime.now(clockSupplier.getClock());
+    return now.isBefore(expiry);
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
@@ -17,6 +17,8 @@ import org.apache.http.HttpHeaders;
  *
  * <p>Calls to getToken() will first check if the token is still valid (currently defined by having
  * at least 10 seconds until expiry). If not, refresh() is called first to refresh the token.
+ *
+ * @deprecated replaced by {@code CachedTokenSource}.
  */
 public abstract class RefreshableTokenSource implements TokenSource {
   protected Token token;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
@@ -18,7 +18,7 @@ import org.apache.http.HttpHeaders;
  * <p>Calls to getToken() will first check if the token is still valid (currently defined by having
  * at least 10 seconds until expiry). If not, refresh() is called first to refresh the token.
  *
- * @deprecated replaced by {@code CachedTokenSource}.
+ * @deprecated replaced by {@link CachedTokenSource}.
  */
 public abstract class RefreshableTokenSource implements TokenSource {
   protected Token token;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Token.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Token.java
@@ -59,6 +59,9 @@ public class Token {
     this.clockSupplier = clockSupplier;
   }
 
+  /**
+   * @deprecated use {@link CachedTokenSource} instead.
+   */
   public boolean isExpired() {
     if (expiry == null) {
       return false;
@@ -70,6 +73,9 @@ public class Token {
     return potentiallyExpired.isBefore(now);
   }
 
+  /**
+   * @deprecated use {@link CachedTokenSource} instead.
+   */
   public boolean isValid() {
     return accessToken != null && !isExpired();
   }
@@ -84,5 +90,9 @@ public class Token {
 
   public String getAccessToken() {
     return accessToken;
+  }
+
+  public LocalDateTime getExpiry() {
+    return expiry;
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Token.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Token.java
@@ -59,9 +59,7 @@ public class Token {
     this.clockSupplier = clockSupplier;
   }
 
-  /**
-   * @deprecated use {@link CachedTokenSource} instead.
-   */
+  /** @deprecated use {@link CachedTokenSource} instead. */
   public boolean isExpired() {
     if (expiry == null) {
       return false;
@@ -73,9 +71,7 @@ public class Token {
     return potentiallyExpired.isBefore(now);
   }
 
-  /**
-   * @deprecated use {@link CachedTokenSource} instead.
-   */
+  /** @deprecated use {@link CachedTokenSource} instead. */
   public boolean isValid() {
     return accessToken != null && !isExpired();
   }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/CachedTokenTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/CachedTokenTest.java
@@ -1,0 +1,58 @@
+package com.databricks.sdk.core.oauth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.databricks.sdk.core.utils.ClockSupplier;
+import com.databricks.sdk.core.utils.FakeClockSupplier;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+
+public class CachedTokenTest {
+  private static final ZoneId ZONE_ID = ZoneId.of("UTC");
+  private static final Instant INSTANT_NOW = Instant.ofEpochSecond(0);
+  private static final LocalDateTime NOW = LocalDateTime.ofInstant(INSTANT_NOW, ZONE_ID);
+  private static final ClockSupplier FAKE_CLOCK = new FakeClockSupplier(INSTANT_NOW, ZONE_ID);
+  private static final String TOKEN_TYPE = "test-token-type";
+
+  @Test
+  void shouldNotRefreshValidToken() {
+    Token token1 = new Token("token1", TOKEN_TYPE, NOW.plusHours(1));
+    Token token2 = new Token("token2", TOKEN_TYPE, NOW.plusHours(2));
+    CachedTokenSource ts = new CachedTokenSource(FAKE_CLOCK, testTokenSource(token1, token2));
+
+    assertEquals(ts.getToken(), token1);
+    assertEquals(ts.getToken(), token1); // token1 remains valid
+  }
+
+  @Test
+  void shouldRefreshInvalidToken() {
+    Token token1 = new Token("token1", TOKEN_TYPE, NOW.minusHours(1));
+    Token token2 = new Token("token2", TOKEN_TYPE, NOW.plusHours(1));
+    CachedTokenSource ts = new CachedTokenSource(FAKE_CLOCK, testTokenSource(token1, token2));
+
+    assertEquals(ts.getToken(), token1);
+    assertEquals(ts.getToken(), token2);
+    assertEquals(ts.getToken(), token2); // token2 remains valid
+  }
+
+  @Test
+  void shouldRefresh40SecBeforeExpiry() {
+    Token token1 = new Token("token1", TOKEN_TYPE, NOW.plusSeconds(40));
+    Token token2 = new Token("token2", TOKEN_TYPE, NOW.plusSeconds(41));
+    CachedTokenSource ts = new CachedTokenSource(FAKE_CLOCK, testTokenSource(token1, token2));
+
+    assertEquals(ts.getToken(), token1);
+    assertEquals(ts.getToken(), token2);
+    assertEquals(ts.getToken(), token2); // token2 remains valid
+  }
+
+  // Return a TokenSource that iterates over the given input tokens.
+  private static TokenSource testTokenSource(Token... inputTokens) {
+    Iterator<Token> iterator = Arrays.asList(inputTokens).iterator();
+    return iterator::next;
+  }
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

See PR #306 for an example use of `CachedTokenSource`. 

## Tests
<!-- How is this tested? -->

