### PR TITLE
Accept any `HttpRequest` instead of `HttpUriRequest` in `CommonHttpClient`

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
@@ -30,7 +30,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.apache.http.message.BasicHttpRequest;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
@@ -105,14 +104,15 @@ public class CommonsHttpClient implements HttpClient {
       HttpHost targetHost = (HttpHost) context.getAttribute("http.target_host");
       HttpRequest request = (HttpRequest) context.getAttribute("http.request");
       URI uri = new URI(request.getRequestLine().getUri());
-      uri = new URI(
-          targetHost.getSchemeName(),
-          null,
-          targetHost.getHostName(),
-          targetHost.getPort(),
-          uri.getPath(),
-          uri.getQuery(),
-          uri.getFragment());
+      uri =
+          new URI(
+              targetHost.getSchemeName(),
+              null,
+              targetHost.getHostName(),
+              targetHost.getPort(),
+              uri.getPath(),
+              uri.getQuery(),
+              uri.getFragment());
       return uri.toURL();
     } catch (MalformedURLException | URISyntaxException e) {
       throw new DatabricksException("Unable to get target URL", e);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
@@ -22,10 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
-import org.apache.http.NameValuePair;
-import org.apache.http.StatusLine;
+import org.apache.http.*;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.*;
 import org.apache.http.entity.InputStreamEntity;
@@ -33,6 +30,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.message.BasicHttpRequest;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
@@ -105,16 +103,16 @@ public class CommonsHttpClient implements HttpClient {
   private URL getTargetUrl(HttpContext context) {
     try {
       HttpHost targetHost = (HttpHost) context.getAttribute("http.target_host");
-      HttpUriRequest request = (HttpUriRequest) context.getAttribute("http.request");
-      URI uri =
-          new URI(
-              targetHost.getSchemeName(),
-              null,
-              targetHost.getHostName(),
-              targetHost.getPort(),
-              request.getURI().getPath(),
-              request.getURI().getQuery(),
-              request.getURI().getFragment());
+      HttpRequest request = (HttpRequest) context.getAttribute("http.request");
+      URI uri = new URI(request.getRequestLine().getUri());
+      uri = new URI(
+          targetHost.getSchemeName(),
+          null,
+          targetHost.getHostName(),
+          targetHost.getPort(),
+          uri.getPath(),
+          uri.getQuery(),
+          uri.getFragment());
       return uri.toURL();
     } catch (MalformedURLException | URISyntaxException e) {
       throw new DatabricksException("Unable to get target URL", e);


### PR DESCRIPTION
## Changes

This PR addresses a regression reportedly introduced in PR #290 when connecting via a proxy that requires authentication (see context).

The problem comes from a casting exception in `CommonHttpClient` which attempts to cast a `BasicHttpRequest` (which represents the next request after receiving the auth required response) into a `HttpUriRequest`. This PR solves the casting issue by processing the ancestor of both classes, `HttpRequest`. 

### Context

The regression was detected when trying to authenticate via a Proxy that requires authentication. In particular, the request to respond to the proxy's authentication request is automatically created as a `BasicHttpRequest` by the apache `HttpClient`.   

## Tests

Unit tests and integration tests are passing. The fix was also verified by the user who uncovered the issue.

Note: we should add a regression test that simulate the proxy setting. However, I'd like to take the time to experiment with different configurations. Given that the change is relatively simple, I'd recommend to proceed with this PR and add the test in a follow-up PR. 

