### PR TITLE
[Internal] Run `AccountClientIT` test only for aws-prod-ucacct

### DIFF
--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountClientIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountClientIT.java
@@ -9,7 +9,7 @@ import com.databricks.sdk.service.provisioning.Workspace;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-// Enable this test for aws-prod-acct once the issue with adding SP to non UC account is resolved
+// Enable this test for aws-prod-acct once the issue with adding SP to non UC account is resolved 
 @EnvContext("ucacct")
 @ExtendWith(EnvTest.class)
 public class AccountClientIT {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountClientIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountClientIT.java
@@ -9,7 +9,8 @@ import com.databricks.sdk.service.provisioning.Workspace;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@EnvContext("account")
+// Enable this test for aws-prod-acct once the issue with adding SP to non UC account is resolved
+@EnvContext("ucacct")
 @ExtendWith(EnvTest.class)
 public class AccountClientIT {
   @Test

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountClientIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountClientIT.java
@@ -9,7 +9,7 @@ import com.databricks.sdk.service.provisioning.Workspace;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-// Enable this test for aws-prod-acct once the issue with adding SP to non UC account is resolved 
+// Enable this test for aws-prod-acct once the issue with adding SP to non UC account is resolved
 @EnvContext("ucacct")
 @ExtendWith(EnvTest.class)
 public class AccountClientIT {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Non-UC workspaces do not support adding SP. This is currently blocking the release pipeline due to a failing test in our integration tests. To unblock released we are only going to run this test in aws-prod-ucacct

## Tests
<!-- How is this tested? -->
Manually ran this test locally on ucacct and it passed
Also ran nightly over the which passed for aws-prod-acct
