### PR TITLE
[Fix] Add missing token URL and client ID in Github OIDC Credentials Provider

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/AzureGithubOidcCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/AzureGithubOidcCredentialsProvider.java
@@ -41,8 +41,10 @@ public class AzureGithubOidcCredentialsProvider implements CredentialsProvider {
     TokenSource tokenSource =
         new OidcTokenSource(
             config.getHttpClient(),
-            "",
-            config.getClientId(),
+            config.getDatabricksEnvironment().getAzureEnvironment().getActiveDirectoryEndpoint()
+                + config.getAzureTenantId()
+                + "/oauth2/token",
+            config.getAzureClientId(),
             config.getEffectiveAzureLoginAppId(),
             idToken.get(),
             "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
@@ -85,7 +87,7 @@ public class AzureGithubOidcCredentialsProvider implements CredentialsProvider {
           "Failed to request ID token: status code "
               + resp.getStatusCode()
               + ", response body: "
-              + resp.getBody());
+              + resp.getBody().toString());
     }
 
     ObjectNode jsonResp;


### PR DESCRIPTION
## Changes

Add missing token URL and client ID in Github OIDC Credentials Provider. 

## Tests

Verified locally that these are properly passed. This change will be covered by Databricks internal integration tests. 

