### PR TITLE
[Fix] DatabricksConfig: newWithWorkspaceHost should retain authType

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -713,7 +713,6 @@ public class DatabricksConfig {
                 // For cloud-native OAuth, we need to reauthenticate as the audience has changed, so
                 // don't cache the
                 // header factory.
-                "authType",
                 "headerFactory"));
     DatabricksConfig newConfig = new DatabricksConfig();
     for (Field f : DatabricksConfig.class.getDeclaredFields()) {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -137,4 +137,24 @@ public class DatabricksConfigTest {
       assertEquals(oidcEndpoints.getTokenEndpoint(), "https://test.auth.endpoint/oidc/v1/token");
     }
   }
+
+  @Test
+  public void testNewWithWorkspaceHost() {
+    DatabricksConfig config =
+        new DatabricksConfig()
+            .setAuthType("oauth-m2m")
+            .setClientId("my-client-id")
+            .setClientSecret("my-client-secret")
+            .setAccountId("account-id")
+            .setHost("https://account.cloud.databricks.com");
+    String workspaceHost = "https://workspace.cloud.databricks.com";
+
+    DatabricksConfig newWorkspaceConfig = config.newWithWorkspaceHost(workspaceHost).resolve();
+
+    assert newWorkspaceConfig.getHost().equals(workspaceHost);
+    assert newWorkspaceConfig.getAuthType().equals("oauth-m2m");
+    assert newWorkspaceConfig.getClientId().equals("my-client-id");
+    assert newWorkspaceConfig.getClientSecret().equals("my-client-secret");
+    assert newWorkspaceConfig.getAccountId() == null;
+  }
 }


### PR DESCRIPTION
## Changes
* New DatabricksConfig() object should retain auth type as its reusing the existing authentication mechanism. This is how its done in the Py and Go SDK

## Tests
* Added unit test

