### PR TITLE
[Internal] Fix nightly test failure

### DIFF
--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -155,6 +155,5 @@ public class DatabricksConfigTest {
     assert newWorkspaceConfig.getAuthType().equals("oauth-m2m");
     assert newWorkspaceConfig.getClientId().equals("my-client-id");
     assert newWorkspaceConfig.getClientSecret().equals("my-client-secret");
-    assert newWorkspaceConfig.getAccountId() == null;
   }
 }


### PR DESCRIPTION
## Changes
`getWorkspaceClient()` clears the account ID from the config, but `resolve()` may load it again if the account ID is part of the selected .databrickscfg profile or an environment variable (which it is in our integration tests).

## Tests
<!-- How is this tested? -->

