### PR TITLE
[Fix] Handle login.html incorrect validation for private link

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/PrivateLinkInfo.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/PrivateLinkInfo.java
@@ -53,7 +53,8 @@ public class PrivateLinkInfo {
 
   public static boolean isPrivateLinkRedirect(Response resp) {
     return resp.getUrl().getPath().equals("/login.html")
-        && resp.getUrl().getQuery().contains("error=private-link-validation-error");
+        && (resp.getUrl().getQuery() != null
+            && resp.getUrl().getQuery().contains("error=private-link-validation-error"));
   }
 
   static PrivateLinkValidationError createPrivateLinkValidationError(Response resp) {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/error/PrivateLinkInfoTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/error/PrivateLinkInfoTest.java
@@ -1,0 +1,39 @@
+package com.databricks.sdk.core.error;
+
+import com.databricks.sdk.core.error.platform.*;
+import com.databricks.sdk.core.http.Request;
+import com.databricks.sdk.core.http.Response;
+import org.junit.jupiter.api.Test;
+
+public class PrivateLinkInfoTest {
+  @Test
+  void testIsPrivateLinkRedirectWithLoginHtmlAndQueryParamSet() {
+    Response response =
+        new Response(
+            new Request("GET", "https://example.com/login.html")
+                .withQueryParam("error", "private-link-validation-error"),
+            307,
+            "Temporary Redirect",
+            null);
+    assert PrivateLinkInfo.isPrivateLinkRedirect(response) == true;
+  }
+
+  @Test
+  void testIsPrivateLinkRedirectWithLoginHtmlAndQueryParamNotSet() {
+    Response response =
+        new Response(
+            new Request("GET", "https://example.com/login.html"), 307, "Temporary Redirect", null);
+    assert PrivateLinkInfo.isPrivateLinkRedirect(response) == false;
+  }
+
+  @Test
+  void testIsPrivateLinkRedirectNotLoginPage() {
+    Response response =
+        new Response(
+            new Request("GET", "https://example.com/not-login.html"),
+            307,
+            "Temporary Redirect",
+            null);
+    assert PrivateLinkInfo.isPrivateLinkRedirect(response) == false;
+  }
+}


### PR DESCRIPTION
## Changes
1. query returned can be null, however its not handled correctly
2. checking if query is null or not before checking for error code `private-link-validation-error`

## Tests
Unit Tests

