### PR TITLE
[Fix] Make userAgent.toString thread safe

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -123,7 +123,8 @@ public class UserAgent {
       segments.addAll(
               otherInfo.stream()
                       .map(e -> String.format("%s/%s", e.getKey(), e.getValue()))
-                      .collect(Collectors.toSet()));
+                      .collect(Collectors.toSet())
+      );
     }
     return segments.stream().collect(Collectors.joining(" "));
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -119,10 +119,12 @@ public class UserAgent {
     segments.add(String.format("databricks-sdk-java/%s", version));
     segments.add(String.format("jvm/%s", jvmVersion()));
     segments.add(String.format("os/%s", osName()));
-    segments.addAll(
-        otherInfo.stream()
-            .map(e -> String.format("%s/%s", e.getKey(), e.getValue()))
-            .collect(Collectors.toSet()));
+    synchronized (otherInfo) {
+      segments.addAll(
+              otherInfo.stream()
+                      .map(e -> String.format("%s/%s", e.getKey(), e.getValue()))
+                      .collect(Collectors.toSet()));
+    }
     return segments.stream().collect(Collectors.joining(" "));
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -121,10 +121,9 @@ public class UserAgent {
     segments.add(String.format("os/%s", osName()));
     synchronized (otherInfo) {
       segments.addAll(
-              otherInfo.stream()
-                      .map(e -> String.format("%s/%s", e.getKey(), e.getValue()))
-                      .collect(Collectors.toSet())
-      );
+          otherInfo.stream()
+              .map(e -> String.format("%s/%s", e.getKey(), e.getValue()))
+              .collect(Collectors.toSet()));
     }
     return segments.stream().collect(Collectors.joining(" "));
   }


### PR DESCRIPTION
## Changes
- If we try load testing our JDBC driver with parallel `select 1` queries, we get the following stack trace. This PR fixes the issue :
`Caused by: java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1715)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:556)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:546)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:702)
	at com.databricks.sdk.core.UserAgent.asString(UserAgent.java:125)
	at com.databricks.sdk.core.ApiClient.executeInner(ApiClient.java:256)
	at com.databricks.sdk.core.ApiClient.getResponse(ApiClient.java:235)
	at com.databricks.sdk.core.ApiClient.execute(ApiClient.java:227)
	at com.databricks.sdk.core.ApiClient.POST(ApiClient.java:164)
	at com.databricks.jdbc.dbclient.impl.sqlexec.DatabricksSdkClient.createSession(DatabricksSdkClient.java:99)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)`

## Tests
- Locally created a JAR file and the issue is not there now.
