### PR TITLE
[Fix] Fix listAccountMetastoreAssignments Integration test

### DIFF
--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountMetastoreAssignmentsIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountMetastoreAssignmentsIT.java
@@ -33,7 +33,6 @@ public class AccountMetastoreAssignmentsIT {
       @EnvOrSkip("TEST_WORKSPACE_ID") String expectedWorkspaceId) {
     Iterable<Long> list = a.metastoreAssignments().list(metastoreId);
     List<Long> all = CollectionUtils.asList(list);
-    List<Long> expected = Collections.singletonList(Long.valueOf(expectedWorkspaceId));
-    Assertions.assertEquals(expected, all);
+    Assertions.assertTrue(all.contains(Long.valueOf(expectedWorkspaceId)));
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountMetastoreAssignmentsIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountMetastoreAssignmentsIT.java
@@ -6,7 +6,6 @@ import com.databricks.sdk.integration.framework.EnvContext;
 import com.databricks.sdk.integration.framework.EnvOrSkip;
 import com.databricks.sdk.integration.framework.EnvTest;
 import com.databricks.sdk.service.catalog.AccountsMetastoreAssignment;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Currently listAccountMetastoreAssignments test assumes to have a single workspace assigned to a metastore. Updated the test to check if the expected workspace ID is present in the list of metastore assignments instead of asserting equality with the entire list.

## Tests
<!-- How is this tested? -->
Tested Locally
