### PR TITLE
[Internal] Add DCO guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,22 @@ New contributors should look for the following tags when searching for a first c
 
 [good first issue](https://github.com/databricks/databricks-sdk-java/labels/good%20first%20issue)
 
+## Developer Certificate of Origin
+
+To contribute to this repository, you must sign off your commits to certify that you have the right to contribute the code and that it complies with the open source license.
+You can easily do this by adding a "Signed-off-by" line to your commit message to certify your compliance. Please use use your real name as pseudonymous/anonymous contributions are not accepted.
+
+```
+Signed-off-by: Joe Smith <joe.smith@email.com>
+```
+
+If you set your `user.name` and `user.email` git configs, you can sign your commit automatically with git commit -s:
+
+```
+git commit -s -m "Your commit message"
+```
+
+
 ## Contribution Workflow
 
 Code contributions—bug fixes, new development, test improvement—all follow a GitHub-centered workflow. To participate in Databricks Java SDK development, set up a GitHub account. Then:
@@ -43,7 +59,7 @@ Code contributions—bug fixes, new development, test improvement—all follow a
     ```bash
     git add -A
 
-    git commit -m "commit message here"
+    git commit -s -m "commit message here"
     ```
 
 1. Push your changes to your GitHub repo.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,20 @@
+Developer's Certificate of Origin 1.1
+By making a contribution to this project, I certify that:
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
## Changes

This PR update the contributing guidelines to include the DCO (Developer Certificate of Origin) that external contributors must sign-off to contribute.

## Tests

N/A
