### PR TITLE
Refactor DatabricksConfig.getOidcEndpoints to a provider class & Cache oidc endpoints

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
@@ -107,7 +107,8 @@ public class OAuthClient {
     this.hc = b.hc;
 
     DatabricksConfig config = new DatabricksConfig().setHost(b.host).resolve();
-    OpenIDConnectEndpoints oidc = config.getOidcEndpoints();
+    OidcEndpointsProvider odicEndpointsProvider = new OidcEndpointsProvider(config);
+    OpenIDConnectEndpoints oidc = odicEndpointsProvider.getOidcEndpoints();
     if (oidc == null) {
       throw new DatabricksException(b.host + " does not support OAuth");
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthM2MServicePrincipalCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthM2MServicePrincipalCredentialsProvider.java
@@ -1,7 +1,6 @@
 package com.databricks.sdk.core.oauth;
 
 import com.databricks.sdk.core.*;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -12,7 +11,6 @@ import java.util.Map;
  * /oidc/.well-known/oauth-authorization-server is available on the given host.
  */
 public class OAuthM2MServicePrincipalCredentialsProvider implements CredentialsProvider {
-  private final ObjectMapper mapper = new ObjectMapper();
 
   @Override
   public String authType() {
@@ -30,7 +28,8 @@ public class OAuthM2MServicePrincipalCredentialsProvider implements CredentialsP
     // TODO: Azure returns 404 for UC workspace after redirecting to
     // https://login.microsoftonline.com/{cfg.azure_tenant_id}/.well-known/oauth-authorization-server
     try {
-      OpenIDConnectEndpoints jsonResponse = config.getOidcEndpoints();
+      OidcEndpointsProvider provider = new OidcEndpointsProvider(config);
+      OpenIDConnectEndpoints jsonResponse = provider.getOidcEndpoints();
       ClientCredentials tokenSource =
           new ClientCredentials.Builder()
               .withHttpClient(config.getHttpClient())

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OidcEndpointsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OidcEndpointsProvider.java
@@ -1,0 +1,118 @@
+package com.databricks.sdk.core.oauth;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.ConfigLoader;
+import com.databricks.sdk.core.http.Request;
+import com.databricks.sdk.core.http.Response;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Provider of Open ID Connect endpoints from a given Databricks config.
+ */
+class OidcEndpointsProvider {
+
+  private static final Duration CACHE_MAX_STALENESS = Duration.ofMinutes(5);
+
+  // Shorthand for Pair<T, Time>.
+  private static class CacheEntry<T> {
+
+    private T entry;
+    private Instant insertionTime;
+
+    public CacheEntry(T entry, Instant insertionTime) {
+      this.entry = entry;
+      this.insertionTime = insertionTime;
+    }
+
+    public CacheEntry(T entry) {
+      this(entry, Instant.now());
+    }
+
+    public T getEntry() {
+      return this.entry;
+    }
+
+    public Instant getInsertionTime() {
+      return this.insertionTime;
+    }
+
+    public Duration getAge() {
+      return Duration.between(getInsertionTime(), Instant.now());
+    }
+  }
+
+  private static ConcurrentHashMap<String, CacheEntry<OpenIDConnectEndpoints>> cache = new ConcurrentHashMap<>();
+
+  private final DatabricksConfig config;
+
+  public OidcEndpointsProvider(DatabricksConfig config) {
+    this.config = config;
+  }
+
+  public OpenIDConnectEndpoints getOidcEndpoints() throws IOException {
+    if (this.config.getDiscoveryUrl() != null) {
+      return getEndpoints(this.config.getDiscoveryUrl());
+    }
+
+    if (this.config.getHost() == null) {
+      return null;
+    }
+
+    if (this.config.isAzure() && this.config.getAzureClientId() != null) {
+      return fetchAzureEndpoints();
+    }
+
+    if (this.config.isAccountClient() && this.config.getAccountId() != null) {
+      return fetchAccountClientEndpoints();
+    }
+
+    return getEndpoints(this.config.getHost() + "/oidc/.well-known/oauth-authorization-server");
+  }
+
+  private OpenIDConnectEndpoints fetchAccountClientEndpoints() {
+    String prefix = this.config.getHost() + "/oidc/accounts/" + this.config.getAccountId();
+    return new OpenIDConnectEndpoints(prefix + "/v1/token", prefix + "/v1/authorize");
+  }
+
+  private OpenIDConnectEndpoints fetchAzureEndpoints() {
+    OpenIDConnectEndpoints resp = getEndpoints(this.config.getHost()
+        + "/oidc/oauth2/v2.0/authorize");
+    String realAuthUrl = resp.getAuthorizationEndpoint();
+    return new OpenIDConnectEndpoints(realAuthUrl.replaceAll("/authorize", "/token"), realAuthUrl);
+  }
+
+  // Gets the endpoints from the cache or through http request.
+  private OpenIDConnectEndpoints getEndpoints(String url) {
+    return cache.compute(url, (key, val) -> {
+      if (val != null && val.getAge().compareTo(CACHE_MAX_STALENESS) < 0) {
+        return val;
+      }
+
+      return new CacheEntry<OpenIDConnectEndpoints>(makeHttpGetEndpointsRequest(key));
+    }).getEntry();
+  }
+
+  private OpenIDConnectEndpoints makeHttpGetEndpointsRequest(String url) {
+    try {
+      Request request = new Request("GET", url);
+      if (this.config.isAzure()) {
+        request.setRedirectionBehavior(false);
+      }
+      Response resp = this.config.getHttpClient().execute(request);
+      if (resp.getStatusCode() == 200) {
+        return new ObjectMapper().readValue(resp.getBody(),
+            OpenIDConnectEndpoints.class);
+      } else {
+        // LOG some error
+        return null;
+      }
+    } catch (IOException e) {
+      throw ConfigLoader.makeNicerError(e.getMessage(), e, this.config);
+    }
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OpenIDConnectEndpoints.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OpenIDConnectEndpoints.java
@@ -2,7 +2,6 @@ package com.databricks.sdk.core.oauth;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.net.MalformedURLException;
 
 /**
  * Data class modelling the set of OpenID Connect endpoints, as defined in <a
@@ -17,8 +16,7 @@ public class OpenIDConnectEndpoints {
 
   public OpenIDConnectEndpoints(
       @JsonProperty("token_endpoint") String tokenEndpoint,
-      @JsonProperty("authorization_endpoint") String authorizationEndpoint)
-      throws MalformedURLException {
+      @JsonProperty("authorization_endpoint") String authorizationEndpoint) {
     this.tokenEndpoint = tokenEndpoint;
     this.authorizationEndpoint = authorizationEndpoint;
   }


### PR DESCRIPTION
Still WIP but would love to get early feedback before I put more effort into this.

## Changes
- Refactoring getting oidc endpoints out of DatabricksConfig into a spearate provider class
- Adding a static cache for oidc endpoints.

## Tests
WIP will fix/add units tests.
