### PR TITLE
Support configuring a proxy scheme

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ProxyConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ProxyConfig.java
@@ -6,6 +6,7 @@ public class ProxyConfig {
   private String username;
   private String password;
   private ProxyAuthType proxyAuthType;
+  private String scheme;
   private Boolean useSystemProperties;
   // a list of hosts that should be reached directly, bypassing the proxy.
   // This is a list of patterns separated by '|'. The patterns may start or end with a '*' for
@@ -67,6 +68,15 @@ public class ProxyConfig {
 
   public ProxyConfig setProxyAuthType(ProxyAuthType proxyAuthType) {
     this.proxyAuthType = proxyAuthType;
+    return this;
+  }
+
+  public String getScheme() {
+    return scheme;
+  }
+
+  public ProxyConfig setScheme(String scheme) {
+    this.scheme = scheme;
     return this;
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/ProxyUtils.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/utils/ProxyUtils.java
@@ -62,7 +62,7 @@ public class ProxyUtils {
       builder.setRoutePlanner(
           new CustomRoutePlanner(new HttpHost(proxyHost, proxyPort, proxyScheme), config.getNonProxyHosts()));
     }
-    setupProxyAuth(proxyHost, proxyPort, proxyAuthType, proxyUser, proxyPassword, proxyScheme, builder);
+    setupProxyAuth(proxyHost, proxyPort, proxyAuthType, proxyUser, proxyPassword, builder);
   }
 
   /**
@@ -81,12 +81,11 @@ public class ProxyUtils {
       ProxyConfig.ProxyAuthType proxyAuthType,
       String proxyUser,
       String proxyPassword,
-      String proxyScheme,
       HttpClientBuilder builder) {
     if (proxyAuthType == null) {
       return;
     }
-    AuthScope authScope = new AuthScope(proxyHost, proxyPort, null, proxyScheme);
+    AuthScope authScope = new AuthScope(proxyHost, proxyPort);
     switch (proxyAuthType) {
       case NONE:
         break;


### PR DESCRIPTION
## Changes
Motivation here is to support connecting to proxies using `https` scheme not just default `http` which is used in `HttpHost` when no scheme is explicitly provided.

## Tests
Confirmed behaviour by testing a build of JAR locally against a HTTPS proxy.

