### PR TITLE
[Fix] Retry on too many auth requests

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -38,32 +38,32 @@ public class ApiClient {
     private Function<Void, String> getAuthTypeFunc;
 
     public Builder withDatabricksConfig(DatabricksConfig config) {
-        this.config = config;
-        return this;
+      this.config = config;
+      return this;
     }
 
     public Builder withTimer(Timer timer) {
-        this.timer = timer;
-        return this;
+      this.timer = timer;
+      return this;
     }
 
     public Builder withAuthenticateFunc(Function<Void, Map<String, String>> authenticateFunc) {
-        this.authenticateFunc = authenticateFunc;
-        return this;
+      this.authenticateFunc = authenticateFunc;
+      return this;
     }
 
     public Builder withGetHostFunc(Function<Void, String> getHostFunc) {
-        this.getHostFunc = getHostFunc;
-        return this;
+      this.getHostFunc = getHostFunc;
+      return this;
     }
 
     public Builder withGetAuthTypeFunc(Function<Void, String> getAuthTypeFunc) {
-        this.getAuthTypeFunc = getAuthTypeFunc;
-        return this;
+      this.getAuthTypeFunc = getAuthTypeFunc;
+      return this;
     }
 
     public ApiClient build() {
-        return new ApiClient(config, timer, authenticateFunc, getHostFunc, getAuthTypeFunc);
+      return new ApiClient(config, timer, authenticateFunc, getHostFunc, getAuthTypeFunc);
     }
   }
 
@@ -99,10 +99,20 @@ public class ApiClient {
   }
 
   public ApiClient(DatabricksConfig config, Timer timer) {
-    this(config, timer, v -> config.authenticate(), v -> config.getHost(), v -> config.getAuthType());
+    this(
+        config,
+        timer,
+        v -> config.authenticate(),
+        v -> config.getHost(),
+        v -> config.getAuthType());
   }
 
-  public ApiClient(DatabricksConfig config, Timer timer, Function<Void, Map<String, String>> authenticateFunc, Function<Void, String> getHostFunc, Function<Void, String> getAuthTypeFunc) {
+  public ApiClient(
+      DatabricksConfig config,
+      Timer timer,
+      Function<Void, Map<String, String>> authenticateFunc,
+      Function<Void, String> getHostFunc,
+      Function<Void, String> getAuthTypeFunc) {
     this.config = config;
     this.timer = timer;
     this.authenticateFunc = authenticateFunc;
@@ -127,7 +137,7 @@ public class ApiClient {
     httpClient = config.getHttpClient();
     bodyLogger = new BodyLogger(mapper, 1024, debugTruncateBytes);
     retryStrategyPicker = new RequestBasedRetryStrategyPicker(this.config);
-    }
+  }
 
   private static <I> void setQuery(Request in, I entity) {
     if (entity == null) {
@@ -305,7 +315,7 @@ public class ApiClient {
       String authType = getAuthTypeFunc.apply(null);
       String userAgent = UserAgent.asString();
       if (authType != "") {
-          userAgent += String.format(" auth/%s", authType);
+        userAgent += String.format(" auth/%s", authType);
       }
       in.withHeader("User-Agent", userAgent);
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -320,9 +320,9 @@ public class ApiClient {
 
       // Set User-Agent with auth type info, which is available only
       // after the first invocation to config.authenticate()
-      String authType = getAuthTypeFunc.apply(null);
       String userAgent = UserAgent.asString();
-      if (authType != "") {
+      if (getAuthTypeFunc != null) {
+        String authType = getAuthTypeFunc.apply(null);
         userAgent += String.format(" auth/%s", authType);
       }
       in.withHeader("User-Agent", userAgent);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * guessing
  */
 public class ApiClient {
-  static class Builder {
+  public static class Builder {
     private Timer timer;
     private Function<Void, Map<String, String>> authenticateFunc;
     private Function<Void, String> getHostFunc;
@@ -45,8 +45,8 @@ public class ApiClient {
       this.authenticateFunc = v -> config.authenticate();
       this.getHostFunc = v -> config.getHost();
       this.getAuthTypeFunc = v -> config.getAuthType();
-      this.debugTruncateBytes = config.getDebugTruncateBytes();
       this.httpClient = config.getHttpClient();
+      this.debugTruncateBytes = config.getDebugTruncateBytes();
       this.accountId = config.getAccountId();
       this.retryStrategyPicker = new RequestBasedRetryStrategyPicker(config.getHost());
       this.isDebugHeaders = config.isDebugHeaders();
@@ -267,6 +267,8 @@ public class ApiClient {
     } else if (InputStream.class.isAssignableFrom(in.getClass())) {
       InputStream body = (InputStream) in;
       return new Request(method, path, body);
+    } else if (in instanceof String) {
+      return new Request(method, path, (String) in);
     } else {
       String body = serialize(in);
       return new Request(method, path, body);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -582,15 +582,19 @@ public class DatabricksConfig {
       return new OpenIDConnectEndpoints(prefix + "/v1/token", prefix + "/v1/authorize");
     }
 
-    ApiClient apiClient = new ApiClient.Builder()
-      .withDatabricksConfig(this)
-      .withTimer(new SystemTimer())
-      .withAuthenticateFunc(v -> new HashMap<String, String>())
-      .withGetHostFunc(v -> getHost())
-      .withGetAuthTypeFunc(v -> "")
-      .build();
+    ApiClient apiClient =
+        new ApiClient.Builder()
+            .withDatabricksConfig(this)
+            .withTimer(new SystemTimer())
+            .withAuthenticateFunc(v -> new HashMap<String, String>())
+            .withGetHostFunc(v -> getHost())
+            .withGetAuthTypeFunc(v -> "")
+            .build();
 
-    return apiClient.GET("/oidc/.well-known/oauth-authorization-server", OpenIDConnectEndpoints.class, new HashMap<>());
+    return apiClient.GET(
+        "/oidc/.well-known/oauth-authorization-server",
+        OpenIDConnectEndpoints.class,
+        new HashMap<>());
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -584,13 +584,9 @@ public class DatabricksConfig {
 
     ApiClient apiClient =
         new ApiClient.Builder()
-            .withDatabricksConfig(this)
-            .withTimer(new SystemTimer())
-            .withAuthenticateFunc(v -> new HashMap<String, String>())
+            .withHttpClient(getHttpClient())
             .withGetHostFunc(v -> getHost())
-            .withGetAuthTypeFunc(v -> "")
             .build();
-
     return apiClient.GET(
         "/oidc/.well-known/oauth-authorization-server",
         OpenIDConnectEndpoints.class,

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -7,7 +7,6 @@ import com.databricks.sdk.core.http.Response;
 import com.databricks.sdk.core.oauth.OpenIDConnectEndpoints;
 import com.databricks.sdk.core.utils.Cloud;
 import com.databricks.sdk.core.utils.Environment;
-import com.databricks.sdk.core.utils.SystemTimer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/http/FormRequest.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/http/FormRequest.java
@@ -8,15 +8,15 @@ public class FormRequest extends Request {
   }
 
   public FormRequest(String method, String url, Map<String, String> form) {
-    super(method, url, mapToQuery(wrapValuesInList(form)));
+    super(method, url, wrapValuesInList(form));
     withHeader("Content-Type", "application/x-www-form-urlencoded");
   }
 
-  static Map<String, List<String>> wrapValuesInList(Map<String, String> map) {
+  public static String wrapValuesInList(Map<String, String> map) {
     Map<String, List<String>> m = new LinkedHashMap<>();
     for (Map.Entry<String, String> entry : map.entrySet()) {
       m.put(entry.getKey(), Collections.singletonList(entry.getValue()));
     }
-    return m;
+    return mapToQuery(m);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OpenIDConnectEndpoints.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OpenIDConnectEndpoints.java
@@ -11,9 +11,14 @@ import java.net.MalformedURLException;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OpenIDConnectEndpoints {
+  @JsonProperty("token_endpoint")
   private String tokenEndpoint;
 
+  @JsonProperty("authorization_endpoint")
   private String authorizationEndpoint;
+
+  public OpenIDConnectEndpoints() {
+  }
 
   public OpenIDConnectEndpoints(
       @JsonProperty("token_endpoint") String tokenEndpoint,

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OpenIDConnectEndpoints.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OpenIDConnectEndpoints.java
@@ -17,8 +17,7 @@ public class OpenIDConnectEndpoints {
   @JsonProperty("authorization_endpoint")
   private String authorizationEndpoint;
 
-  public OpenIDConnectEndpoints() {
-  }
+  public OpenIDConnectEndpoints() {}
 
   public OpenIDConnectEndpoints(
       @JsonProperty("token_endpoint") String tokenEndpoint,

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
@@ -4,8 +4,6 @@ import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.core.http.FormRequest;
 import com.databricks.sdk.core.http.HttpClient;
-import com.databricks.sdk.core.retry.RequestBasedRetryStrategyPicker;
-import com.databricks.sdk.core.utils.SystemTimer;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -64,15 +62,7 @@ public abstract class RefreshableTokenSource implements TokenSource {
     }
     headers.put("Content-Type", "application/x-www-form-urlencoded");
     try {
-      ApiClient apiClient =
-          new ApiClient.Builder()
-              .withHttpClient(hc)
-              .withTimer(new SystemTimer())
-              .withAuthenticateFunc(v -> headers)
-              .withGetAuthTypeFunc(v -> "")
-              .withGetHostFunc(v -> "")
-              .withRetryStrategyPicker(new RequestBasedRetryStrategyPicker(""))
-              .build();
+      ApiClient apiClient = new ApiClient.Builder().withHttpClient(hc).build();
 
       OAuthResponse resp =
           apiClient.POST(

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
@@ -1,11 +1,11 @@
 package com.databricks.sdk.core.oauth;
 
+import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.core.http.FormRequest;
 import com.databricks.sdk.core.http.HttpClient;
-import com.databricks.sdk.core.http.Response;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
+import com.databricks.sdk.core.retry.RequestBasedRetryStrategyPicker;
+import com.databricks.sdk.core.utils.SystemTimer;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -62,17 +62,27 @@ public abstract class RefreshableTokenSource implements TokenSource {
         headers.put(HttpHeaders.AUTHORIZATION, authHeaderValue);
         break;
     }
-    FormRequest req = new FormRequest(tokenUrl, params);
-    req.withHeaders(headers);
+    headers.put("Content-Type", "application/x-www-form-urlencoded");
     try {
-      Response rawResp = hc.execute(req);
-      OAuthResponse resp = new ObjectMapper().readValue(rawResp.getBody(), OAuthResponse.class);
+      ApiClient apiClient =
+          new ApiClient.Builder()
+              .withHttpClient(hc)
+              .withTimer(new SystemTimer())
+              .withAuthenticateFunc(v -> headers)
+              .withGetAuthTypeFunc(v -> "")
+              .withGetHostFunc(v -> "")
+              .withRetryStrategyPicker(new RequestBasedRetryStrategyPicker(""))
+              .build();
+
+      OAuthResponse resp =
+          apiClient.POST(
+              tokenUrl, FormRequest.wrapValuesInList(params), OAuthResponse.class, headers);
       if (resp.getErrorCode() != null) {
         throw new IllegalArgumentException(resp.getErrorCode() + ": " + resp.getErrorSummary());
       }
       LocalDateTime expiry = LocalDateTime.now().plus(resp.getExpiresIn(), ChronoUnit.SECONDS);
       return new Token(resp.getAccessToken(), resp.getTokenType(), resp.getRefreshToken(), expiry);
-    } catch (IOException e) {
+    } catch (Exception e) {
       throw new DatabricksException("Failed to refresh credentials: " + e.getMessage(), e);
     }
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/retry/RequestBasedRetryStrategyPicker.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/retry/RequestBasedRetryStrategyPicker.java
@@ -1,6 +1,5 @@
 package com.databricks.sdk.core.retry;
 
-import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.core.http.Request;
 import java.util.AbstractMap;
 import java.util.Arrays;
@@ -44,8 +43,7 @@ public class RequestBasedRetryStrategyPicker implements RetryStrategyPicker {
                 request ->
                     new AbstractMap.SimpleEntry<>(
                         request.getMethod(),
-                        Pattern.compile(
-                            host + request.getUrl(), Pattern.CASE_INSENSITIVE)))
+                        Pattern.compile(host + request.getUrl(), Pattern.CASE_INSENSITIVE)))
             .collect(Collectors.toList());
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/retry/RequestBasedRetryStrategyPicker.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/retry/RequestBasedRetryStrategyPicker.java
@@ -37,7 +37,7 @@ public class RequestBasedRetryStrategyPicker implements RetryStrategyPicker {
   private static final IdempotentRequestRetryStrategy IDEMPOTENT_RETRY_STRATEGY =
       new IdempotentRequestRetryStrategy();
 
-  public RequestBasedRetryStrategyPicker(DatabricksConfig config) {
+  public RequestBasedRetryStrategyPicker(String host) {
     this.idempotentRequestsPattern =
         IDEMPOTENT_REQUESTS.stream()
             .map(
@@ -45,7 +45,7 @@ public class RequestBasedRetryStrategyPicker implements RetryStrategyPicker {
                     new AbstractMap.SimpleEntry<>(
                         request.getMethod(),
                         Pattern.compile(
-                            config.getHost() + request.getUrl(), Pattern.CASE_INSENSITIVE)))
+                            host + request.getUrl(), Pattern.CASE_INSENSITIVE)))
             .collect(Collectors.toList());
   }
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthLoadTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthLoadTest.java
@@ -1,0 +1,73 @@
+// These are auto-generated tests for Unified Authentication
+// In case of editing this file, make sure the change is propagated to all Databricks SDK codebases
+
+package com.databricks.sdk;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.databricks.sdk.core.ConfigResolving;
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.commons.CommonsHttpClient;
+import com.databricks.sdk.core.utils.GitHubUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import org.junit.jupiter.api.Test;
+
+public class DatabricksAuthLoadTest implements GitHubUtils, ConfigResolving {
+
+  public void testConcurrentConfigBasicAuthAttrs() throws Exception {
+    int numThreads = 200;
+    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+    List<Future<Boolean>> futures = new ArrayList<>();
+    int successCount = 0;
+    int failureCount = 0;
+
+    Callable<Boolean> task =
+        () -> {
+          try {
+            DatabricksConfig config =
+                new DatabricksConfig()
+                    .setHost("https://dbc-bb03964f-3f59.cloud.databricks.com")
+                    .setClientId("<<REDACTED>>")
+                    .setClientSecret("<<REDACTED>>");
+
+            config.setHttpClient(new CommonsHttpClient.Builder().withTimeoutSeconds(30).build());
+            config.authenticate();
+
+            assertEquals("oauth-m2m", config.getAuthType());
+
+            return true;
+          } catch (Exception e) {
+            System.err.println(
+                "DatabricksException occurred in thread " + Thread.currentThread().getName());
+            e.printStackTrace();
+            return false;
+          }
+        };
+
+    for (int i = 0; i < numThreads; i++) {
+      futures.add(executorService.submit(task));
+    }
+
+    executorService.shutdown();
+    if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+      executorService.shutdownNow();
+    }
+
+    for (Future<Boolean> future : futures) {
+      if (future.get()) {
+        successCount++;
+      } else {
+        failureCount++;
+      }
+    }
+
+    // Log the results
+    System.out.println("Number of successful threads: " + successCount);
+    System.out.println("Number of failed threads: " + failureCount);
+
+    // Optionally, you can assert that there were no failures
+    assertEquals(0, failureCount);
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthLoadTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthLoadTest.java
@@ -1,6 +1,3 @@
-// These are auto-generated tests for Unified Authentication
-// In case of editing this file, make sure the change is propagated to all Databricks SDK codebases
-
 package com.databricks.sdk;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/benchmark/DatabricksAuthLoadTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/benchmark/DatabricksAuthLoadTest.java
@@ -2,12 +2,6 @@ package com.databricks.sdk.benchmark;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.databricks.sdk.core.ConfigResolving;
-import com.databricks.sdk.core.DatabricksConfig;
-import com.databricks.sdk.core.commons.CommonsHttpClient;
-import com.databricks.sdk.core.utils.GitHubUtils;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.*;
 
 /*
@@ -16,9 +10,11 @@ import java.util.concurrent.*;
  Now that these endpoints are configured to retry upon receiving a 429 error, the test runs successfully.
  However, since this test generates a large number of requests, it should be run manually rather than being included in CI processes.
 */
+/*
 public class DatabricksAuthLoadTest implements GitHubUtils, ConfigResolving {
 
-  // @Test
+  @Test
+  @Disabled
   public void testConcurrentConfigBasicAuthAttrs() throws Exception {
     int numThreads = 200;
     ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
@@ -74,3 +70,4 @@ public class DatabricksAuthLoadTest implements GitHubUtils, ConfigResolving {
     assertEquals(0, failureCount);
   }
 }
+*/

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/benchmark/DatabricksAuthLoadTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/benchmark/DatabricksAuthLoadTest.java
@@ -1,4 +1,4 @@
-package com.databricks.sdk;
+package com.databricks.sdk.benchmark;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -9,10 +9,16 @@ import com.databricks.sdk.core.utils.GitHubUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
-import org.junit.jupiter.api.Test;
 
+/*
+ This test executes the authentication workflow 200 times concurrently and verifies that all 200 runs complete successfully.
+ It is designed to address a previously observed issue where multiple SDK operations needed to authenticate, causing the OIDC endpoints to rate-limit the requests.
+ Now that these endpoints are configured to retry upon receiving a 429 error, the test runs successfully.
+ However, since this test generates a large number of requests, it should be run manually rather than being included in CI processes.
+*/
 public class DatabricksAuthLoadTest implements GitHubUtils, ConfigResolving {
 
+  // @Test
   public void testConcurrentConfigBasicAuthAttrs() throws Exception {
     int numThreads = 200;
     ExecutorService executorService = Executors.newFixedThreadPool(numThreads);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -104,24 +104,20 @@ public class DatabricksConfigTest {
   @Test
   public void testWorkspaceLevelOidcEndpointsRetries() throws IOException {
     try (FixtureServer server =
-                 new FixtureServer()
-                         .with(
-                                 "GET",
-                                 "/oidc/.well-known/oauth-authorization-server",
-                                 "",
-                                 429)
-                         .with(
-                                 "GET",
-                                 "/oidc/.well-known/oauth-authorization-server",
-                                 "{\"authorization_endpoint\":\"https://test-workspace.cloud.databricks.com/oidc/v1/authorize\"}",
-                                 200)) {
+        new FixtureServer()
+            .with("GET", "/oidc/.well-known/oauth-authorization-server", "", 429)
+            .with(
+                "GET",
+                "/oidc/.well-known/oauth-authorization-server",
+                "{\"authorization_endpoint\":\"https://test-workspace.cloud.databricks.com/oidc/v1/authorize\"}",
+                200)) {
       DatabricksConfig c =
-              new DatabricksConfig().setHost(server.getUrl()).setAccountId("1234567890");
+          new DatabricksConfig().setHost(server.getUrl()).setAccountId("1234567890");
       c.resolve(
-              new Environment(new HashMap<>(), new ArrayList<String>(), System.getProperty("os.name")));
+          new Environment(new HashMap<>(), new ArrayList<String>(), System.getProperty("os.name")));
       assertEquals(
-              c.getOidcEndpoints().getAuthorizationEndpoint(),
-              "https://test-workspace.cloud.databricks.com/oidc/v1/authorize");
+          c.getOidcEndpoints().getAuthorizationEndpoint(),
+          "https://test-workspace.cloud.databricks.com/oidc/v1/authorize");
     }
   }
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -102,6 +102,30 @@ public class DatabricksConfigTest {
   }
 
   @Test
+  public void testWorkspaceLevelOidcEndpointsRetries() throws IOException {
+    try (FixtureServer server =
+                 new FixtureServer()
+                         .with(
+                                 "GET",
+                                 "/oidc/.well-known/oauth-authorization-server",
+                                 "",
+                                 429)
+                         .with(
+                                 "GET",
+                                 "/oidc/.well-known/oauth-authorization-server",
+                                 "{\"authorization_endpoint\":\"https://test-workspace.cloud.databricks.com/oidc/v1/authorize\"}",
+                                 200)) {
+      DatabricksConfig c =
+              new DatabricksConfig().setHost(server.getUrl()).setAccountId("1234567890");
+      c.resolve(
+              new Environment(new HashMap<>(), new ArrayList<String>(), System.getProperty("os.name")));
+      assertEquals(
+              c.getOidcEndpoints().getAuthorizationEndpoint(),
+              "https://test-workspace.cloud.databricks.com/oidc/v1/authorize");
+    }
+  }
+
+  @Test
   public void testAccountLevelOidcEndpoints() throws IOException {
     assertEquals(
         new DatabricksConfig()

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -89,7 +89,8 @@ public class DatabricksConfigTest {
             .with(
                 "GET",
                 "/oidc/.well-known/oauth-authorization-server",
-                "{\"authorization_endpoint\":\"https://test-workspace.cloud.databricks.com/oidc/v1/authorize\"}")) {
+                "{\"authorization_endpoint\":\"https://test-workspace.cloud.databricks.com/oidc/v1/authorize\"}",
+                200)) {
       DatabricksConfig c =
           new DatabricksConfig().setHost(server.getUrl()).setAccountId("1234567890");
       c.resolve(
@@ -121,7 +122,7 @@ public class DatabricksConfigTest {
             + "}";
 
     try (FixtureServer server =
-        new FixtureServer().with("GET", discoveryUrlSuffix, discoveryUrlResponse)) {
+        new FixtureServer().with("GET", discoveryUrlSuffix, discoveryUrlResponse, 200)) {
 
       String discoveryUrl = server.getUrl() + discoveryUrlSuffix;
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/FixtureServer.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/FixtureServer.java
@@ -123,7 +123,8 @@ public class FixtureServer implements Closeable {
                 v.validate(exchange);
               }
             };
-        return new FixtureMapping(validation, response, redirectUrl, redirectStatusCode, statusCode);
+        return new FixtureMapping(
+            validation, response, redirectUrl, redirectStatusCode, statusCode);
       }
     }
 
@@ -139,7 +140,11 @@ public class FixtureServer implements Closeable {
     }
 
     FixtureMapping(
-        Validation validation, String response, String redirectUrl, int redirectStatusCode, int statusCode) {
+        Validation validation,
+        String response,
+        String redirectUrl,
+        int redirectStatusCode,
+        int statusCode) {
       this.validation = validation;
       this.response = response;
       this.redirectUrl = redirectUrl;
@@ -226,7 +231,8 @@ public class FixtureServer implements Closeable {
       respond(exchange, 500, body);
     }
 
-    private void respondSuccess(HttpExchange exchange, String body, int statusCode) throws IOException {
+    private void respondSuccess(HttpExchange exchange, String body, int statusCode)
+        throws IOException {
       respond(exchange, statusCode, body);
     }
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/commons/CommonsHttpClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/commons/CommonsHttpClientTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 class CommonsHttpClientTest {
   @Test
   public void itWorks() throws IOException {
-    try (FixtureServer fixtures = new FixtureServer().with("GET", "/foo?x=y", "bar")) {
+    try (FixtureServer fixtures = new FixtureServer().with("GET", "/foo?x=y", "bar", 200)) {
       HttpClient httpClient = new CommonsHttpClient.Builder().withTimeoutSeconds(30).build();
       Request in = new Request("GET", fixtures.getUrl() + "/foo").withQueryParam("x", "y");
       Response out = httpClient.execute(in);
@@ -34,7 +34,7 @@ class CommonsHttpClientTest {
             .validateHeadersPresent(
                 Collections.singletonMap("Content-Length", Collections.singletonList("3")))
             .validateHeadersAbsent(Collections.singletonList("Transfer-Encoding"))
-            .withResponse("quux")
+            .withResponse("quux", 200)
             .build();
     try (FixtureServer fixtures = new FixtureServer().with(fixture)) {
       HttpClient httpClient = new CommonsHttpClient.Builder().withTimeoutSeconds(30).build();
@@ -55,7 +55,7 @@ class CommonsHttpClientTest {
             .validateHeadersPresent(
                 Collections.singletonMap("Transfer-Encoding", Collections.singletonList("chunked")))
             .validateHeadersAbsent(Collections.singletonList("Content-Length"))
-            .withResponse("quux")
+            .withResponse("quux", 200)
             .build();
     try (FixtureServer fixtures = new FixtureServer().with(fixture)) {
       HttpClient httpClient = new CommonsHttpClient.Builder().withTimeoutSeconds(30).build();
@@ -102,7 +102,7 @@ class CommonsHttpClientTest {
             new FixtureServer.FixtureMapping.Builder()
                 .validatePath("/login.html?error=private-link-validation-error")
                 .validateMethod("GET")
-                .withResponse("login page")
+                .withResponse("login page", 200)
                 .build());
 
     try (FixtureServer server = new FixtureServer().with(fixtures)) {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
@@ -26,7 +26,7 @@ public class ExternalBrowserCredentialsProviderTest {
         new FixtureServer.FixtureMapping.Builder()
             .validateMethod("GET")
             .validatePath("/oidc/.well-known/oauth-authorization-server")
-            .withResponse("{\"token_endpoint\": \"tokenEndPointFromServer\"}")
+            .withResponse("{\"token_endpoint\": \"tokenEndPointFromServer\"}", 200)
             .build();
     try (FixtureServer fixtures = new FixtureServer()) {
       fixtures.with(fixture).with(fixture);
@@ -61,7 +61,7 @@ public class ExternalBrowserCredentialsProviderTest {
         new FixtureServer.FixtureMapping.Builder()
             .validateMethod("GET")
             .validatePath("/oidc/.well-known/oauth-authorization-server")
-            .withResponse("{\"token_endpoint\": \"tokenEndPointFromServer\"}")
+            .withResponse("{\"token_endpoint\": \"tokenEndPointFromServer\"}", 200)
             .build();
     try (FixtureServer fixtures = new FixtureServer()) {
       fixtures.with(fixture).with(fixture);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/retry/RequestBasedRetryStrategyPickerTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/retry/RequestBasedRetryStrategyPickerTest.java
@@ -9,7 +9,7 @@ public class RequestBasedRetryStrategyPickerTest {
   private static final String TEST_URL = "https://test.com";
   private static final DatabricksConfig CONFIG = new DatabricksConfig().setHost(TEST_URL);
   private static final RetryStrategyPicker RETRY_STRATEGY_PICKER =
-      new RequestBasedRetryStrategyPicker(CONFIG);
+      new RequestBasedRetryStrategyPicker(CONFIG.getHost());
 
   @Test
   public void testGetRetryStrategy() {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR addresses an issue encountered during authentication, where the server returns a 429 status code when fetching OIDC endpoints from a well-known location, particularly during frequent authentication requests. The update introduces a retry mechanism within the auth flow to mitigate the impact of 429 errors.

Modified `ApiClient` object construction to allow unauthenticated calls by including authentication function injection, where within the OIDC workflow act as no-op actions. `DatabricksConfig` would now instantiate an `ApiClient` instead of a standard `CommonsHttpClient` in these cases.
errors during a complete authentication workflow, especially under high concurrent request conditions.

## Tests
<!-- How is this tested? -->
* Added unit tests to verify the retry functionality upon encountering a 429 response.
* Included a manual test to simulate real-world scenarios, ensuring the retry mechanism effectively handles 429 
