### PR TITLE
[Internal] Add a run-integration-tests profile that skips unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,21 @@
   </reporting>
   <profiles>
     <profile>
+      <id>run-integration-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.1.2</version>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>release</id>
       <build>
         <plugins>


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR adds another profile in `pom.xml` to allow us to skip unit tests in our nightly integration test workflow.

## Tests
<!-- How is this tested? -->

