### PR TITLE
[Feature] Experimental: Make retry strategy configurable

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/commons/CommonsHttpClient.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.*;
+import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.*;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
@@ -47,6 +48,7 @@ public class CommonsHttpClient implements HttpClient {
     private ProxyConfig proxyConfig;
     private SSLConnectionSocketFactory sslSocketFactory;
     private PoolingHttpClientConnectionManager connectionManager;
+    private HttpRequestRetryHandler requestRetryHandler;
 
     /**
      * @param databricksConfig The DatabricksConfig to use for the HttpClient. If the
@@ -96,6 +98,17 @@ public class CommonsHttpClient implements HttpClient {
       return this;
     }
 
+    /**
+     * @param requestRetryHandler the HttpRequestRetryHandler to use for the HttpClient.
+     * @return This builder.
+     *     <p><b>Note:</b> This API is experimental and may change or be removed in future releases
+     *     without notice.
+     */
+    public Builder withRequestRetryHandler(HttpRequestRetryHandler requestRetryHandler) {
+      this.requestRetryHandler = requestRetryHandler;
+      return this;
+    }
+
     /** Builds a new instance of CommonsHttpClient with the configured parameters. */
     public CommonsHttpClient build() {
       return new CommonsHttpClient(this);
@@ -130,6 +143,9 @@ public class CommonsHttpClient implements HttpClient {
           new PoolingHttpClientConnectionManager();
       connectionManager.setMaxTotal(100);
       httpClientBuilder.setConnectionManager(connectionManager);
+    }
+    if (builder.requestRetryHandler != null) {
+      httpClientBuilder.setRetryHandler(builder.requestRetryHandler);
     }
     hc = httpClientBuilder.build();
   }


### PR DESCRIPTION
Adds support to configure Retry Strategy in HttpClient. Currently only the default retry strategy is used. This strategy retries 3 times and does not have any sleep interval in between. For our use case, we would prefer using the ExponentialBackOffStrategy.

This does not affect the default behavior but gives additional options to the users.