### PR TITLE
[Fix] Fix Ubuntu unit tests on Github Actions

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
@@ -19,10 +19,13 @@ public class AzureCliCredentialsProvider implements CredentialsProvider {
   }
 
   public CliTokenSource tokenSourceFor(DatabricksConfig config, String resource) {
+    String azPath =
+        Optional.ofNullable(config.getEnv()).map(env -> env.get("AZ_PATH")).orElse("az");
+
     List<String> cmd =
         new ArrayList<>(
             Arrays.asList(
-                "az", "account", "get-access-token", "--resource", resource, "--output", "json"));
+                azPath, "account", "get-access-token", "--resource", resource, "--output", "json"));
     Optional<String> subscription = getSubscription(config);
     if (subscription.isPresent()) {
       // This will fail if the user has access to the workspace, but not to the subscription

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
@@ -13,7 +13,8 @@ public class DatabricksAuthManualTest implements ConfigResolving {
     StaticEnv env =
         new StaticEnv()
             .with("HOME", TestOSUtils.resource("/testdata/azure"))
-            .with("PATH", "testdata:/bin");
+            .with("PATH", "/bin:testdata")
+            .with("AZ_PATH", TestOSUtils.resource("/testdata/az"));
     String azureWorkspaceResourceId =
         "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
     DatabricksConfig config =
@@ -32,7 +33,8 @@ public class DatabricksAuthManualTest implements ConfigResolving {
     StaticEnv env =
         new StaticEnv()
             .with("HOME", TestOSUtils.resource("/testdata/azure"))
-            .with("PATH", "testdata:/bin");
+            .with("PATH", "/bin:testdata")
+            .with("AZ_PATH", TestOSUtils.resource("/testdata/az"));
     String azureWorkspaceResourceId =
         "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
     DatabricksConfig config =
@@ -50,7 +52,8 @@ public class DatabricksAuthManualTest implements ConfigResolving {
     StaticEnv env =
         new StaticEnv()
             .with("HOME", TestOSUtils.resource("/testdata/azure"))
-            .with("PATH", "testdata:/bin")
+            .with("PATH", "/bin:testdata")
+            .with("AZ_PATH", TestOSUtils.resource("/testdata/az"))
             .with("FAIL_IF", "https://management.core.windows.net/");
     String azureWorkspaceResourceId =
         "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/TestOSUtils.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/utils/TestOSUtils.java
@@ -28,6 +28,15 @@ public class TestOSUtils {
     if (resource == null) {
       fail("Asset not found: " + file);
     }
-    return resource.getFile();
+
+    String filePath = resource.getFile();
+    File f = new File(filePath);
+
+    // Make the file executable
+    if (!f.setExecutable(true)) {
+      fail("Failed to set the file as executable: " + file);
+    }
+
+    return filePath;
   }
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
About a week ago, unit tests running on `ubuntu-latest` started failing, likely due to a new version of 22.04 being rolled out. As a result, the actual Azure CLI was getting executed instead of the stubbed version during tests. This PR fixes that by making sure the unit tests directly target the stubbed CLI.

## Tests
<!-- How is this tested? -->

