### PR TITLE
[Fix] Change Auth method log to debug instead of info

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
@@ -58,12 +58,12 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
       if (config.getAuthType() != null
           && !config.getAuthType().isEmpty()
           && !provider.authType().equals(config.getAuthType())) {
-        LOG.info(
+        LOG.debug(
             "Ignoring {} auth, because {} is preferred", provider.authType(), config.getAuthType());
         continue;
       }
       try {
-        LOG.info("Trying {} auth", provider.authType());
+        LOG.debug("Trying {} auth", provider.authType());
         HeaderFactory headerFactory = provider.configure(config);
         if (headerFactory == null) {
           continue;


### PR DESCRIPTION
Change info log line about Auth method to debug to avoid spamming the log file. Currently this is the only log in the sdk that directly writes to info 

![image](https://github.com/user-attachments/assets/01473743-e79a-4112-a99b-f19e3bbc44f9)


## Tests
not tested

Signed-off-by: Ashraf Saleh <a.saleh@celonis.com>
