### PR TITLE
[Fix] Fix vulnerabilities in the present SDK version

### DIFF
--- a/databricks-sdk-java/pom.xml
+++ b/databricks-sdk-java/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.databricks</groupId>
@@ -49,9 +49,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.ini4j</groupId>
-      <artifactId>ini4j</artifactId>
-      <version>0.5.4</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+      <version>2.11.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.13.0</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/databricks-sdk-java/pom.xml
+++ b/databricks-sdk-java/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.databricks</groupId>

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigLoader.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigLoader.java
@@ -59,8 +59,7 @@ public class ConfigLoader {
         accessor.setValueOnConfig(cfg, env);
       }
     } catch (DatabricksException e) {
-      String msg =
-              String.format("%s auth: %s", cfg.getCredentialsProvider().authType(), e.getMessage());
+      String msg = String.format("%s auth: %s", cfg.getCredentialsProvider().authType(), e.getMessage());
       throw new DatabricksException(msg, e);
     }
   }
@@ -89,6 +88,7 @@ public class ConfigLoader {
 
     INIConfiguration ini = parseDatabricksCfg(configFile, isDefaultConfig);
     if (ini == null) return;
+
     String profile = cfg.getProfile();
     boolean hasExplicitProfile = !isNullOrEmpty(profile);
     if (!hasExplicitProfile) {
@@ -166,22 +166,18 @@ public class ConfigLoader {
       }
       if (authSet.size() <= 1) return;
       String names = String.join(" and ", authSet);
-      throw new DatabricksException(
-              String.format("validate: more than one authorization method configured: %s", names));
+      throw new DatabricksException(String.format("validate: more than one authorization method configured: %s", names));
     } catch (IllegalAccessException e) {
       throw new DatabricksException("Cannot create default config", e);
     }
   }
 
-  public static DatabricksException makeNicerError(
-          String message, Exception e, DatabricksConfig cfg) {
+  public static DatabricksException makeNicerError(String message, Exception e, DatabricksConfig cfg) {
     return makeNicerError(message, e, 200, cfg);
   }
 
-  public static DatabricksException makeNicerError(
-          String message, Exception e, Integer statusCode, DatabricksConfig cfg) {
-    boolean isHttpUnauthorizedOrForbidden =
-            true; // TODO - pass status code with exception, default this to false
+  public static DatabricksException makeNicerError(String message, Exception e, Integer statusCode, DatabricksConfig cfg) {
+    boolean isHttpUnauthorizedOrForbidden = true; // TODO - pass status code with exception, default this to false
     if (statusCode == 401 || statusCode == 402) isHttpUnauthorizedOrForbidden = true;
     String debugString = "";
     if (cfg.getEnv() != null) {
@@ -231,12 +227,12 @@ public class ConfigLoader {
       if (!attrsUsed.isEmpty()) {
         buf.add(String.format("Config: %s", String.join(", ", attrsUsed)));
       } else {
-        buf.add(String.format("Config: <empty>"));
+        buf.add("Config: <empty>");
       }
       if (!envsUsed.isEmpty()) {
         buf.add(String.format("Env: %s", String.join(", ", envsUsed)));
       } else {
-        buf.add(String.format("Env: <none>"));
+        buf.add("Env: <none>");
       }
       return String.join(". ", buf);
     } catch (IllegalAccessException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.databricks</groupId>
   <artifactId>databricks-sdk-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.databricks</groupId>
   <artifactId>databricks-sdk-parent</artifactId>


### PR DESCRIPTION
## What changes are proposed in this pull request?

- **What** : 
  - Update commons.io to fix the [CVE in the present version](https://mvnrepository.com/artifact/com.databricks/databricks-sdk-java/0.34.0). Looks like depandabot PRs are no longer being created/merged. [[Link](https://github.com/databricks/databricks-sdk-java/pull/261/files)]
  - Change ini4j configuration because of vulnerability.

- **Why** 
  - ini4j 0.5.4 version has an infinite loop situation in the following piece of code. This loop can cause excessive memory and CPU usage, potentially crashing the application. Alternate libraries like Apache Commons Configuration gracefully handle the situation (by limiting the recursions internally). I will raise a PR on SDK later today to replace the ini4j library. Moreover : the official site of ini4j [is up for sale](http://www.ini4j.org/) and the last update to this maven package was done in [2015](https://mvnrepository.com/artifact/org.ini4j/ini4j). There is no reason we should continue to use this package.

```
Ini ini = new Ini();
  ini.load(new ByteArrayInputStream("""
      [deploy]
      a = ${test/a}
      b = ${doc/b}
              
      [test]
      a = ${deploy/a}
      b = ${deploy/b}
              
      [doc]
      a = 15
      b = 45
      """.getBytes(StandardCharsets.UTF_8)));
  
  // Will cause stack overflow
  ini.get("deploy").fetch("a");
```

## How is this tested?

- The existing unit tests run fine.