### PR TITLE
[Release] Release v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Version changelog
 
+## [Release] Release v0.37.0
+
+### Internal Changes
+
+ * Update SDK to OpenAPI spec ([#389](https://github.com/databricks/databricks-sdk-java/pull/389)).
+
+
+### API Changes:
+
+ * Added `com.databricks.sdk.service.cleanrooms` package.
+ * Added `delete()` method for `workspaceClient.aibiDashboardEmbeddingAccessPolicy()` service.
+ * Added `delete()` method for `workspaceClient.aibiDashboardEmbeddingApprovedDomains()` service.
+ * Added `databricksGcpServiceAccount` field for `com.databricks.sdk.service.catalog.CreateCredentialRequest`.
+ * Added `databricksGcpServiceAccount` field for `com.databricks.sdk.service.catalog.CredentialInfo`.
+ * Added `gcpOptions` field for `com.databricks.sdk.service.catalog.GenerateTemporaryServiceCredentialRequest`.
+ * Added `databricksGcpServiceAccount` field for `com.databricks.sdk.service.catalog.UpdateCredentialRequest`.
+ * Added `cachedQuerySchema` field for `com.databricks.sdk.service.dashboards.QueryAttachment`.
+ * Added .
+ * Removed `gcpServiceAccountKey` field for `com.databricks.sdk.service.catalog.CreateCredentialRequest`.
+
+OpenAPI SHA: 7016dcbf2e011459416cf408ce21143bcc4b3a25, Date: 2024-12-05
+
+
 ## [Release] Release v0.36.0
 
 ### Internal Changes

--- a/databricks-sdk-java/pom.xml
+++ b/databricks-sdk-java/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.databricks</groupId>
     <artifactId>databricks-sdk-parent</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
   </parent>
   <artifactId>databricks-sdk-java</artifactId>
   <properties>

--- a/examples/docs/pom.xml
+++ b/examples/docs/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>com.databricks</groupId>
       <artifactId>databricks-sdk-java</artifactId>
-      <version>0.36.0</version>
+      <version>0.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/examples/spring-boot-oauth-u2m-demo/pom.xml
+++ b/examples/spring-boot-oauth-u2m-demo/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.databricks</groupId>
       <artifactId>databricks-sdk-java</artifactId>
-      <version>0.36.0</version>
+      <version>0.37.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.databricks</groupId>
   <artifactId>databricks-sdk-parent</artifactId>
-  <version>0.36.0</version>
+  <version>0.37.0</version>
   <packaging>pom</packaging>
   <name>Databricks SDK for Java</name>
   <description>The Databricks SDK for Java includes functionality to accelerate development with Java for

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <sdk.version>0.36.0</sdk.version>
+    <sdk.version>0.37.0</sdk.version>
   </properties>
 
   <groupId>com.databricks</groupId>


### PR DESCRIPTION

### Internal Changes

 * Update SDK to OpenAPI spec ([#389](https://github.com/databricks/databricks-sdk-java/pull/389)).


### API Changes:

 * Added `com.databricks.sdk.service.cleanrooms` package.
 * Added `delete()` method for `workspaceClient.aibiDashboardEmbeddingAccessPolicy()` service.
 * Added `delete()` method for `workspaceClient.aibiDashboardEmbeddingApprovedDomains()` service.
 * Added `databricksGcpServiceAccount` field for `com.databricks.sdk.service.catalog.CreateCredentialRequest`.
 * Added `databricksGcpServiceAccount` field for `com.databricks.sdk.service.catalog.CredentialInfo`.
 * Added `gcpOptions` field for `com.databricks.sdk.service.catalog.GenerateTemporaryServiceCredentialRequest`.
 * Added `databricksGcpServiceAccount` field for `com.databricks.sdk.service.catalog.UpdateCredentialRequest`.
 * Added `cachedQuerySchema` field for `com.databricks.sdk.service.dashboards.QueryAttachment`.
 * Added .
 * Removed `gcpServiceAccountKey` field for `com.databricks.sdk.service.catalog.CreateCredentialRequest`.

OpenAPI SHA: 7016dcbf2e011459416cf408ce21143bcc4b3a25, Date: 2024-12-05


