### PR TITLE
[Fix] Correctly include query parameters for APIs whose request objects contain the body as a field

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -198,65 +198,10 @@ public class ApiClient {
     }
   }
 
-  public <O> O HEAD(String path, Class<O> target, Map<String, String> headers) {
-    return HEAD(path, null, target, headers);
-  }
-
-  public <I, O> O HEAD(String path, I in, Class<O> target, Map<String, String> headers) {
+  public <I, O> O execute(
+      String method, String path, I in, Class<O> target, Map<String, String> headers) {
     try {
-      return execute(prepareRequest("HEAD", path, in, headers), target);
-    } catch (IOException e) {
-      throw new DatabricksException("IO error: " + e.getMessage(), e);
-    }
-  }
-
-  public <O> O GET(String path, Class<O> target, Map<String, String> headers) {
-    return GET(path, null, target, headers);
-  }
-
-  public <I, O> O GET(String path, I in, Class<O> target, Map<String, String> headers) {
-    try {
-      return execute(prepareRequest("GET", path, in, headers), target);
-    } catch (IOException e) {
-      throw new DatabricksException("IO error: " + e.getMessage(), e);
-    }
-  }
-
-  public <O> O POST(String path, Class<O> target, Map<String, String> headers) {
-    try {
-      return execute(prepareRequest("POST", path, null, headers), target);
-    } catch (IOException e) {
-      throw new DatabricksException("IO error: " + e.getMessage(), e);
-    }
-  }
-
-  public <I, O> O POST(String path, I in, Class<O> target, Map<String, String> headers) {
-    try {
-      return execute(prepareRequest("POST", path, in, headers), target);
-    } catch (IOException e) {
-      throw new DatabricksException("IO error: " + e.getMessage(), e);
-    }
-  }
-
-  public <I, O> O PUT(String path, I in, Class<O> target, Map<String, String> headers) {
-    try {
-      return execute(prepareRequest("PUT", path, in, headers), target);
-    } catch (IOException e) {
-      throw new DatabricksException("IO error: " + e.getMessage(), e);
-    }
-  }
-
-  public <I, O> O PATCH(String path, I in, Class<O> target, Map<String, String> headers) {
-    try {
-      return execute(prepareRequest("PATCH", path, in, headers), target);
-    } catch (IOException e) {
-      throw new DatabricksException("IO error: " + e.getMessage(), e);
-    }
-  }
-
-  public <I, O> O DELETE(String path, I in, Class<O> target, Map<String, String> headers) {
-    try {
-      return execute(prepareRequest("DELETE", path, in, headers), target);
+      return execute(prepareRequest(method, path, in, headers), target);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ApiClient.java
@@ -151,7 +151,7 @@ public class ApiClient {
     bodyLogger = new BodyLogger(mapper, 1024, debugTruncateBytes);
   }
 
-  private static <I> void setQuery(Request in, I entity) {
+  public static <I> void setQuery(Request in, I entity) {
     if (entity == null) {
       return;
     }
@@ -239,7 +239,7 @@ public class ApiClient {
    * @param target Expected pojo type
    * @return POJO of requested type
    */
-  private <T> T execute(Request in, Class<T> target) throws IOException {
+  public <T> T execute(Request in, Class<T> target) throws IOException {
     Response out = getResponse(in);
     if (target == Void.class) {
       return null;
@@ -478,7 +478,7 @@ public class ApiClient {
     }
   }
 
-  private String serialize(Object body) throws JsonProcessingException {
+  public String serialize(Object body) throws JsonProcessingException {
     if (body == null) {
       return null;
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -586,11 +586,13 @@ public class DatabricksConfig {
             .withHttpClient(getHttpClient())
             .withGetHostFunc(v -> getHost())
             .build();
-    return apiClient.execute("GET",
-        "/oidc/.well-known/oauth-authorization-server",
-        null,
-        OpenIDConnectEndpoints.class,
-        new HashMap<>());
+    try {
+      return apiClient.execute(
+          new Request("GET", "/oidc/.well-known/oauth-authorization-server"),
+          OpenIDConnectEndpoints.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -586,8 +586,9 @@ public class DatabricksConfig {
             .withHttpClient(getHttpClient())
             .withGetHostFunc(v -> getHost())
             .build();
-    return apiClient.GET(
+    return apiClient.execute("GET",
         "/oidc/.well-known/oauth-authorization-server",
+        null,
         OpenIDConnectEndpoints.class,
         new HashMap<>());
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
@@ -65,7 +65,7 @@ public abstract class RefreshableTokenSource implements TokenSource {
       ApiClient apiClient = new ApiClient.Builder().withHttpClient(hc).build();
 
       OAuthResponse resp =
-          apiClient.POST(
+          apiClient.execute("POST",
               tokenUrl, FormRequest.wrapValuesInList(params), OAuthResponse.class, headers);
       if (resp.getErrorCode() != null) {
         throw new IllegalArgumentException(resp.getErrorCode() + ": " + resp.getErrorSummary());

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
@@ -4,6 +4,7 @@ import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.core.http.FormRequest;
 import com.databricks.sdk.core.http.HttpClient;
+import com.databricks.sdk.core.http.Request;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -61,12 +62,11 @@ public abstract class RefreshableTokenSource implements TokenSource {
         break;
     }
     headers.put("Content-Type", "application/x-www-form-urlencoded");
+    Request req = new Request("POST", tokenUrl, FormRequest.wrapValuesInList(params));
+    req.withHeaders(headers);
     try {
       ApiClient apiClient = new ApiClient.Builder().withHttpClient(hc).build();
-
-      OAuthResponse resp =
-          apiClient.execute("POST",
-              tokenUrl, FormRequest.wrapValuesInList(params), OAuthResponse.class, headers);
+      OAuthResponse resp = apiClient.execute(req, OAuthResponse.class);
       if (resp.getErrorCode() != null) {
         throw new IllegalArgumentException(resp.getErrorCode() + ": " + resp.getErrorSummary());
       }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/apps/AppsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/apps/AppsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.apps;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Apps */
 @Generated
@@ -18,36 +19,55 @@ class AppsImpl implements AppsService {
   @Override
   public App create(CreateAppRequest request) {
     String path = "/api/2.0/apps";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request.getApp(), App.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request.getApp()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, App.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public App delete(DeleteAppRequest request) {
     String path = String.format("/api/2.0/apps/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("DELETE", path, request, App.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, App.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public AppDeployment deploy(CreateAppDeploymentRequest request) {
     String path = String.format("/api/2.0/apps/%s/deployments", request.getAppName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST", path, request.getAppDeployment(), AppDeployment.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request.getAppDeployment()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, AppDeployment.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public App get(GetAppRequest request) {
     String path = String.format("/api/2.0/apps/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, App.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, App.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -55,86 +75,136 @@ class AppsImpl implements AppsService {
     String path =
         String.format(
             "/api/2.0/apps/%s/deployments/%s", request.getAppName(), request.getDeploymentId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, AppDeployment.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, AppDeployment.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetAppPermissionLevelsResponse getPermissionLevels(GetAppPermissionLevelsRequest request) {
     String path =
         String.format("/api/2.0/permissions/apps/%s/permissionLevels", request.getAppName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetAppPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetAppPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public AppPermissions getPermissions(GetAppPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/apps/%s", request.getAppName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, AppPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, AppPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListAppsResponse list(ListAppsRequest request) {
     String path = "/api/2.0/apps";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListAppsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListAppsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListAppDeploymentsResponse listDeployments(ListAppDeploymentsRequest request) {
     String path = String.format("/api/2.0/apps/%s/deployments", request.getAppName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListAppDeploymentsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListAppDeploymentsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public AppPermissions setPermissions(AppPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/apps/%s", request.getAppName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, AppPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, AppPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public App start(StartAppRequest request) {
     String path = String.format("/api/2.0/apps/%s/start", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, App.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, App.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public App stop(StopAppRequest request) {
     String path = String.format("/api/2.0/apps/%s/stop", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, App.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, App.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public App update(UpdateAppRequest request) {
     String path = String.format("/api/2.0/apps/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request.getApp(), App.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request.getApp()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, App.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public AppPermissions updatePermissions(AppPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/apps/%s", request.getAppName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, AppPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, AppPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/apps/AppsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/apps/AppsImpl.java
@@ -21,7 +21,7 @@ class AppsImpl implements AppsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request.getApp(), App.class, headers);
+    return apiClient.execute("POST", path, request.getApp(), App.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class AppsImpl implements AppsService {
     String path = String.format("/api/2.0/apps/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.DELETE(path, request, App.class, headers);
+    return apiClient.execute("DELETE", path, request, App.class, headers);
   }
 
   @Override
@@ -38,7 +38,8 @@ class AppsImpl implements AppsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request.getAppDeployment(), AppDeployment.class, headers);
+    return apiClient.execute(
+        "POST", path, request.getAppDeployment(), AppDeployment.class, headers);
   }
 
   @Override
@@ -46,7 +47,7 @@ class AppsImpl implements AppsService {
     String path = String.format("/api/2.0/apps/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, App.class, headers);
+    return apiClient.execute("GET", path, request, App.class, headers);
   }
 
   @Override
@@ -56,7 +57,7 @@ class AppsImpl implements AppsService {
             "/api/2.0/apps/%s/deployments/%s", request.getAppName(), request.getDeploymentId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, AppDeployment.class, headers);
+    return apiClient.execute("GET", path, request, AppDeployment.class, headers);
   }
 
   @Override
@@ -65,7 +66,7 @@ class AppsImpl implements AppsService {
         String.format("/api/2.0/permissions/apps/%s/permissionLevels", request.getAppName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetAppPermissionLevelsResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetAppPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -73,7 +74,7 @@ class AppsImpl implements AppsService {
     String path = String.format("/api/2.0/permissions/apps/%s", request.getAppName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, AppPermissions.class, headers);
+    return apiClient.execute("GET", path, request, AppPermissions.class, headers);
   }
 
   @Override
@@ -81,7 +82,7 @@ class AppsImpl implements AppsService {
     String path = "/api/2.0/apps";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListAppsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListAppsResponse.class, headers);
   }
 
   @Override
@@ -89,7 +90,7 @@ class AppsImpl implements AppsService {
     String path = String.format("/api/2.0/apps/%s/deployments", request.getAppName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListAppDeploymentsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListAppDeploymentsResponse.class, headers);
   }
 
   @Override
@@ -98,7 +99,7 @@ class AppsImpl implements AppsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, AppPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, AppPermissions.class, headers);
   }
 
   @Override
@@ -107,7 +108,7 @@ class AppsImpl implements AppsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, App.class, headers);
+    return apiClient.execute("POST", path, request, App.class, headers);
   }
 
   @Override
@@ -116,7 +117,7 @@ class AppsImpl implements AppsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, App.class, headers);
+    return apiClient.execute("POST", path, request, App.class, headers);
   }
 
   @Override
@@ -125,7 +126,7 @@ class AppsImpl implements AppsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request.getApp(), App.class, headers);
+    return apiClient.execute("PATCH", path, request.getApp(), App.class, headers);
   }
 
   @Override
@@ -134,6 +135,6 @@ class AppsImpl implements AppsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, AppPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, AppPermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BillableUsageImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BillableUsageImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.billing;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of BillableUsage */
 @Generated
@@ -19,8 +20,13 @@ class BillableUsageImpl implements BillableUsageService {
   public DownloadResponse download(DownloadRequest request) {
     String path =
         String.format("/api/2.0/accounts/%s/usage/download", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "text/plain");
-    return apiClient.execute("GET", path, request, DownloadResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "text/plain");
+      return apiClient.execute(req, DownloadResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BillableUsageImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BillableUsageImpl.java
@@ -21,6 +21,6 @@ class BillableUsageImpl implements BillableUsageService {
         String.format("/api/2.0/accounts/%s/usage/download", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "text/plain");
-    return apiClient.GET(path, request, DownloadResponse.class, headers);
+    return apiClient.execute("GET", path, request, DownloadResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BudgetsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BudgetsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.billing;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Budgets */
 @Generated
@@ -18,11 +19,15 @@ class BudgetsImpl implements BudgetsService {
   @Override
   public CreateBudgetConfigurationResponse create(CreateBudgetConfigurationRequest request) {
     String path = String.format("/api/2.1/accounts/%s/budgets", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST", path, request, CreateBudgetConfigurationResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateBudgetConfigurationResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,9 +36,14 @@ class BudgetsImpl implements BudgetsService {
         String.format(
             "/api/2.1/accounts/%s/budgets/%s",
             apiClient.configuredAccountID(), request.getBudgetId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteBudgetConfigurationResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteBudgetConfigurationResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -42,17 +52,27 @@ class BudgetsImpl implements BudgetsService {
         String.format(
             "/api/2.1/accounts/%s/budgets/%s",
             apiClient.configuredAccountID(), request.getBudgetId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetBudgetConfigurationResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetBudgetConfigurationResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListBudgetConfigurationsResponse list(ListBudgetConfigurationsRequest request) {
     String path = String.format("/api/2.1/accounts/%s/budgets", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListBudgetConfigurationsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListBudgetConfigurationsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -61,10 +81,14 @@ class BudgetsImpl implements BudgetsService {
         String.format(
             "/api/2.1/accounts/%s/budgets/%s",
             apiClient.configuredAccountID(), request.getBudgetId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "PUT", path, request, UpdateBudgetConfigurationResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, UpdateBudgetConfigurationResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BudgetsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/BudgetsImpl.java
@@ -21,7 +21,8 @@ class BudgetsImpl implements BudgetsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateBudgetConfigurationResponse.class, headers);
+    return apiClient.execute(
+        "POST", path, request, CreateBudgetConfigurationResponse.class, headers);
   }
 
   @Override
@@ -32,7 +33,7 @@ class BudgetsImpl implements BudgetsService {
             apiClient.configuredAccountID(), request.getBudgetId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteBudgetConfigurationResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteBudgetConfigurationResponse.class, headers);
   }
 
   @Override
@@ -43,7 +44,7 @@ class BudgetsImpl implements BudgetsService {
             apiClient.configuredAccountID(), request.getBudgetId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetBudgetConfigurationResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetBudgetConfigurationResponse.class, headers);
   }
 
   @Override
@@ -51,7 +52,7 @@ class BudgetsImpl implements BudgetsService {
     String path = String.format("/api/2.1/accounts/%s/budgets", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListBudgetConfigurationsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListBudgetConfigurationsResponse.class, headers);
   }
 
   @Override
@@ -63,6 +64,7 @@ class BudgetsImpl implements BudgetsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, UpdateBudgetConfigurationResponse.class, headers);
+    return apiClient.execute(
+        "PUT", path, request, UpdateBudgetConfigurationResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/LogDeliveryImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/LogDeliveryImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.billing;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of LogDelivery */
 @Generated
@@ -19,10 +20,15 @@ class LogDeliveryImpl implements LogDeliveryService {
   public WrappedLogDeliveryConfiguration create(WrappedCreateLogDeliveryConfiguration request) {
     String path =
         String.format("/api/2.0/accounts/%s/log-delivery", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, WrappedLogDeliveryConfiguration.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, WrappedLogDeliveryConfiguration.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,18 +37,28 @@ class LogDeliveryImpl implements LogDeliveryService {
         String.format(
             "/api/2.0/accounts/%s/log-delivery/%s",
             apiClient.configuredAccountID(), request.getLogDeliveryConfigurationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, WrappedLogDeliveryConfiguration.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, WrappedLogDeliveryConfiguration.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public WrappedLogDeliveryConfigurations list(ListLogDeliveryRequest request) {
     String path =
         String.format("/api/2.0/accounts/%s/log-delivery", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, WrappedLogDeliveryConfigurations.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, WrappedLogDeliveryConfigurations.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -51,9 +67,14 @@ class LogDeliveryImpl implements LogDeliveryService {
         String.format(
             "/api/2.0/accounts/%s/log-delivery/%s",
             apiClient.configuredAccountID(), request.getLogDeliveryConfigurationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, PatchStatusResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PatchStatusResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/LogDeliveryImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/LogDeliveryImpl.java
@@ -22,7 +22,7 @@ class LogDeliveryImpl implements LogDeliveryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, WrappedLogDeliveryConfiguration.class, headers);
+    return apiClient.execute("POST", path, request, WrappedLogDeliveryConfiguration.class, headers);
   }
 
   @Override
@@ -33,7 +33,7 @@ class LogDeliveryImpl implements LogDeliveryService {
             apiClient.configuredAccountID(), request.getLogDeliveryConfigurationId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, WrappedLogDeliveryConfiguration.class, headers);
+    return apiClient.execute("GET", path, request, WrappedLogDeliveryConfiguration.class, headers);
   }
 
   @Override
@@ -42,7 +42,7 @@ class LogDeliveryImpl implements LogDeliveryService {
         String.format("/api/2.0/accounts/%s/log-delivery", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, WrappedLogDeliveryConfigurations.class, headers);
+    return apiClient.execute("GET", path, request, WrappedLogDeliveryConfigurations.class, headers);
   }
 
   @Override
@@ -54,6 +54,6 @@ class LogDeliveryImpl implements LogDeliveryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, PatchStatusResponse.class, headers);
+    apiClient.execute("PATCH", path, request, PatchStatusResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/UsageDashboardsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/UsageDashboardsImpl.java
@@ -21,7 +21,8 @@ class UsageDashboardsImpl implements UsageDashboardsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateBillingUsageDashboardResponse.class, headers);
+    return apiClient.execute(
+        "POST", path, request, CreateBillingUsageDashboardResponse.class, headers);
   }
 
   @Override
@@ -29,6 +30,6 @@ class UsageDashboardsImpl implements UsageDashboardsService {
     String path = String.format("/api/2.0/accounts/%s/dashboard", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetBillingUsageDashboardResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetBillingUsageDashboardResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/UsageDashboardsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/billing/UsageDashboardsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.billing;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of UsageDashboards */
 @Generated
@@ -18,18 +19,27 @@ class UsageDashboardsImpl implements UsageDashboardsService {
   @Override
   public CreateBillingUsageDashboardResponse create(CreateBillingUsageDashboardRequest request) {
     String path = String.format("/api/2.0/accounts/%s/dashboard", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST", path, request, CreateBillingUsageDashboardResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateBillingUsageDashboardResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetBillingUsageDashboardResponse get(GetBillingUsageDashboardRequest request) {
     String path = String.format("/api/2.0/accounts/%s/dashboard", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetBillingUsageDashboardResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetBillingUsageDashboardResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoreAssignmentsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoreAssignmentsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AccountMetastoreAssignments */
 @Generated
@@ -21,10 +22,15 @@ class AccountMetastoreAssignmentsImpl implements AccountMetastoreAssignmentsServ
         String.format(
             "/api/2.0/accounts/%s/workspaces/%s/metastores/%s",
             apiClient.configuredAccountID(), request.getWorkspaceId(), request.getMetastoreId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, CreateResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, CreateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -33,9 +39,14 @@ class AccountMetastoreAssignmentsImpl implements AccountMetastoreAssignmentsServ
         String.format(
             "/api/2.0/accounts/%s/workspaces/%s/metastores/%s",
             apiClient.configuredAccountID(), request.getWorkspaceId(), request.getMetastoreId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -44,9 +55,14 @@ class AccountMetastoreAssignmentsImpl implements AccountMetastoreAssignmentsServ
         String.format(
             "/api/2.0/accounts/%s/workspaces/%s/metastore",
             apiClient.configuredAccountID(), request.getWorkspaceId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, AccountsMetastoreAssignment.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, AccountsMetastoreAssignment.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -56,10 +72,14 @@ class AccountMetastoreAssignmentsImpl implements AccountMetastoreAssignmentsServ
         String.format(
             "/api/2.0/accounts/%s/metastores/%s/workspaces",
             apiClient.configuredAccountID(), request.getMetastoreId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, ListAccountMetastoreAssignmentsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListAccountMetastoreAssignmentsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -68,9 +88,14 @@ class AccountMetastoreAssignmentsImpl implements AccountMetastoreAssignmentsServ
         String.format(
             "/api/2.0/accounts/%s/workspaces/%s/metastores/%s",
             apiClient.configuredAccountID(), request.getWorkspaceId(), request.getMetastoreId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoreAssignmentsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoreAssignmentsImpl.java
@@ -24,7 +24,7 @@ class AccountMetastoreAssignmentsImpl implements AccountMetastoreAssignmentsServ
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, CreateResponse.class, headers);
+    apiClient.execute("POST", path, request, CreateResponse.class, headers);
   }
 
   @Override
@@ -35,7 +35,7 @@ class AccountMetastoreAssignmentsImpl implements AccountMetastoreAssignmentsServ
             apiClient.configuredAccountID(), request.getWorkspaceId(), request.getMetastoreId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -46,7 +46,7 @@ class AccountMetastoreAssignmentsImpl implements AccountMetastoreAssignmentsServ
             apiClient.configuredAccountID(), request.getWorkspaceId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, AccountsMetastoreAssignment.class, headers);
+    return apiClient.execute("GET", path, request, AccountsMetastoreAssignment.class, headers);
   }
 
   @Override
@@ -58,7 +58,8 @@ class AccountMetastoreAssignmentsImpl implements AccountMetastoreAssignmentsServ
             apiClient.configuredAccountID(), request.getMetastoreId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListAccountMetastoreAssignmentsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, ListAccountMetastoreAssignmentsResponse.class, headers);
   }
 
   @Override
@@ -70,6 +71,6 @@ class AccountMetastoreAssignmentsImpl implements AccountMetastoreAssignmentsServ
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoresImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoresImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AccountMetastores */
 @Generated
@@ -18,10 +19,15 @@ class AccountMetastoresImpl implements AccountMetastoresService {
   @Override
   public AccountsMetastoreInfo create(AccountsCreateMetastore request) {
     String path = String.format("/api/2.0/accounts/%s/metastores", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, AccountsMetastoreInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, AccountsMetastoreInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -30,9 +36,14 @@ class AccountMetastoresImpl implements AccountMetastoresService {
         String.format(
             "/api/2.0/accounts/%s/metastores/%s",
             apiClient.configuredAccountID(), request.getMetastoreId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -41,17 +52,27 @@ class AccountMetastoresImpl implements AccountMetastoresService {
         String.format(
             "/api/2.0/accounts/%s/metastores/%s",
             apiClient.configuredAccountID(), request.getMetastoreId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, AccountsMetastoreInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, AccountsMetastoreInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListMetastoresResponse list() {
     String path = String.format("/api/2.0/accounts/%s/metastores", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListMetastoresResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListMetastoresResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -60,9 +81,14 @@ class AccountMetastoresImpl implements AccountMetastoresService {
         String.format(
             "/api/2.0/accounts/%s/metastores/%s",
             apiClient.configuredAccountID(), request.getMetastoreId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, AccountsMetastoreInfo.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, AccountsMetastoreInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoresImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountMetastoresImpl.java
@@ -21,7 +21,7 @@ class AccountMetastoresImpl implements AccountMetastoresService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, AccountsMetastoreInfo.class, headers);
+    return apiClient.execute("POST", path, request, AccountsMetastoreInfo.class, headers);
   }
 
   @Override
@@ -32,7 +32,7 @@ class AccountMetastoresImpl implements AccountMetastoresService {
             apiClient.configuredAccountID(), request.getMetastoreId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -43,7 +43,7 @@ class AccountMetastoresImpl implements AccountMetastoresService {
             apiClient.configuredAccountID(), request.getMetastoreId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, AccountsMetastoreInfo.class, headers);
+    return apiClient.execute("GET", path, request, AccountsMetastoreInfo.class, headers);
   }
 
   @Override
@@ -51,7 +51,7 @@ class AccountMetastoresImpl implements AccountMetastoresService {
     String path = String.format("/api/2.0/accounts/%s/metastores", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListMetastoresResponse.class, headers);
+    return apiClient.execute("GET", path, null, ListMetastoresResponse.class, headers);
   }
 
   @Override
@@ -63,6 +63,6 @@ class AccountMetastoresImpl implements AccountMetastoresService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, AccountsMetastoreInfo.class, headers);
+    return apiClient.execute("PUT", path, request, AccountsMetastoreInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountStorageCredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountStorageCredentialsImpl.java
@@ -24,7 +24,7 @@ class AccountStorageCredentialsImpl implements AccountStorageCredentialsService 
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, AccountsStorageCredentialInfo.class, headers);
+    return apiClient.execute("POST", path, request, AccountsStorageCredentialInfo.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class AccountStorageCredentialsImpl implements AccountStorageCredentialsService 
             request.getStorageCredentialName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -50,7 +50,7 @@ class AccountStorageCredentialsImpl implements AccountStorageCredentialsService 
             request.getStorageCredentialName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, AccountsStorageCredentialInfo.class, headers);
+    return apiClient.execute("GET", path, request, AccountsStorageCredentialInfo.class, headers);
   }
 
   @Override
@@ -61,7 +61,8 @@ class AccountStorageCredentialsImpl implements AccountStorageCredentialsService 
             apiClient.configuredAccountID(), request.getMetastoreId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListAccountStorageCredentialsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, ListAccountStorageCredentialsResponse.class, headers);
   }
 
   @Override
@@ -75,6 +76,6 @@ class AccountStorageCredentialsImpl implements AccountStorageCredentialsService 
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, AccountsStorageCredentialInfo.class, headers);
+    return apiClient.execute("PUT", path, request, AccountsStorageCredentialInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountStorageCredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/AccountStorageCredentialsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AccountStorageCredentials */
 @Generated
@@ -21,10 +22,15 @@ class AccountStorageCredentialsImpl implements AccountStorageCredentialsService 
         String.format(
             "/api/2.0/accounts/%s/metastores/%s/storage-credentials",
             apiClient.configuredAccountID(), request.getMetastoreId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, AccountsStorageCredentialInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, AccountsStorageCredentialInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -35,9 +41,14 @@ class AccountStorageCredentialsImpl implements AccountStorageCredentialsService 
             apiClient.configuredAccountID(),
             request.getMetastoreId(),
             request.getStorageCredentialName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -48,9 +59,14 @@ class AccountStorageCredentialsImpl implements AccountStorageCredentialsService 
             apiClient.configuredAccountID(),
             request.getMetastoreId(),
             request.getStorageCredentialName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, AccountsStorageCredentialInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, AccountsStorageCredentialInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -59,10 +75,14 @@ class AccountStorageCredentialsImpl implements AccountStorageCredentialsService 
         String.format(
             "/api/2.0/accounts/%s/metastores/%s/storage-credentials",
             apiClient.configuredAccountID(), request.getMetastoreId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, ListAccountStorageCredentialsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListAccountStorageCredentialsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -73,9 +93,14 @@ class AccountStorageCredentialsImpl implements AccountStorageCredentialsService 
             apiClient.configuredAccountID(),
             request.getMetastoreId(),
             request.getStorageCredentialName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, AccountsStorageCredentialInfo.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, AccountsStorageCredentialInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ArtifactAllowlistsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ArtifactAllowlistsImpl.java
@@ -21,7 +21,7 @@ class ArtifactAllowlistsImpl implements ArtifactAllowlistsService {
         String.format("/api/2.1/unity-catalog/artifact-allowlists/%s", request.getArtifactType());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ArtifactAllowlistInfo.class, headers);
+    return apiClient.execute("GET", path, request, ArtifactAllowlistInfo.class, headers);
   }
 
   @Override
@@ -31,6 +31,6 @@ class ArtifactAllowlistsImpl implements ArtifactAllowlistsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, ArtifactAllowlistInfo.class, headers);
+    return apiClient.execute("PUT", path, request, ArtifactAllowlistInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ArtifactAllowlistsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ArtifactAllowlistsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ArtifactAllowlists */
 @Generated
@@ -19,18 +20,28 @@ class ArtifactAllowlistsImpl implements ArtifactAllowlistsService {
   public ArtifactAllowlistInfo get(GetArtifactAllowlistRequest request) {
     String path =
         String.format("/api/2.1/unity-catalog/artifact-allowlists/%s", request.getArtifactType());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ArtifactAllowlistInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ArtifactAllowlistInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ArtifactAllowlistInfo update(SetArtifactAllowlist request) {
     String path =
         String.format("/api/2.1/unity-catalog/artifact-allowlists/%s", request.getArtifactType());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, ArtifactAllowlistInfo.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ArtifactAllowlistInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/CatalogsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/CatalogsImpl.java
@@ -21,7 +21,7 @@ class CatalogsImpl implements CatalogsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CatalogInfo.class, headers);
+    return apiClient.execute("POST", path, request, CatalogInfo.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class CatalogsImpl implements CatalogsService {
     String path = String.format("/api/2.1/unity-catalog/catalogs/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class CatalogsImpl implements CatalogsService {
     String path = String.format("/api/2.1/unity-catalog/catalogs/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, CatalogInfo.class, headers);
+    return apiClient.execute("GET", path, request, CatalogInfo.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class CatalogsImpl implements CatalogsService {
     String path = "/api/2.1/unity-catalog/catalogs";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListCatalogsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListCatalogsResponse.class, headers);
   }
 
   @Override
@@ -54,6 +54,6 @@ class CatalogsImpl implements CatalogsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, CatalogInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, CatalogInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/CatalogsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/CatalogsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Catalogs */
 @Generated
@@ -18,42 +19,67 @@ class CatalogsImpl implements CatalogsService {
   @Override
   public CatalogInfo create(CreateCatalog request) {
     String path = "/api/2.1/unity-catalog/catalogs";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CatalogInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CatalogInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteCatalogRequest request) {
     String path = String.format("/api/2.1/unity-catalog/catalogs/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CatalogInfo get(GetCatalogRequest request) {
     String path = String.format("/api/2.1/unity-catalog/catalogs/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, CatalogInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, CatalogInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListCatalogsResponse list(ListCatalogsRequest request) {
     String path = "/api/2.1/unity-catalog/catalogs";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListCatalogsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListCatalogsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CatalogInfo update(UpdateCatalog request) {
     String path = String.format("/api/2.1/unity-catalog/catalogs/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, CatalogInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CatalogInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ConnectionsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ConnectionsImpl.java
@@ -21,7 +21,7 @@ class ConnectionsImpl implements ConnectionsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ConnectionInfo.class, headers);
+    return apiClient.execute("POST", path, request, ConnectionInfo.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class ConnectionsImpl implements ConnectionsService {
     String path = String.format("/api/2.1/unity-catalog/connections/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class ConnectionsImpl implements ConnectionsService {
     String path = String.format("/api/2.1/unity-catalog/connections/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ConnectionInfo.class, headers);
+    return apiClient.execute("GET", path, request, ConnectionInfo.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class ConnectionsImpl implements ConnectionsService {
     String path = "/api/2.1/unity-catalog/connections";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListConnectionsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListConnectionsResponse.class, headers);
   }
 
   @Override
@@ -54,6 +54,6 @@ class ConnectionsImpl implements ConnectionsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, ConnectionInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, ConnectionInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ConnectionsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ConnectionsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Connections */
 @Generated
@@ -18,42 +19,67 @@ class ConnectionsImpl implements ConnectionsService {
   @Override
   public ConnectionInfo create(CreateConnection request) {
     String path = "/api/2.1/unity-catalog/connections";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, ConnectionInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ConnectionInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteConnectionRequest request) {
     String path = String.format("/api/2.1/unity-catalog/connections/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ConnectionInfo get(GetConnectionRequest request) {
     String path = String.format("/api/2.1/unity-catalog/connections/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ConnectionInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ConnectionInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListConnectionsResponse list(ListConnectionsRequest request) {
     String path = "/api/2.1/unity-catalog/connections";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListConnectionsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListConnectionsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ConnectionInfo update(UpdateConnection request) {
     String path = String.format("/api/2.1/unity-catalog/connections/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, ConnectionInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ConnectionInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/CredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/CredentialsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Credentials */
 @Generated
@@ -18,61 +19,96 @@ class CredentialsImpl implements CredentialsService {
   @Override
   public CredentialInfo createCredential(CreateCredentialRequest request) {
     String path = "/api/2.1/unity-catalog/credentials";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CredentialInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CredentialInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteCredential(DeleteCredentialRequest request) {
     String path = String.format("/api/2.1/unity-catalog/credentials/%s", request.getNameArg());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteCredentialResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteCredentialResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public TemporaryCredentials generateTemporaryServiceCredential(
       GenerateTemporaryServiceCredentialRequest request) {
     String path = "/api/2.1/unity-catalog/temporary-service-credentials";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, TemporaryCredentials.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, TemporaryCredentials.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CredentialInfo getCredential(GetCredentialRequest request) {
     String path = String.format("/api/2.1/unity-catalog/credentials/%s", request.getNameArg());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, CredentialInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, CredentialInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListCredentialsResponse listCredentials(ListCredentialsRequest request) {
     String path = "/api/2.1/unity-catalog/credentials";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListCredentialsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListCredentialsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CredentialInfo updateCredential(UpdateCredentialRequest request) {
     String path = String.format("/api/2.1/unity-catalog/credentials/%s", request.getNameArg());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, CredentialInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CredentialInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ValidateCredentialResponse validateCredential(ValidateCredentialRequest request) {
     String path = "/api/2.1/unity-catalog/validate-credentials";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, ValidateCredentialResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ValidateCredentialResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/CredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/CredentialsImpl.java
@@ -21,7 +21,7 @@ class CredentialsImpl implements CredentialsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CredentialInfo.class, headers);
+    return apiClient.execute("POST", path, request, CredentialInfo.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class CredentialsImpl implements CredentialsService {
     String path = String.format("/api/2.1/unity-catalog/credentials/%s", request.getNameArg());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteCredentialResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteCredentialResponse.class, headers);
   }
 
   @Override
@@ -39,7 +39,7 @@ class CredentialsImpl implements CredentialsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, TemporaryCredentials.class, headers);
+    return apiClient.execute("POST", path, request, TemporaryCredentials.class, headers);
   }
 
   @Override
@@ -47,7 +47,7 @@ class CredentialsImpl implements CredentialsService {
     String path = String.format("/api/2.1/unity-catalog/credentials/%s", request.getNameArg());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, CredentialInfo.class, headers);
+    return apiClient.execute("GET", path, request, CredentialInfo.class, headers);
   }
 
   @Override
@@ -55,7 +55,7 @@ class CredentialsImpl implements CredentialsService {
     String path = "/api/2.1/unity-catalog/credentials";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListCredentialsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListCredentialsResponse.class, headers);
   }
 
   @Override
@@ -64,7 +64,7 @@ class CredentialsImpl implements CredentialsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, CredentialInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, CredentialInfo.class, headers);
   }
 
   @Override
@@ -73,6 +73,6 @@ class CredentialsImpl implements CredentialsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ValidateCredentialResponse.class, headers);
+    return apiClient.execute("POST", path, request, ValidateCredentialResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ExternalLocationsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ExternalLocationsImpl.java
@@ -21,7 +21,7 @@ class ExternalLocationsImpl implements ExternalLocationsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ExternalLocationInfo.class, headers);
+    return apiClient.execute("POST", path, request, ExternalLocationInfo.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class ExternalLocationsImpl implements ExternalLocationsService {
     String path = String.format("/api/2.1/unity-catalog/external-locations/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class ExternalLocationsImpl implements ExternalLocationsService {
     String path = String.format("/api/2.1/unity-catalog/external-locations/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ExternalLocationInfo.class, headers);
+    return apiClient.execute("GET", path, request, ExternalLocationInfo.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class ExternalLocationsImpl implements ExternalLocationsService {
     String path = "/api/2.1/unity-catalog/external-locations";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListExternalLocationsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListExternalLocationsResponse.class, headers);
   }
 
   @Override
@@ -54,6 +54,6 @@ class ExternalLocationsImpl implements ExternalLocationsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, ExternalLocationInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, ExternalLocationInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ExternalLocationsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ExternalLocationsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ExternalLocations */
 @Generated
@@ -18,42 +19,67 @@ class ExternalLocationsImpl implements ExternalLocationsService {
   @Override
   public ExternalLocationInfo create(CreateExternalLocation request) {
     String path = "/api/2.1/unity-catalog/external-locations";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, ExternalLocationInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ExternalLocationInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteExternalLocationRequest request) {
     String path = String.format("/api/2.1/unity-catalog/external-locations/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ExternalLocationInfo get(GetExternalLocationRequest request) {
     String path = String.format("/api/2.1/unity-catalog/external-locations/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ExternalLocationInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ExternalLocationInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListExternalLocationsResponse list(ListExternalLocationsRequest request) {
     String path = "/api/2.1/unity-catalog/external-locations";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListExternalLocationsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListExternalLocationsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ExternalLocationInfo update(UpdateExternalLocation request) {
     String path = String.format("/api/2.1/unity-catalog/external-locations/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, ExternalLocationInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ExternalLocationInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/FunctionsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/FunctionsImpl.java
@@ -21,7 +21,7 @@ class FunctionsImpl implements FunctionsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, FunctionInfo.class, headers);
+    return apiClient.execute("POST", path, request, FunctionInfo.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class FunctionsImpl implements FunctionsService {
     String path = String.format("/api/2.1/unity-catalog/functions/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class FunctionsImpl implements FunctionsService {
     String path = String.format("/api/2.1/unity-catalog/functions/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, FunctionInfo.class, headers);
+    return apiClient.execute("GET", path, request, FunctionInfo.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class FunctionsImpl implements FunctionsService {
     String path = "/api/2.1/unity-catalog/functions";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListFunctionsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListFunctionsResponse.class, headers);
   }
 
   @Override
@@ -54,6 +54,6 @@ class FunctionsImpl implements FunctionsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, FunctionInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, FunctionInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/FunctionsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/FunctionsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Functions */
 @Generated
@@ -18,42 +19,67 @@ class FunctionsImpl implements FunctionsService {
   @Override
   public FunctionInfo create(CreateFunctionRequest request) {
     String path = "/api/2.1/unity-catalog/functions";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, FunctionInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, FunctionInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteFunctionRequest request) {
     String path = String.format("/api/2.1/unity-catalog/functions/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public FunctionInfo get(GetFunctionRequest request) {
     String path = String.format("/api/2.1/unity-catalog/functions/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, FunctionInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, FunctionInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListFunctionsResponse list(ListFunctionsRequest request) {
     String path = "/api/2.1/unity-catalog/functions";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListFunctionsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListFunctionsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public FunctionInfo update(UpdateFunction request) {
     String path = String.format("/api/2.1/unity-catalog/functions/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, FunctionInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, FunctionInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/GrantsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/GrantsImpl.java
@@ -23,7 +23,7 @@ class GrantsImpl implements GrantsService {
             request.getSecurableType(), request.getFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, PermissionsList.class, headers);
+    return apiClient.execute("GET", path, request, PermissionsList.class, headers);
   }
 
   @Override
@@ -34,7 +34,7 @@ class GrantsImpl implements GrantsService {
             request.getSecurableType(), request.getFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, EffectivePermissionsList.class, headers);
+    return apiClient.execute("GET", path, request, EffectivePermissionsList.class, headers);
   }
 
   @Override
@@ -46,6 +46,6 @@ class GrantsImpl implements GrantsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, PermissionsList.class, headers);
+    return apiClient.execute("PATCH", path, request, PermissionsList.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/GrantsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/GrantsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Grants */
 @Generated
@@ -21,9 +22,14 @@ class GrantsImpl implements GrantsService {
         String.format(
             "/api/2.1/unity-catalog/permissions/%s/%s",
             request.getSecurableType(), request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, PermissionsList.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, PermissionsList.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -32,9 +38,14 @@ class GrantsImpl implements GrantsService {
         String.format(
             "/api/2.1/unity-catalog/effective-permissions/%s/%s",
             request.getSecurableType(), request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, EffectivePermissionsList.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, EffectivePermissionsList.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -43,9 +54,14 @@ class GrantsImpl implements GrantsService {
         String.format(
             "/api/2.1/unity-catalog/permissions/%s/%s",
             request.getSecurableType(), request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, PermissionsList.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, PermissionsList.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/MetastoresImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/MetastoresImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Metastores */
 @Generated
@@ -19,86 +20,136 @@ class MetastoresImpl implements MetastoresService {
   public void assign(CreateMetastoreAssignment request) {
     String path =
         String.format("/api/2.1/unity-catalog/workspaces/%s/metastore", request.getWorkspaceId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, AssignResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, AssignResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public MetastoreInfo create(CreateMetastore request) {
     String path = "/api/2.1/unity-catalog/metastores";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, MetastoreInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, MetastoreInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public MetastoreAssignment current() {
     String path = "/api/2.1/unity-catalog/current-metastore-assignment";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, MetastoreAssignment.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, MetastoreAssignment.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteMetastoreRequest request) {
     String path = String.format("/api/2.1/unity-catalog/metastores/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public MetastoreInfo get(GetMetastoreRequest request) {
     String path = String.format("/api/2.1/unity-catalog/metastores/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, MetastoreInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, MetastoreInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListMetastoresResponse list() {
     String path = "/api/2.1/unity-catalog/metastores";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListMetastoresResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListMetastoresResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetMetastoreSummaryResponse summary() {
     String path = "/api/2.1/unity-catalog/metastore_summary";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, GetMetastoreSummaryResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetMetastoreSummaryResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void unassign(UnassignRequest request) {
     String path =
         String.format("/api/2.1/unity-catalog/workspaces/%s/metastore", request.getWorkspaceId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, UnassignResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, UnassignResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public MetastoreInfo update(UpdateMetastore request) {
     String path = String.format("/api/2.1/unity-catalog/metastores/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, MetastoreInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, MetastoreInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void updateAssignment(UpdateMetastoreAssignment request) {
     String path =
         String.format("/api/2.1/unity-catalog/workspaces/%s/metastore", request.getWorkspaceId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateAssignmentResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateAssignmentResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/MetastoresImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/MetastoresImpl.java
@@ -22,7 +22,7 @@ class MetastoresImpl implements MetastoresService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, AssignResponse.class, headers);
+    apiClient.execute("PUT", path, request, AssignResponse.class, headers);
   }
 
   @Override
@@ -31,7 +31,7 @@ class MetastoresImpl implements MetastoresService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, MetastoreInfo.class, headers);
+    return apiClient.execute("POST", path, request, MetastoreInfo.class, headers);
   }
 
   @Override
@@ -39,7 +39,7 @@ class MetastoresImpl implements MetastoresService {
     String path = "/api/2.1/unity-catalog/current-metastore-assignment";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, MetastoreAssignment.class, headers);
+    return apiClient.execute("GET", path, null, MetastoreAssignment.class, headers);
   }
 
   @Override
@@ -47,7 +47,7 @@ class MetastoresImpl implements MetastoresService {
     String path = String.format("/api/2.1/unity-catalog/metastores/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -55,7 +55,7 @@ class MetastoresImpl implements MetastoresService {
     String path = String.format("/api/2.1/unity-catalog/metastores/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, MetastoreInfo.class, headers);
+    return apiClient.execute("GET", path, request, MetastoreInfo.class, headers);
   }
 
   @Override
@@ -63,7 +63,7 @@ class MetastoresImpl implements MetastoresService {
     String path = "/api/2.1/unity-catalog/metastores";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListMetastoresResponse.class, headers);
+    return apiClient.execute("GET", path, null, ListMetastoresResponse.class, headers);
   }
 
   @Override
@@ -71,7 +71,7 @@ class MetastoresImpl implements MetastoresService {
     String path = "/api/2.1/unity-catalog/metastore_summary";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, GetMetastoreSummaryResponse.class, headers);
+    return apiClient.execute("GET", path, null, GetMetastoreSummaryResponse.class, headers);
   }
 
   @Override
@@ -80,7 +80,7 @@ class MetastoresImpl implements MetastoresService {
         String.format("/api/2.1/unity-catalog/workspaces/%s/metastore", request.getWorkspaceId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, UnassignResponse.class, headers);
+    apiClient.execute("DELETE", path, request, UnassignResponse.class, headers);
   }
 
   @Override
@@ -89,7 +89,7 @@ class MetastoresImpl implements MetastoresService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, MetastoreInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, MetastoreInfo.class, headers);
   }
 
   @Override
@@ -99,6 +99,6 @@ class MetastoresImpl implements MetastoresService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateAssignmentResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateAssignmentResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ModelVersionsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ModelVersionsImpl.java
@@ -22,7 +22,7 @@ class ModelVersionsImpl implements ModelVersionsService {
             "/api/2.1/unity-catalog/models/%s/versions/%s",
             request.getFullName(), request.getVersion());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -33,7 +33,7 @@ class ModelVersionsImpl implements ModelVersionsService {
             request.getFullName(), request.getVersion());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ModelVersionInfo.class, headers);
+    return apiClient.execute("GET", path, request, ModelVersionInfo.class, headers);
   }
 
   @Override
@@ -44,7 +44,7 @@ class ModelVersionsImpl implements ModelVersionsService {
             request.getFullName(), request.getAlias());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ModelVersionInfo.class, headers);
+    return apiClient.execute("GET", path, request, ModelVersionInfo.class, headers);
   }
 
   @Override
@@ -52,7 +52,7 @@ class ModelVersionsImpl implements ModelVersionsService {
     String path = String.format("/api/2.1/unity-catalog/models/%s/versions", request.getFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListModelVersionsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListModelVersionsResponse.class, headers);
   }
 
   @Override
@@ -64,6 +64,6 @@ class ModelVersionsImpl implements ModelVersionsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, ModelVersionInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, ModelVersionInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ModelVersionsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ModelVersionsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ModelVersions */
 @Generated
@@ -21,8 +22,13 @@ class ModelVersionsImpl implements ModelVersionsService {
         String.format(
             "/api/2.1/unity-catalog/models/%s/versions/%s",
             request.getFullName(), request.getVersion());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,9 +37,14 @@ class ModelVersionsImpl implements ModelVersionsService {
         String.format(
             "/api/2.1/unity-catalog/models/%s/versions/%s",
             request.getFullName(), request.getVersion());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ModelVersionInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ModelVersionInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -42,17 +53,27 @@ class ModelVersionsImpl implements ModelVersionsService {
         String.format(
             "/api/2.1/unity-catalog/models/%s/aliases/%s",
             request.getFullName(), request.getAlias());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ModelVersionInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ModelVersionInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListModelVersionsResponse list(ListModelVersionsRequest request) {
     String path = String.format("/api/2.1/unity-catalog/models/%s/versions", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListModelVersionsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListModelVersionsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -61,9 +82,14 @@ class ModelVersionsImpl implements ModelVersionsService {
         String.format(
             "/api/2.1/unity-catalog/models/%s/versions/%s",
             request.getFullName(), request.getVersion());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, ModelVersionInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ModelVersionInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/OnlineTablesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/OnlineTablesImpl.java
@@ -21,7 +21,7 @@ class OnlineTablesImpl implements OnlineTablesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request.getTable(), OnlineTable.class, headers);
+    return apiClient.execute("POST", path, request.getTable(), OnlineTable.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class OnlineTablesImpl implements OnlineTablesService {
     String path = String.format("/api/2.0/online-tables/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,6 +37,6 @@ class OnlineTablesImpl implements OnlineTablesService {
     String path = String.format("/api/2.0/online-tables/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, OnlineTable.class, headers);
+    return apiClient.execute("GET", path, request, OnlineTable.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/OnlineTablesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/OnlineTablesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of OnlineTables */
 @Generated
@@ -18,25 +19,40 @@ class OnlineTablesImpl implements OnlineTablesService {
   @Override
   public OnlineTable create(CreateOnlineTableRequest request) {
     String path = "/api/2.0/online-tables";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request.getTable(), OnlineTable.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request.getTable()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, OnlineTable.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteOnlineTableRequest request) {
     String path = String.format("/api/2.0/online-tables/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public OnlineTable get(GetOnlineTableRequest request) {
     String path = String.format("/api/2.0/online-tables/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, OnlineTable.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, OnlineTable.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/QualityMonitorsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/QualityMonitorsImpl.java
@@ -22,7 +22,7 @@ class QualityMonitorsImpl implements QualityMonitorsService {
             "/api/2.1/unity-catalog/tables/%s/monitor/refreshes/%s/cancel",
             request.getTableName(), request.getRefreshId());
     Map<String, String> headers = new HashMap<>();
-    apiClient.POST(path, null, CancelRefreshResponse.class, headers);
+    apiClient.execute("POST", path, null, CancelRefreshResponse.class, headers);
   }
 
   @Override
@@ -31,14 +31,14 @@ class QualityMonitorsImpl implements QualityMonitorsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, MonitorInfo.class, headers);
+    return apiClient.execute("POST", path, request, MonitorInfo.class, headers);
   }
 
   @Override
   public void delete(DeleteQualityMonitorRequest request) {
     String path = String.format("/api/2.1/unity-catalog/tables/%s/monitor", request.getTableName());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -46,7 +46,7 @@ class QualityMonitorsImpl implements QualityMonitorsService {
     String path = String.format("/api/2.1/unity-catalog/tables/%s/monitor", request.getTableName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, MonitorInfo.class, headers);
+    return apiClient.execute("GET", path, request, MonitorInfo.class, headers);
   }
 
   @Override
@@ -57,7 +57,7 @@ class QualityMonitorsImpl implements QualityMonitorsService {
             request.getTableName(), request.getRefreshId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, MonitorRefreshInfo.class, headers);
+    return apiClient.execute("GET", path, request, MonitorRefreshInfo.class, headers);
   }
 
   @Override
@@ -66,7 +66,7 @@ class QualityMonitorsImpl implements QualityMonitorsService {
         String.format("/api/2.1/unity-catalog/tables/%s/monitor/refreshes", request.getTableName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, MonitorRefreshListResponse.class, headers);
+    return apiClient.execute("GET", path, request, MonitorRefreshListResponse.class, headers);
   }
 
   @Override
@@ -77,7 +77,7 @@ class QualityMonitorsImpl implements QualityMonitorsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, RegenerateDashboardResponse.class, headers);
+    return apiClient.execute("POST", path, request, RegenerateDashboardResponse.class, headers);
   }
 
   @Override
@@ -86,7 +86,7 @@ class QualityMonitorsImpl implements QualityMonitorsService {
         String.format("/api/2.1/unity-catalog/tables/%s/monitor/refreshes", request.getTableName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.POST(path, null, MonitorRefreshInfo.class, headers);
+    return apiClient.execute("POST", path, null, MonitorRefreshInfo.class, headers);
   }
 
   @Override
@@ -95,6 +95,6 @@ class QualityMonitorsImpl implements QualityMonitorsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, MonitorInfo.class, headers);
+    return apiClient.execute("PUT", path, request, MonitorInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/QualityMonitorsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/QualityMonitorsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of QualityMonitors */
 @Generated
@@ -21,32 +22,52 @@ class QualityMonitorsImpl implements QualityMonitorsService {
         String.format(
             "/api/2.1/unity-catalog/tables/%s/monitor/refreshes/%s/cancel",
             request.getTableName(), request.getRefreshId());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("POST", path, null, CancelRefreshResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, CancelRefreshResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public MonitorInfo create(CreateMonitor request) {
     String path = String.format("/api/2.1/unity-catalog/tables/%s/monitor", request.getTableName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, MonitorInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, MonitorInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteQualityMonitorRequest request) {
     String path = String.format("/api/2.1/unity-catalog/tables/%s/monitor", request.getTableName());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public MonitorInfo get(GetQualityMonitorRequest request) {
     String path = String.format("/api/2.1/unity-catalog/tables/%s/monitor", request.getTableName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, MonitorInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, MonitorInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -55,18 +76,28 @@ class QualityMonitorsImpl implements QualityMonitorsService {
         String.format(
             "/api/2.1/unity-catalog/tables/%s/monitor/refreshes/%s",
             request.getTableName(), request.getRefreshId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, MonitorRefreshInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, MonitorRefreshInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public MonitorRefreshListResponse listRefreshes(ListRefreshesRequest request) {
     String path =
         String.format("/api/2.1/unity-catalog/tables/%s/monitor/refreshes", request.getTableName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, MonitorRefreshListResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, MonitorRefreshListResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -74,27 +105,42 @@ class QualityMonitorsImpl implements QualityMonitorsService {
     String path =
         String.format(
             "/api/2.1/quality-monitoring/tables/%s/monitor/dashboard", request.getTableName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, RegenerateDashboardResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RegenerateDashboardResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public MonitorRefreshInfo runRefresh(RunRefreshRequest request) {
     String path =
         String.format("/api/2.1/unity-catalog/tables/%s/monitor/refreshes", request.getTableName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("POST", path, null, MonitorRefreshInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, MonitorRefreshInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public MonitorInfo update(UpdateMonitor request) {
     String path = String.format("/api/2.1/unity-catalog/tables/%s/monitor", request.getTableName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, MonitorInfo.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, MonitorInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/RegisteredModelsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/RegisteredModelsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of RegisteredModels */
 @Generated
@@ -18,17 +19,27 @@ class RegisteredModelsImpl implements RegisteredModelsService {
   @Override
   public RegisteredModelInfo create(CreateRegisteredModelRequest request) {
     String path = "/api/2.1/unity-catalog/models";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, RegisteredModelInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RegisteredModelInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteRegisteredModelRequest request) {
     String path = String.format("/api/2.1/unity-catalog/models/%s", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -37,24 +48,39 @@ class RegisteredModelsImpl implements RegisteredModelsService {
         String.format(
             "/api/2.1/unity-catalog/models/%s/aliases/%s",
             request.getFullName(), request.getAlias());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteAliasResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteAliasResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RegisteredModelInfo get(GetRegisteredModelRequest request) {
     String path = String.format("/api/2.1/unity-catalog/models/%s", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, RegisteredModelInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, RegisteredModelInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListRegisteredModelsResponse list(ListRegisteredModelsRequest request) {
     String path = "/api/2.1/unity-catalog/models";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListRegisteredModelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListRegisteredModelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -63,18 +89,28 @@ class RegisteredModelsImpl implements RegisteredModelsService {
         String.format(
             "/api/2.1/unity-catalog/models/%s/aliases/%s",
             request.getFullName(), request.getAlias());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, RegisteredModelAlias.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RegisteredModelAlias.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RegisteredModelInfo update(UpdateRegisteredModelRequest request) {
     String path = String.format("/api/2.1/unity-catalog/models/%s", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, RegisteredModelInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RegisteredModelInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/RegisteredModelsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/RegisteredModelsImpl.java
@@ -21,14 +21,14 @@ class RegisteredModelsImpl implements RegisteredModelsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, RegisteredModelInfo.class, headers);
+    return apiClient.execute("POST", path, request, RegisteredModelInfo.class, headers);
   }
 
   @Override
   public void delete(DeleteRegisteredModelRequest request) {
     String path = String.format("/api/2.1/unity-catalog/models/%s", request.getFullName());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -38,7 +38,7 @@ class RegisteredModelsImpl implements RegisteredModelsService {
             "/api/2.1/unity-catalog/models/%s/aliases/%s",
             request.getFullName(), request.getAlias());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteAliasResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteAliasResponse.class, headers);
   }
 
   @Override
@@ -46,7 +46,7 @@ class RegisteredModelsImpl implements RegisteredModelsService {
     String path = String.format("/api/2.1/unity-catalog/models/%s", request.getFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, RegisteredModelInfo.class, headers);
+    return apiClient.execute("GET", path, request, RegisteredModelInfo.class, headers);
   }
 
   @Override
@@ -54,7 +54,7 @@ class RegisteredModelsImpl implements RegisteredModelsService {
     String path = "/api/2.1/unity-catalog/models";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListRegisteredModelsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListRegisteredModelsResponse.class, headers);
   }
 
   @Override
@@ -66,7 +66,7 @@ class RegisteredModelsImpl implements RegisteredModelsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, RegisteredModelAlias.class, headers);
+    return apiClient.execute("PUT", path, request, RegisteredModelAlias.class, headers);
   }
 
   @Override
@@ -75,6 +75,6 @@ class RegisteredModelsImpl implements RegisteredModelsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, RegisteredModelInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, RegisteredModelInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ResourceQuotasImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ResourceQuotasImpl.java
@@ -23,7 +23,7 @@ class ResourceQuotasImpl implements ResourceQuotasService {
             request.getParentSecurableType(), request.getParentFullName(), request.getQuotaName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetQuotaResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetQuotaResponse.class, headers);
   }
 
   @Override
@@ -31,6 +31,6 @@ class ResourceQuotasImpl implements ResourceQuotasService {
     String path = "/api/2.1/unity-catalog/resource-quotas/all-resource-quotas";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListQuotasResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListQuotasResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ResourceQuotasImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/ResourceQuotasImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ResourceQuotas */
 @Generated
@@ -21,16 +22,26 @@ class ResourceQuotasImpl implements ResourceQuotasService {
         String.format(
             "/api/2.1/unity-catalog/resource-quotas/%s/%s/%s",
             request.getParentSecurableType(), request.getParentFullName(), request.getQuotaName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetQuotaResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetQuotaResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListQuotasResponse listQuotas(ListQuotasRequest request) {
     String path = "/api/2.1/unity-catalog/resource-quotas/all-resource-quotas";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListQuotasResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListQuotasResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/SchemasImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/SchemasImpl.java
@@ -21,7 +21,7 @@ class SchemasImpl implements SchemasService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, SchemaInfo.class, headers);
+    return apiClient.execute("POST", path, request, SchemaInfo.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class SchemasImpl implements SchemasService {
     String path = String.format("/api/2.1/unity-catalog/schemas/%s", request.getFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class SchemasImpl implements SchemasService {
     String path = String.format("/api/2.1/unity-catalog/schemas/%s", request.getFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, SchemaInfo.class, headers);
+    return apiClient.execute("GET", path, request, SchemaInfo.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class SchemasImpl implements SchemasService {
     String path = "/api/2.1/unity-catalog/schemas";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListSchemasResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListSchemasResponse.class, headers);
   }
 
   @Override
@@ -54,6 +54,6 @@ class SchemasImpl implements SchemasService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, SchemaInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, SchemaInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/SchemasImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/SchemasImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Schemas */
 @Generated
@@ -18,42 +19,67 @@ class SchemasImpl implements SchemasService {
   @Override
   public SchemaInfo create(CreateSchema request) {
     String path = "/api/2.1/unity-catalog/schemas";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, SchemaInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, SchemaInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteSchemaRequest request) {
     String path = String.format("/api/2.1/unity-catalog/schemas/%s", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public SchemaInfo get(GetSchemaRequest request) {
     String path = String.format("/api/2.1/unity-catalog/schemas/%s", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, SchemaInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, SchemaInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListSchemasResponse list(ListSchemasRequest request) {
     String path = "/api/2.1/unity-catalog/schemas";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListSchemasResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListSchemasResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public SchemaInfo update(UpdateSchema request) {
     String path = String.format("/api/2.1/unity-catalog/schemas/%s", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, SchemaInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, SchemaInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/StorageCredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/StorageCredentialsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of StorageCredentials */
 @Generated
@@ -18,52 +19,81 @@ class StorageCredentialsImpl implements StorageCredentialsService {
   @Override
   public StorageCredentialInfo create(CreateStorageCredential request) {
     String path = "/api/2.1/unity-catalog/storage-credentials";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, StorageCredentialInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, StorageCredentialInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteStorageCredentialRequest request) {
     String path = String.format("/api/2.1/unity-catalog/storage-credentials/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public StorageCredentialInfo get(GetStorageCredentialRequest request) {
     String path = String.format("/api/2.1/unity-catalog/storage-credentials/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, StorageCredentialInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, StorageCredentialInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListStorageCredentialsResponse list(ListStorageCredentialsRequest request) {
     String path = "/api/2.1/unity-catalog/storage-credentials";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListStorageCredentialsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListStorageCredentialsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public StorageCredentialInfo update(UpdateStorageCredential request) {
     String path = String.format("/api/2.1/unity-catalog/storage-credentials/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, StorageCredentialInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, StorageCredentialInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ValidateStorageCredentialResponse validate(ValidateStorageCredential request) {
     String path = "/api/2.1/unity-catalog/validate-storage-credentials";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST", path, request, ValidateStorageCredentialResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ValidateStorageCredentialResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/StorageCredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/StorageCredentialsImpl.java
@@ -21,7 +21,7 @@ class StorageCredentialsImpl implements StorageCredentialsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, StorageCredentialInfo.class, headers);
+    return apiClient.execute("POST", path, request, StorageCredentialInfo.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class StorageCredentialsImpl implements StorageCredentialsService {
     String path = String.format("/api/2.1/unity-catalog/storage-credentials/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class StorageCredentialsImpl implements StorageCredentialsService {
     String path = String.format("/api/2.1/unity-catalog/storage-credentials/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, StorageCredentialInfo.class, headers);
+    return apiClient.execute("GET", path, request, StorageCredentialInfo.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class StorageCredentialsImpl implements StorageCredentialsService {
     String path = "/api/2.1/unity-catalog/storage-credentials";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListStorageCredentialsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListStorageCredentialsResponse.class, headers);
   }
 
   @Override
@@ -54,7 +54,7 @@ class StorageCredentialsImpl implements StorageCredentialsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, StorageCredentialInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, StorageCredentialInfo.class, headers);
   }
 
   @Override
@@ -63,6 +63,7 @@ class StorageCredentialsImpl implements StorageCredentialsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ValidateStorageCredentialResponse.class, headers);
+    return apiClient.execute(
+        "POST", path, request, ValidateStorageCredentialResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/SystemSchemasImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/SystemSchemasImpl.java
@@ -23,7 +23,7 @@ class SystemSchemasImpl implements SystemSchemasService {
             request.getMetastoreId(), request.getSchemaName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DisableResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DisableResponse.class, headers);
   }
 
   @Override
@@ -34,7 +34,7 @@ class SystemSchemasImpl implements SystemSchemasService {
             request.getMetastoreId(), request.getSchemaName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.PUT(path, null, EnableResponse.class, headers);
+    apiClient.execute("PUT", path, null, EnableResponse.class, headers);
   }
 
   @Override
@@ -44,6 +44,6 @@ class SystemSchemasImpl implements SystemSchemasService {
             "/api/2.1/unity-catalog/metastores/%s/systemschemas", request.getMetastoreId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListSystemSchemasResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListSystemSchemasResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/SystemSchemasImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/SystemSchemasImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of SystemSchemas */
 @Generated
@@ -21,9 +22,14 @@ class SystemSchemasImpl implements SystemSchemasService {
         String.format(
             "/api/2.1/unity-catalog/metastores/%s/systemschemas/%s",
             request.getMetastoreId(), request.getSchemaName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DisableResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DisableResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -32,9 +38,14 @@ class SystemSchemasImpl implements SystemSchemasService {
         String.format(
             "/api/2.1/unity-catalog/metastores/%s/systemschemas/%s",
             request.getMetastoreId(), request.getSchemaName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("PUT", path, null, EnableResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, EnableResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -42,8 +53,13 @@ class SystemSchemasImpl implements SystemSchemasService {
     String path =
         String.format(
             "/api/2.1/unity-catalog/metastores/%s/systemschemas", request.getMetastoreId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListSystemSchemasResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListSystemSchemasResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TableConstraintsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TableConstraintsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of TableConstraints */
 @Generated
@@ -18,17 +19,27 @@ class TableConstraintsImpl implements TableConstraintsService {
   @Override
   public TableConstraint create(CreateTableConstraint request) {
     String path = "/api/2.1/unity-catalog/constraints";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, TableConstraint.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, TableConstraint.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteTableConstraintRequest request) {
     String path = String.format("/api/2.1/unity-catalog/constraints/%s", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TableConstraintsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TableConstraintsImpl.java
@@ -21,7 +21,7 @@ class TableConstraintsImpl implements TableConstraintsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, TableConstraint.class, headers);
+    return apiClient.execute("POST", path, request, TableConstraint.class, headers);
   }
 
   @Override
@@ -29,6 +29,6 @@ class TableConstraintsImpl implements TableConstraintsService {
     String path = String.format("/api/2.1/unity-catalog/constraints/%s", request.getFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TablesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TablesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Tables */
 @Generated
@@ -18,49 +19,79 @@ class TablesImpl implements TablesService {
   @Override
   public void delete(DeleteTableRequest request) {
     String path = String.format("/api/2.1/unity-catalog/tables/%s", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public TableExistsResponse exists(ExistsRequest request) {
     String path = String.format("/api/2.1/unity-catalog/tables/%s/exists", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, TableExistsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, TableExistsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public TableInfo get(GetTableRequest request) {
     String path = String.format("/api/2.1/unity-catalog/tables/%s", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, TableInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, TableInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListTablesResponse list(ListTablesRequest request) {
     String path = "/api/2.1/unity-catalog/tables";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListTablesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListTablesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListTableSummariesResponse listSummaries(ListSummariesRequest request) {
     String path = "/api/2.1/unity-catalog/table-summaries";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListTableSummariesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListTableSummariesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(UpdateTableRequest request) {
     String path = String.format("/api/2.1/unity-catalog/tables/%s", request.getFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TablesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TablesImpl.java
@@ -20,7 +20,7 @@ class TablesImpl implements TablesService {
     String path = String.format("/api/2.1/unity-catalog/tables/%s", request.getFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -28,7 +28,7 @@ class TablesImpl implements TablesService {
     String path = String.format("/api/2.1/unity-catalog/tables/%s/exists", request.getFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, TableExistsResponse.class, headers);
+    return apiClient.execute("GET", path, request, TableExistsResponse.class, headers);
   }
 
   @Override
@@ -36,7 +36,7 @@ class TablesImpl implements TablesService {
     String path = String.format("/api/2.1/unity-catalog/tables/%s", request.getFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, TableInfo.class, headers);
+    return apiClient.execute("GET", path, request, TableInfo.class, headers);
   }
 
   @Override
@@ -44,7 +44,7 @@ class TablesImpl implements TablesService {
     String path = "/api/2.1/unity-catalog/tables";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListTablesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListTablesResponse.class, headers);
   }
 
   @Override
@@ -52,7 +52,7 @@ class TablesImpl implements TablesService {
     String path = "/api/2.1/unity-catalog/table-summaries";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListTableSummariesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListTableSummariesResponse.class, headers);
   }
 
   @Override
@@ -61,6 +61,6 @@ class TablesImpl implements TablesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TemporaryTableCredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TemporaryTableCredentialsImpl.java
@@ -22,6 +22,7 @@ class TemporaryTableCredentialsImpl implements TemporaryTableCredentialsService 
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, GenerateTemporaryTableCredentialResponse.class, headers);
+    return apiClient.execute(
+        "POST", path, request, GenerateTemporaryTableCredentialResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TemporaryTableCredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/TemporaryTableCredentialsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of TemporaryTableCredentials */
 @Generated
@@ -19,10 +20,14 @@ class TemporaryTableCredentialsImpl implements TemporaryTableCredentialsService 
   public GenerateTemporaryTableCredentialResponse generateTemporaryTableCredentials(
       GenerateTemporaryTableCredentialRequest request) {
     String path = "/api/2.0/unity-catalog/temporary-table-credentials";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST", path, request, GenerateTemporaryTableCredentialResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, GenerateTemporaryTableCredentialResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/VolumesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/VolumesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Volumes */
 @Generated
@@ -18,41 +19,66 @@ class VolumesImpl implements VolumesService {
   @Override
   public VolumeInfo create(CreateVolumeRequestContent request) {
     String path = "/api/2.1/unity-catalog/volumes";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, VolumeInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, VolumeInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteVolumeRequest request) {
     String path = String.format("/api/2.1/unity-catalog/volumes/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListVolumesResponseContent list(ListVolumesRequest request) {
     String path = "/api/2.1/unity-catalog/volumes";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListVolumesResponseContent.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListVolumesResponseContent.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public VolumeInfo read(ReadVolumeRequest request) {
     String path = String.format("/api/2.1/unity-catalog/volumes/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, VolumeInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, VolumeInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public VolumeInfo update(UpdateVolumeRequestContent request) {
     String path = String.format("/api/2.1/unity-catalog/volumes/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, VolumeInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, VolumeInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/VolumesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/VolumesImpl.java
@@ -21,14 +21,14 @@ class VolumesImpl implements VolumesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, VolumeInfo.class, headers);
+    return apiClient.execute("POST", path, request, VolumeInfo.class, headers);
   }
 
   @Override
   public void delete(DeleteVolumeRequest request) {
     String path = String.format("/api/2.1/unity-catalog/volumes/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -36,7 +36,7 @@ class VolumesImpl implements VolumesService {
     String path = "/api/2.1/unity-catalog/volumes";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListVolumesResponseContent.class, headers);
+    return apiClient.execute("GET", path, request, ListVolumesResponseContent.class, headers);
   }
 
   @Override
@@ -44,7 +44,7 @@ class VolumesImpl implements VolumesService {
     String path = String.format("/api/2.1/unity-catalog/volumes/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, VolumeInfo.class, headers);
+    return apiClient.execute("GET", path, request, VolumeInfo.class, headers);
   }
 
   @Override
@@ -53,6 +53,6 @@ class VolumesImpl implements VolumesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, VolumeInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, VolumeInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/WorkspaceBindingsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/WorkspaceBindingsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.catalog;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of WorkspaceBindings */
 @Generated
@@ -19,9 +20,14 @@ class WorkspaceBindingsImpl implements WorkspaceBindingsService {
   public CurrentWorkspaceBindings get(GetWorkspaceBindingRequest request) {
     String path =
         String.format("/api/2.1/unity-catalog/workspace-bindings/catalogs/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, CurrentWorkspaceBindings.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, CurrentWorkspaceBindings.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -30,19 +36,29 @@ class WorkspaceBindingsImpl implements WorkspaceBindingsService {
         String.format(
             "/api/2.1/unity-catalog/bindings/%s/%s",
             request.getSecurableType(), request.getSecurableName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, WorkspaceBindingsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, WorkspaceBindingsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CurrentWorkspaceBindings update(UpdateWorkspaceBindings request) {
     String path =
         String.format("/api/2.1/unity-catalog/workspace-bindings/catalogs/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, CurrentWorkspaceBindings.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CurrentWorkspaceBindings.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -51,9 +67,14 @@ class WorkspaceBindingsImpl implements WorkspaceBindingsService {
         String.format(
             "/api/2.1/unity-catalog/bindings/%s/%s",
             request.getSecurableType(), request.getSecurableName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, WorkspaceBindingsResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, WorkspaceBindingsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/WorkspaceBindingsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/catalog/WorkspaceBindingsImpl.java
@@ -21,7 +21,7 @@ class WorkspaceBindingsImpl implements WorkspaceBindingsService {
         String.format("/api/2.1/unity-catalog/workspace-bindings/catalogs/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, CurrentWorkspaceBindings.class, headers);
+    return apiClient.execute("GET", path, request, CurrentWorkspaceBindings.class, headers);
   }
 
   @Override
@@ -32,7 +32,7 @@ class WorkspaceBindingsImpl implements WorkspaceBindingsService {
             request.getSecurableType(), request.getSecurableName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, WorkspaceBindingsResponse.class, headers);
+    return apiClient.execute("GET", path, request, WorkspaceBindingsResponse.class, headers);
   }
 
   @Override
@@ -42,7 +42,7 @@ class WorkspaceBindingsImpl implements WorkspaceBindingsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, CurrentWorkspaceBindings.class, headers);
+    return apiClient.execute("PATCH", path, request, CurrentWorkspaceBindings.class, headers);
   }
 
   @Override
@@ -54,6 +54,6 @@ class WorkspaceBindingsImpl implements WorkspaceBindingsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, WorkspaceBindingsResponse.class, headers);
+    return apiClient.execute("PATCH", path, request, WorkspaceBindingsResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomAssetsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomAssetsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.cleanrooms;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of CleanRoomAssets */
 @Generated
@@ -18,10 +19,15 @@ class CleanRoomAssetsImpl implements CleanRoomAssetsService {
   @Override
   public CleanRoomAsset create(CreateCleanRoomAssetRequest request) {
     String path = String.format("/api/2.0/clean-rooms/%s/assets", request.getCleanRoomName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request.getAsset(), CleanRoomAsset.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request.getAsset()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CleanRoomAsset.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -30,9 +36,14 @@ class CleanRoomAssetsImpl implements CleanRoomAssetsService {
         String.format(
             "/api/2.0/clean-rooms/%s/assets/%s/%s",
             request.getCleanRoomName(), request.getAssetType(), request.getAssetFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteCleanRoomAssetResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteCleanRoomAssetResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -41,17 +52,27 @@ class CleanRoomAssetsImpl implements CleanRoomAssetsService {
         String.format(
             "/api/2.0/clean-rooms/%s/assets/%s/%s",
             request.getCleanRoomName(), request.getAssetType(), request.getAssetFullName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, CleanRoomAsset.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, CleanRoomAsset.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListCleanRoomAssetsResponse list(ListCleanRoomAssetsRequest request) {
     String path = String.format("/api/2.0/clean-rooms/%s/assets", request.getCleanRoomName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListCleanRoomAssetsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListCleanRoomAssetsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -60,9 +81,14 @@ class CleanRoomAssetsImpl implements CleanRoomAssetsService {
         String.format(
             "/api/2.0/clean-rooms/%s/assets/%s/%s",
             request.getCleanRoomName(), request.getAssetType(), request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request.getAsset(), CleanRoomAsset.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request.getAsset()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CleanRoomAsset.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomAssetsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomAssetsImpl.java
@@ -21,7 +21,7 @@ class CleanRoomAssetsImpl implements CleanRoomAssetsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request.getAsset(), CleanRoomAsset.class, headers);
+    return apiClient.execute("POST", path, request.getAsset(), CleanRoomAsset.class, headers);
   }
 
   @Override
@@ -32,7 +32,7 @@ class CleanRoomAssetsImpl implements CleanRoomAssetsService {
             request.getCleanRoomName(), request.getAssetType(), request.getAssetFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteCleanRoomAssetResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteCleanRoomAssetResponse.class, headers);
   }
 
   @Override
@@ -43,7 +43,7 @@ class CleanRoomAssetsImpl implements CleanRoomAssetsService {
             request.getCleanRoomName(), request.getAssetType(), request.getAssetFullName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, CleanRoomAsset.class, headers);
+    return apiClient.execute("GET", path, request, CleanRoomAsset.class, headers);
   }
 
   @Override
@@ -51,7 +51,7 @@ class CleanRoomAssetsImpl implements CleanRoomAssetsService {
     String path = String.format("/api/2.0/clean-rooms/%s/assets", request.getCleanRoomName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListCleanRoomAssetsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListCleanRoomAssetsResponse.class, headers);
   }
 
   @Override
@@ -63,6 +63,6 @@ class CleanRoomAssetsImpl implements CleanRoomAssetsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request.getAsset(), CleanRoomAsset.class, headers);
+    return apiClient.execute("PATCH", path, request.getAsset(), CleanRoomAsset.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomTaskRunsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomTaskRunsImpl.java
@@ -20,6 +20,7 @@ class CleanRoomTaskRunsImpl implements CleanRoomTaskRunsService {
     String path = String.format("/api/2.0/clean-rooms/%s/runs", request.getCleanRoomName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListCleanRoomNotebookTaskRunsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, ListCleanRoomNotebookTaskRunsResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomTaskRunsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomTaskRunsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.cleanrooms;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of CleanRoomTaskRuns */
 @Generated
@@ -18,9 +19,13 @@ class CleanRoomTaskRunsImpl implements CleanRoomTaskRunsService {
   @Override
   public ListCleanRoomNotebookTaskRunsResponse list(ListCleanRoomNotebookTaskRunsRequest request) {
     String path = String.format("/api/2.0/clean-rooms/%s/runs", request.getCleanRoomName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, ListCleanRoomNotebookTaskRunsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListCleanRoomNotebookTaskRunsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomsImpl.java
@@ -21,7 +21,7 @@ class CleanRoomsImpl implements CleanRoomsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request.getCleanRoom(), CleanRoom.class, headers);
+    return apiClient.execute("POST", path, request.getCleanRoom(), CleanRoom.class, headers);
   }
 
   @Override
@@ -32,8 +32,12 @@ class CleanRoomsImpl implements CleanRoomsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(
-        path, request.getOutputCatalog(), CreateCleanRoomOutputCatalogResponse.class, headers);
+    return apiClient.execute(
+        "POST",
+        path,
+        request.getOutputCatalog(),
+        CreateCleanRoomOutputCatalogResponse.class,
+        headers);
   }
 
   @Override
@@ -41,7 +45,7 @@ class CleanRoomsImpl implements CleanRoomsService {
     String path = String.format("/api/2.0/clean-rooms/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -49,7 +53,7 @@ class CleanRoomsImpl implements CleanRoomsService {
     String path = String.format("/api/2.0/clean-rooms/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, CleanRoom.class, headers);
+    return apiClient.execute("GET", path, request, CleanRoom.class, headers);
   }
 
   @Override
@@ -57,7 +61,7 @@ class CleanRoomsImpl implements CleanRoomsService {
     String path = "/api/2.0/clean-rooms";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListCleanRoomsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListCleanRoomsResponse.class, headers);
   }
 
   @Override
@@ -66,6 +70,6 @@ class CleanRoomsImpl implements CleanRoomsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, CleanRoom.class, headers);
+    return apiClient.execute("PATCH", path, request, CleanRoom.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/cleanrooms/CleanRoomsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.cleanrooms;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of CleanRooms */
 @Generated
@@ -18,10 +19,15 @@ class CleanRoomsImpl implements CleanRoomsService {
   @Override
   public CleanRoom create(CreateCleanRoomRequest request) {
     String path = "/api/2.0/clean-rooms";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request.getCleanRoom(), CleanRoom.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request.getCleanRoom()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CleanRoom.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -29,47 +35,67 @@ class CleanRoomsImpl implements CleanRoomsService {
       CreateCleanRoomOutputCatalogRequest request) {
     String path =
         String.format("/api/2.0/clean-rooms/%s/output-catalogs", request.getCleanRoomName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST",
-        path,
-        request.getOutputCatalog(),
-        CreateCleanRoomOutputCatalogResponse.class,
-        headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request.getOutputCatalog()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateCleanRoomOutputCatalogResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteCleanRoomRequest request) {
     String path = String.format("/api/2.0/clean-rooms/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CleanRoom get(GetCleanRoomRequest request) {
     String path = String.format("/api/2.0/clean-rooms/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, CleanRoom.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, CleanRoom.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListCleanRoomsResponse list(ListCleanRoomsRequest request) {
     String path = "/api/2.0/clean-rooms";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListCleanRoomsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListCleanRoomsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CleanRoom update(UpdateCleanRoomRequest request) {
     String path = String.format("/api/2.0/clean-rooms/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, CleanRoom.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CleanRoom.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClusterPoliciesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClusterPoliciesImpl.java
@@ -21,7 +21,7 @@ class ClusterPoliciesImpl implements ClusterPoliciesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreatePolicyResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreatePolicyResponse.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class ClusterPoliciesImpl implements ClusterPoliciesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeletePolicyResponse.class, headers);
+    apiClient.execute("POST", path, request, DeletePolicyResponse.class, headers);
   }
 
   @Override
@@ -39,7 +39,7 @@ class ClusterPoliciesImpl implements ClusterPoliciesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, EditPolicyResponse.class, headers);
+    apiClient.execute("POST", path, request, EditPolicyResponse.class, headers);
   }
 
   @Override
@@ -47,7 +47,7 @@ class ClusterPoliciesImpl implements ClusterPoliciesService {
     String path = "/api/2.0/policies/clusters/get";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Policy.class, headers);
+    return apiClient.execute("GET", path, request, Policy.class, headers);
   }
 
   @Override
@@ -59,7 +59,8 @@ class ClusterPoliciesImpl implements ClusterPoliciesService {
             request.getClusterPolicyId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetClusterPolicyPermissionLevelsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetClusterPolicyPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -68,7 +69,7 @@ class ClusterPoliciesImpl implements ClusterPoliciesService {
         String.format("/api/2.0/permissions/cluster-policies/%s", request.getClusterPolicyId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ClusterPolicyPermissions.class, headers);
+    return apiClient.execute("GET", path, request, ClusterPolicyPermissions.class, headers);
   }
 
   @Override
@@ -76,7 +77,7 @@ class ClusterPoliciesImpl implements ClusterPoliciesService {
     String path = "/api/2.0/policies/clusters/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListPoliciesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListPoliciesResponse.class, headers);
   }
 
   @Override
@@ -86,7 +87,7 @@ class ClusterPoliciesImpl implements ClusterPoliciesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, ClusterPolicyPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, ClusterPolicyPermissions.class, headers);
   }
 
   @Override
@@ -96,6 +97,6 @@ class ClusterPoliciesImpl implements ClusterPoliciesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, ClusterPolicyPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, ClusterPolicyPermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClusterPoliciesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClusterPoliciesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ClusterPolicies */
 @Generated
@@ -18,36 +19,56 @@ class ClusterPoliciesImpl implements ClusterPoliciesService {
   @Override
   public CreatePolicyResponse create(CreatePolicy request) {
     String path = "/api/2.0/policies/clusters/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreatePolicyResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreatePolicyResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeletePolicy request) {
     String path = "/api/2.0/policies/clusters/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeletePolicyResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeletePolicyResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void edit(EditPolicy request) {
     String path = "/api/2.0/policies/clusters/edit";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, EditPolicyResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, EditPolicyResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Policy get(GetClusterPolicyRequest request) {
     String path = "/api/2.0/policies/clusters/get";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Policy.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Policy.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -57,46 +78,70 @@ class ClusterPoliciesImpl implements ClusterPoliciesService {
         String.format(
             "/api/2.0/permissions/cluster-policies/%s/permissionLevels",
             request.getClusterPolicyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetClusterPolicyPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetClusterPolicyPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ClusterPolicyPermissions getPermissions(GetClusterPolicyPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/cluster-policies/%s", request.getClusterPolicyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ClusterPolicyPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ClusterPolicyPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListPoliciesResponse list(ListClusterPoliciesRequest request) {
     String path = "/api/2.0/policies/clusters/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListPoliciesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListPoliciesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ClusterPolicyPermissions setPermissions(ClusterPolicyPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/cluster-policies/%s", request.getClusterPolicyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, ClusterPolicyPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ClusterPolicyPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ClusterPolicyPermissions updatePermissions(ClusterPolicyPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/cluster-policies/%s", request.getClusterPolicyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, ClusterPolicyPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ClusterPolicyPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClustersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClustersImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Clusters */
 @Generated
@@ -18,54 +19,84 @@ class ClustersImpl implements ClustersService {
   @Override
   public void changeOwner(ChangeClusterOwner request) {
     String path = "/api/2.1/clusters/change-owner";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, ChangeClusterOwnerResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, ChangeClusterOwnerResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CreateClusterResponse create(CreateCluster request) {
     String path = "/api/2.1/clusters/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateClusterResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateClusterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteCluster request) {
     String path = "/api/2.1/clusters/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteClusterResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteClusterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void edit(EditCluster request) {
     String path = "/api/2.1/clusters/edit";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, EditClusterResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, EditClusterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetEventsResponse events(GetEvents request) {
     String path = "/api/2.1/clusters/events";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, GetEventsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, GetEventsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ClusterDetails get(GetClusterRequest request) {
     String path = "/api/2.1/clusters/get";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ClusterDetails.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ClusterDetails.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -73,130 +104,204 @@ class ClustersImpl implements ClustersService {
       GetClusterPermissionLevelsRequest request) {
     String path =
         String.format("/api/2.0/permissions/clusters/%s/permissionLevels", request.getClusterId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetClusterPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetClusterPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ClusterPermissions getPermissions(GetClusterPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/clusters/%s", request.getClusterId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ClusterPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ClusterPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListClustersResponse list(ListClustersRequest request) {
     String path = "/api/2.1/clusters/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListClustersResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListClustersResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListNodeTypesResponse listNodeTypes() {
     String path = "/api/2.1/clusters/list-node-types";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListNodeTypesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListNodeTypesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListAvailableZonesResponse listZones() {
     String path = "/api/2.1/clusters/list-zones";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListAvailableZonesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListAvailableZonesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void permanentDelete(PermanentDeleteCluster request) {
     String path = "/api/2.1/clusters/permanent-delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, PermanentDeleteClusterResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PermanentDeleteClusterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void pin(PinCluster request) {
     String path = "/api/2.1/clusters/pin";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, PinClusterResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PinClusterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void resize(ResizeCluster request) {
     String path = "/api/2.1/clusters/resize";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, ResizeClusterResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, ResizeClusterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void restart(RestartCluster request) {
     String path = "/api/2.1/clusters/restart";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, RestartClusterResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, RestartClusterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ClusterPermissions setPermissions(ClusterPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/clusters/%s", request.getClusterId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, ClusterPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ClusterPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetSparkVersionsResponse sparkVersions() {
     String path = "/api/2.1/clusters/spark-versions";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, GetSparkVersionsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetSparkVersionsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void start(StartCluster request) {
     String path = "/api/2.1/clusters/start";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, StartClusterResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, StartClusterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void unpin(UnpinCluster request) {
     String path = "/api/2.1/clusters/unpin";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, UnpinClusterResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UnpinClusterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(UpdateCluster request) {
     String path = "/api/2.1/clusters/update";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, UpdateClusterResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateClusterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ClusterPermissions updatePermissions(ClusterPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/clusters/%s", request.getClusterId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, ClusterPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ClusterPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClustersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/ClustersImpl.java
@@ -21,7 +21,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, ChangeClusterOwnerResponse.class, headers);
+    apiClient.execute("POST", path, request, ChangeClusterOwnerResponse.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateClusterResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateClusterResponse.class, headers);
   }
 
   @Override
@@ -39,7 +39,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteClusterResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteClusterResponse.class, headers);
   }
 
   @Override
@@ -48,7 +48,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, EditClusterResponse.class, headers);
+    apiClient.execute("POST", path, request, EditClusterResponse.class, headers);
   }
 
   @Override
@@ -57,7 +57,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, GetEventsResponse.class, headers);
+    return apiClient.execute("POST", path, request, GetEventsResponse.class, headers);
   }
 
   @Override
@@ -65,7 +65,7 @@ class ClustersImpl implements ClustersService {
     String path = "/api/2.1/clusters/get";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ClusterDetails.class, headers);
+    return apiClient.execute("GET", path, request, ClusterDetails.class, headers);
   }
 
   @Override
@@ -75,7 +75,8 @@ class ClustersImpl implements ClustersService {
         String.format("/api/2.0/permissions/clusters/%s/permissionLevels", request.getClusterId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetClusterPermissionLevelsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetClusterPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -83,7 +84,7 @@ class ClustersImpl implements ClustersService {
     String path = String.format("/api/2.0/permissions/clusters/%s", request.getClusterId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ClusterPermissions.class, headers);
+    return apiClient.execute("GET", path, request, ClusterPermissions.class, headers);
   }
 
   @Override
@@ -91,7 +92,7 @@ class ClustersImpl implements ClustersService {
     String path = "/api/2.1/clusters/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListClustersResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListClustersResponse.class, headers);
   }
 
   @Override
@@ -99,7 +100,7 @@ class ClustersImpl implements ClustersService {
     String path = "/api/2.1/clusters/list-node-types";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListNodeTypesResponse.class, headers);
+    return apiClient.execute("GET", path, null, ListNodeTypesResponse.class, headers);
   }
 
   @Override
@@ -107,7 +108,7 @@ class ClustersImpl implements ClustersService {
     String path = "/api/2.1/clusters/list-zones";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListAvailableZonesResponse.class, headers);
+    return apiClient.execute("GET", path, null, ListAvailableZonesResponse.class, headers);
   }
 
   @Override
@@ -116,7 +117,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, PermanentDeleteClusterResponse.class, headers);
+    apiClient.execute("POST", path, request, PermanentDeleteClusterResponse.class, headers);
   }
 
   @Override
@@ -125,7 +126,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, PinClusterResponse.class, headers);
+    apiClient.execute("POST", path, request, PinClusterResponse.class, headers);
   }
 
   @Override
@@ -134,7 +135,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, ResizeClusterResponse.class, headers);
+    apiClient.execute("POST", path, request, ResizeClusterResponse.class, headers);
   }
 
   @Override
@@ -143,7 +144,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, RestartClusterResponse.class, headers);
+    apiClient.execute("POST", path, request, RestartClusterResponse.class, headers);
   }
 
   @Override
@@ -152,7 +153,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, ClusterPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, ClusterPermissions.class, headers);
   }
 
   @Override
@@ -160,7 +161,7 @@ class ClustersImpl implements ClustersService {
     String path = "/api/2.1/clusters/spark-versions";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, GetSparkVersionsResponse.class, headers);
+    return apiClient.execute("GET", path, null, GetSparkVersionsResponse.class, headers);
   }
 
   @Override
@@ -169,7 +170,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, StartClusterResponse.class, headers);
+    apiClient.execute("POST", path, request, StartClusterResponse.class, headers);
   }
 
   @Override
@@ -178,7 +179,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, UnpinClusterResponse.class, headers);
+    apiClient.execute("POST", path, request, UnpinClusterResponse.class, headers);
   }
 
   @Override
@@ -187,7 +188,7 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, UpdateClusterResponse.class, headers);
+    apiClient.execute("POST", path, request, UpdateClusterResponse.class, headers);
   }
 
   @Override
@@ -196,6 +197,6 @@ class ClustersImpl implements ClustersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, ClusterPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, ClusterPermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/CommandExecutionImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/CommandExecutionImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of CommandExecution */
 @Generated
@@ -18,52 +19,82 @@ class CommandExecutionImpl implements CommandExecutionService {
   @Override
   public void cancel(CancelCommand request) {
     String path = "/api/1.2/commands/cancel";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, CancelResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, CancelResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CommandStatusResponse commandStatus(CommandStatusRequest request) {
     String path = "/api/1.2/commands/status";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, CommandStatusResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, CommandStatusResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ContextStatusResponse contextStatus(ContextStatusRequest request) {
     String path = "/api/1.2/contexts/status";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ContextStatusResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ContextStatusResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Created create(CreateContext request) {
     String path = "/api/1.2/contexts/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Created.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Created.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void destroy(DestroyContext request) {
     String path = "/api/1.2/contexts/destroy";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DestroyResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DestroyResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Created execute(Command request) {
     String path = "/api/1.2/commands/execute";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Created.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Created.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/CommandExecutionImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/CommandExecutionImpl.java
@@ -21,7 +21,7 @@ class CommandExecutionImpl implements CommandExecutionService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, CancelResponse.class, headers);
+    apiClient.execute("POST", path, request, CancelResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class CommandExecutionImpl implements CommandExecutionService {
     String path = "/api/1.2/commands/status";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, CommandStatusResponse.class, headers);
+    return apiClient.execute("GET", path, request, CommandStatusResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class CommandExecutionImpl implements CommandExecutionService {
     String path = "/api/1.2/contexts/status";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ContextStatusResponse.class, headers);
+    return apiClient.execute("GET", path, request, ContextStatusResponse.class, headers);
   }
 
   @Override
@@ -46,7 +46,7 @@ class CommandExecutionImpl implements CommandExecutionService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Created.class, headers);
+    return apiClient.execute("POST", path, request, Created.class, headers);
   }
 
   @Override
@@ -55,7 +55,7 @@ class CommandExecutionImpl implements CommandExecutionService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DestroyResponse.class, headers);
+    apiClient.execute("POST", path, request, DestroyResponse.class, headers);
   }
 
   @Override
@@ -64,6 +64,6 @@ class CommandExecutionImpl implements CommandExecutionService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Created.class, headers);
+    return apiClient.execute("POST", path, request, Created.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/GlobalInitScriptsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/GlobalInitScriptsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of GlobalInitScripts */
 @Generated
@@ -18,41 +19,65 @@ class GlobalInitScriptsImpl implements GlobalInitScriptsService {
   @Override
   public CreateResponse create(GlobalInitScriptCreateRequest request) {
     String path = "/api/2.0/global-init-scripts";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteGlobalInitScriptRequest request) {
     String path = String.format("/api/2.0/global-init-scripts/%s", request.getScriptId());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GlobalInitScriptDetailsWithContent get(GetGlobalInitScriptRequest request) {
     String path = String.format("/api/2.0/global-init-scripts/%s", request.getScriptId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GlobalInitScriptDetailsWithContent.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GlobalInitScriptDetailsWithContent.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListGlobalInitScriptsResponse list() {
     String path = "/api/2.0/global-init-scripts";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListGlobalInitScriptsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListGlobalInitScriptsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(GlobalInitScriptUpdateRequest request) {
     String path = String.format("/api/2.0/global-init-scripts/%s", request.getScriptId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/GlobalInitScriptsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/GlobalInitScriptsImpl.java
@@ -21,14 +21,14 @@ class GlobalInitScriptsImpl implements GlobalInitScriptsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateResponse.class, headers);
   }
 
   @Override
   public void delete(DeleteGlobalInitScriptRequest request) {
     String path = String.format("/api/2.0/global-init-scripts/%s", request.getScriptId());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -36,7 +36,8 @@ class GlobalInitScriptsImpl implements GlobalInitScriptsService {
     String path = String.format("/api/2.0/global-init-scripts/%s", request.getScriptId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GlobalInitScriptDetailsWithContent.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GlobalInitScriptDetailsWithContent.class, headers);
   }
 
   @Override
@@ -44,7 +45,7 @@ class GlobalInitScriptsImpl implements GlobalInitScriptsService {
     String path = "/api/2.0/global-init-scripts";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListGlobalInitScriptsResponse.class, headers);
+    return apiClient.execute("GET", path, null, ListGlobalInitScriptsResponse.class, headers);
   }
 
   @Override
@@ -52,6 +53,6 @@ class GlobalInitScriptsImpl implements GlobalInitScriptsService {
     String path = String.format("/api/2.0/global-init-scripts/%s", request.getScriptId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstancePoolsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstancePoolsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of InstancePools */
 @Generated
@@ -18,36 +19,56 @@ class InstancePoolsImpl implements InstancePoolsService {
   @Override
   public CreateInstancePoolResponse create(CreateInstancePool request) {
     String path = "/api/2.0/instance-pools/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateInstancePoolResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateInstancePoolResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteInstancePool request) {
     String path = "/api/2.0/instance-pools/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteInstancePoolResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteInstancePoolResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void edit(EditInstancePool request) {
     String path = "/api/2.0/instance-pools/edit";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, EditInstancePoolResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, EditInstancePoolResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetInstancePool get(GetInstancePoolRequest request) {
     String path = "/api/2.0/instance-pools/get";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetInstancePool.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetInstancePool.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -56,46 +77,70 @@ class InstancePoolsImpl implements InstancePoolsService {
     String path =
         String.format(
             "/api/2.0/permissions/instance-pools/%s/permissionLevels", request.getInstancePoolId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetInstancePoolPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetInstancePoolPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public InstancePoolPermissions getPermissions(GetInstancePoolPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/instance-pools/%s", request.getInstancePoolId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, InstancePoolPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, InstancePoolPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListInstancePools list() {
     String path = "/api/2.0/instance-pools/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListInstancePools.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListInstancePools.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public InstancePoolPermissions setPermissions(InstancePoolPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/instance-pools/%s", request.getInstancePoolId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, InstancePoolPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, InstancePoolPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public InstancePoolPermissions updatePermissions(InstancePoolPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/instance-pools/%s", request.getInstancePoolId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, InstancePoolPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, InstancePoolPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstancePoolsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstancePoolsImpl.java
@@ -21,7 +21,7 @@ class InstancePoolsImpl implements InstancePoolsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateInstancePoolResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateInstancePoolResponse.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class InstancePoolsImpl implements InstancePoolsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteInstancePoolResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteInstancePoolResponse.class, headers);
   }
 
   @Override
@@ -39,7 +39,7 @@ class InstancePoolsImpl implements InstancePoolsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, EditInstancePoolResponse.class, headers);
+    apiClient.execute("POST", path, request, EditInstancePoolResponse.class, headers);
   }
 
   @Override
@@ -47,7 +47,7 @@ class InstancePoolsImpl implements InstancePoolsService {
     String path = "/api/2.0/instance-pools/get";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetInstancePool.class, headers);
+    return apiClient.execute("GET", path, request, GetInstancePool.class, headers);
   }
 
   @Override
@@ -58,7 +58,8 @@ class InstancePoolsImpl implements InstancePoolsService {
             "/api/2.0/permissions/instance-pools/%s/permissionLevels", request.getInstancePoolId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetInstancePoolPermissionLevelsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetInstancePoolPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -67,7 +68,7 @@ class InstancePoolsImpl implements InstancePoolsService {
         String.format("/api/2.0/permissions/instance-pools/%s", request.getInstancePoolId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, InstancePoolPermissions.class, headers);
+    return apiClient.execute("GET", path, request, InstancePoolPermissions.class, headers);
   }
 
   @Override
@@ -75,7 +76,7 @@ class InstancePoolsImpl implements InstancePoolsService {
     String path = "/api/2.0/instance-pools/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListInstancePools.class, headers);
+    return apiClient.execute("GET", path, null, ListInstancePools.class, headers);
   }
 
   @Override
@@ -85,7 +86,7 @@ class InstancePoolsImpl implements InstancePoolsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, InstancePoolPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, InstancePoolPermissions.class, headers);
   }
 
   @Override
@@ -95,6 +96,6 @@ class InstancePoolsImpl implements InstancePoolsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, InstancePoolPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, InstancePoolPermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstanceProfilesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstanceProfilesImpl.java
@@ -21,7 +21,7 @@ class InstanceProfilesImpl implements InstanceProfilesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, AddResponse.class, headers);
+    apiClient.execute("POST", path, request, AddResponse.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class InstanceProfilesImpl implements InstanceProfilesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, EditResponse.class, headers);
+    apiClient.execute("POST", path, request, EditResponse.class, headers);
   }
 
   @Override
@@ -38,7 +38,7 @@ class InstanceProfilesImpl implements InstanceProfilesService {
     String path = "/api/2.0/instance-profiles/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListInstanceProfilesResponse.class, headers);
+    return apiClient.execute("GET", path, null, ListInstanceProfilesResponse.class, headers);
   }
 
   @Override
@@ -47,6 +47,6 @@ class InstanceProfilesImpl implements InstanceProfilesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, RemoveResponse.class, headers);
+    apiClient.execute("POST", path, request, RemoveResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstanceProfilesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/InstanceProfilesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of InstanceProfiles */
 @Generated
@@ -18,35 +19,55 @@ class InstanceProfilesImpl implements InstanceProfilesService {
   @Override
   public void add(AddInstanceProfile request) {
     String path = "/api/2.0/instance-profiles/add";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, AddResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, AddResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void edit(InstanceProfile request) {
     String path = "/api/2.0/instance-profiles/edit";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, EditResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, EditResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListInstanceProfilesResponse list() {
     String path = "/api/2.0/instance-profiles/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListInstanceProfilesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListInstanceProfilesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void remove(RemoveInstanceProfile request) {
     String path = "/api/2.0/instance-profiles/remove";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, RemoveResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, RemoveResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/LibrariesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/LibrariesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Libraries */
 @Generated
@@ -18,35 +19,54 @@ class LibrariesImpl implements LibrariesService {
   @Override
   public ListAllClusterLibraryStatusesResponse allClusterStatuses() {
     String path = "/api/2.0/libraries/all-cluster-statuses";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, null, ListAllClusterLibraryStatusesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListAllClusterLibraryStatusesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ClusterLibraryStatuses clusterStatus(ClusterStatus request) {
     String path = "/api/2.0/libraries/cluster-status";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ClusterLibraryStatuses.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ClusterLibraryStatuses.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void install(InstallLibraries request) {
     String path = "/api/2.0/libraries/install";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, InstallLibrariesResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, InstallLibrariesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void uninstall(UninstallLibraries request) {
     String path = "/api/2.0/libraries/uninstall";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, UninstallLibrariesResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UninstallLibrariesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/LibrariesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/LibrariesImpl.java
@@ -20,7 +20,8 @@ class LibrariesImpl implements LibrariesService {
     String path = "/api/2.0/libraries/all-cluster-statuses";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListAllClusterLibraryStatusesResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, null, ListAllClusterLibraryStatusesResponse.class, headers);
   }
 
   @Override
@@ -28,7 +29,7 @@ class LibrariesImpl implements LibrariesService {
     String path = "/api/2.0/libraries/cluster-status";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ClusterLibraryStatuses.class, headers);
+    return apiClient.execute("GET", path, request, ClusterLibraryStatuses.class, headers);
   }
 
   @Override
@@ -37,7 +38,7 @@ class LibrariesImpl implements LibrariesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, InstallLibrariesResponse.class, headers);
+    apiClient.execute("POST", path, request, InstallLibrariesResponse.class, headers);
   }
 
   @Override
@@ -46,6 +47,6 @@ class LibrariesImpl implements LibrariesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, UninstallLibrariesResponse.class, headers);
+    apiClient.execute("POST", path, request, UninstallLibrariesResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/PolicyComplianceForClustersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/PolicyComplianceForClustersImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of PolicyComplianceForClusters */
 @Generated
@@ -19,26 +20,40 @@ class PolicyComplianceForClustersImpl implements PolicyComplianceForClustersServ
   public EnforceClusterComplianceResponse enforceCompliance(
       EnforceClusterComplianceRequest request) {
     String path = "/api/2.0/policies/clusters/enforce-compliance";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST", path, request, EnforceClusterComplianceResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, EnforceClusterComplianceResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetClusterComplianceResponse getCompliance(GetClusterComplianceRequest request) {
     String path = "/api/2.0/policies/clusters/get-compliance";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetClusterComplianceResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetClusterComplianceResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListClusterCompliancesResponse listCompliance(ListClusterCompliancesRequest request) {
     String path = "/api/2.0/policies/clusters/list-compliance";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListClusterCompliancesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListClusterCompliancesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/PolicyComplianceForClustersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/PolicyComplianceForClustersImpl.java
@@ -22,7 +22,8 @@ class PolicyComplianceForClustersImpl implements PolicyComplianceForClustersServ
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, EnforceClusterComplianceResponse.class, headers);
+    return apiClient.execute(
+        "POST", path, request, EnforceClusterComplianceResponse.class, headers);
   }
 
   @Override
@@ -30,7 +31,7 @@ class PolicyComplianceForClustersImpl implements PolicyComplianceForClustersServ
     String path = "/api/2.0/policies/clusters/get-compliance";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetClusterComplianceResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetClusterComplianceResponse.class, headers);
   }
 
   @Override
@@ -38,6 +39,6 @@ class PolicyComplianceForClustersImpl implements PolicyComplianceForClustersServ
     String path = "/api/2.0/policies/clusters/list-compliance";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListClusterCompliancesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListClusterCompliancesResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/PolicyFamiliesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/PolicyFamiliesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.compute;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of PolicyFamilies */
 @Generated
@@ -18,16 +19,26 @@ class PolicyFamiliesImpl implements PolicyFamiliesService {
   @Override
   public PolicyFamily get(GetPolicyFamilyRequest request) {
     String path = String.format("/api/2.0/policy-families/%s", request.getPolicyFamilyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, PolicyFamily.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, PolicyFamily.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListPolicyFamiliesResponse list(ListPolicyFamiliesRequest request) {
     String path = "/api/2.0/policy-families";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListPolicyFamiliesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListPolicyFamiliesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/PolicyFamiliesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/compute/PolicyFamiliesImpl.java
@@ -20,7 +20,7 @@ class PolicyFamiliesImpl implements PolicyFamiliesService {
     String path = String.format("/api/2.0/policy-families/%s", request.getPolicyFamilyId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, PolicyFamily.class, headers);
+    return apiClient.execute("GET", path, request, PolicyFamily.class, headers);
   }
 
   @Override
@@ -28,6 +28,6 @@ class PolicyFamiliesImpl implements PolicyFamiliesService {
     String path = "/api/2.0/policy-families";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListPolicyFamiliesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListPolicyFamiliesResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dashboards/GenieImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dashboards/GenieImpl.java
@@ -24,7 +24,7 @@ class GenieImpl implements GenieService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, GenieMessage.class, headers);
+    return apiClient.execute("POST", path, request, GenieMessage.class, headers);
   }
 
   @Override
@@ -36,7 +36,7 @@ class GenieImpl implements GenieService {
             request.getSpaceId(), request.getConversationId(), request.getMessageId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.POST(path, null, GenieGetMessageQueryResultResponse.class, headers);
+    return apiClient.execute("POST", path, null, GenieGetMessageQueryResultResponse.class, headers);
   }
 
   @Override
@@ -47,7 +47,7 @@ class GenieImpl implements GenieService {
             request.getSpaceId(), request.getConversationId(), request.getMessageId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GenieMessage.class, headers);
+    return apiClient.execute("GET", path, request, GenieMessage.class, headers);
   }
 
   @Override
@@ -59,7 +59,8 @@ class GenieImpl implements GenieService {
             request.getSpaceId(), request.getConversationId(), request.getMessageId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GenieGetMessageQueryResultResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GenieGetMessageQueryResultResponse.class, headers);
   }
 
   @Override
@@ -70,6 +71,6 @@ class GenieImpl implements GenieService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, GenieStartConversationResponse.class, headers);
+    return apiClient.execute("POST", path, request, GenieStartConversationResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dashboards/GenieImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dashboards/GenieImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.dashboards;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Genie */
 @Generated
@@ -21,10 +22,15 @@ class GenieImpl implements GenieService {
         String.format(
             "/api/2.0/genie/spaces/%s/conversations/%s/messages",
             request.getSpaceId(), request.getConversationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, GenieMessage.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, GenieMessage.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -34,9 +40,14 @@ class GenieImpl implements GenieService {
         String.format(
             "/api/2.0/genie/spaces/%s/conversations/%s/messages/%s/execute-query",
             request.getSpaceId(), request.getConversationId(), request.getMessageId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("POST", path, null, GenieGetMessageQueryResultResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GenieGetMessageQueryResultResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -45,9 +56,14 @@ class GenieImpl implements GenieService {
         String.format(
             "/api/2.0/genie/spaces/%s/conversations/%s/messages/%s",
             request.getSpaceId(), request.getConversationId(), request.getMessageId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GenieMessage.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GenieMessage.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -57,10 +73,14 @@ class GenieImpl implements GenieService {
         String.format(
             "/api/2.0/genie/spaces/%s/conversations/%s/messages/%s/query-result",
             request.getSpaceId(), request.getConversationId(), request.getMessageId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GenieGetMessageQueryResultResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GenieGetMessageQueryResultResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -68,9 +88,14 @@ class GenieImpl implements GenieService {
       GenieStartConversationMessageRequest request) {
     String path =
         String.format("/api/2.0/genie/spaces/%s/start-conversation", request.getSpaceId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, GenieStartConversationResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, GenieStartConversationResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dashboards/LakeviewImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dashboards/LakeviewImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.dashboards;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Lakeview */
 @Generated
@@ -18,20 +19,30 @@ class LakeviewImpl implements LakeviewService {
   @Override
   public Dashboard create(CreateDashboardRequest request) {
     String path = "/api/2.0/lakeview/dashboards";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request.getDashboard(), Dashboard.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request.getDashboard()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Dashboard.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Schedule createSchedule(CreateScheduleRequest request) {
     String path =
         String.format("/api/2.0/lakeview/dashboards/%s/schedules", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request.getSchedule(), Schedule.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request.getSchedule()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Schedule.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -40,10 +51,15 @@ class LakeviewImpl implements LakeviewService {
         String.format(
             "/api/2.0/lakeview/dashboards/%s/schedules/%s/subscriptions",
             request.getDashboardId(), request.getScheduleId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request.getSubscription(), Subscription.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request.getSubscription()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Subscription.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -52,9 +68,14 @@ class LakeviewImpl implements LakeviewService {
         String.format(
             "/api/2.0/lakeview/dashboards/%s/schedules/%s",
             request.getDashboardId(), request.getScheduleId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteScheduleResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteScheduleResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -63,26 +84,41 @@ class LakeviewImpl implements LakeviewService {
         String.format(
             "/api/2.0/lakeview/dashboards/%s/schedules/%s/subscriptions/%s",
             request.getDashboardId(), request.getScheduleId(), request.getSubscriptionId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteSubscriptionResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteSubscriptionResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Dashboard get(GetDashboardRequest request) {
     String path = String.format("/api/2.0/lakeview/dashboards/%s", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Dashboard.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Dashboard.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public PublishedDashboard getPublished(GetPublishedDashboardRequest request) {
     String path =
         String.format("/api/2.0/lakeview/dashboards/%s/published", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, PublishedDashboard.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, PublishedDashboard.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -91,9 +127,14 @@ class LakeviewImpl implements LakeviewService {
         String.format(
             "/api/2.0/lakeview/dashboards/%s/schedules/%s",
             request.getDashboardId(), request.getScheduleId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Schedule.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Schedule.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -102,26 +143,41 @@ class LakeviewImpl implements LakeviewService {
         String.format(
             "/api/2.0/lakeview/dashboards/%s/schedules/%s/subscriptions/%s",
             request.getDashboardId(), request.getScheduleId(), request.getSubscriptionId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Subscription.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Subscription.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListDashboardsResponse list(ListDashboardsRequest request) {
     String path = "/api/2.0/lakeview/dashboards";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListDashboardsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListDashboardsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListSchedulesResponse listSchedules(ListSchedulesRequest request) {
     String path =
         String.format("/api/2.0/lakeview/dashboards/%s/schedules", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListSchedulesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListSchedulesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -130,54 +186,84 @@ class LakeviewImpl implements LakeviewService {
         String.format(
             "/api/2.0/lakeview/dashboards/%s/schedules/%s/subscriptions",
             request.getDashboardId(), request.getScheduleId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListSubscriptionsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListSubscriptionsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Dashboard migrate(MigrateDashboardRequest request) {
     String path = "/api/2.0/lakeview/dashboards/migrate";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Dashboard.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Dashboard.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public PublishedDashboard publish(PublishRequest request) {
     String path =
         String.format("/api/2.0/lakeview/dashboards/%s/published", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, PublishedDashboard.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, PublishedDashboard.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void trash(TrashDashboardRequest request) {
     String path = String.format("/api/2.0/lakeview/dashboards/%s", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, TrashDashboardResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, TrashDashboardResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void unpublish(UnpublishDashboardRequest request) {
     String path =
         String.format("/api/2.0/lakeview/dashboards/%s/published", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, UnpublishDashboardResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, UnpublishDashboardResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Dashboard update(UpdateDashboardRequest request) {
     String path = String.format("/api/2.0/lakeview/dashboards/%s", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request.getDashboard(), Dashboard.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request.getDashboard()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Dashboard.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -186,9 +272,14 @@ class LakeviewImpl implements LakeviewService {
         String.format(
             "/api/2.0/lakeview/dashboards/%s/schedules/%s",
             request.getDashboardId(), request.getScheduleId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request.getSchedule(), Schedule.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request.getSchedule()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Schedule.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dashboards/LakeviewImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/dashboards/LakeviewImpl.java
@@ -21,7 +21,7 @@ class LakeviewImpl implements LakeviewService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request.getDashboard(), Dashboard.class, headers);
+    return apiClient.execute("POST", path, request.getDashboard(), Dashboard.class, headers);
   }
 
   @Override
@@ -31,7 +31,7 @@ class LakeviewImpl implements LakeviewService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request.getSchedule(), Schedule.class, headers);
+    return apiClient.execute("POST", path, request.getSchedule(), Schedule.class, headers);
   }
 
   @Override
@@ -43,7 +43,7 @@ class LakeviewImpl implements LakeviewService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request.getSubscription(), Subscription.class, headers);
+    return apiClient.execute("POST", path, request.getSubscription(), Subscription.class, headers);
   }
 
   @Override
@@ -54,7 +54,7 @@ class LakeviewImpl implements LakeviewService {
             request.getDashboardId(), request.getScheduleId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteScheduleResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteScheduleResponse.class, headers);
   }
 
   @Override
@@ -65,7 +65,7 @@ class LakeviewImpl implements LakeviewService {
             request.getDashboardId(), request.getScheduleId(), request.getSubscriptionId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteSubscriptionResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteSubscriptionResponse.class, headers);
   }
 
   @Override
@@ -73,7 +73,7 @@ class LakeviewImpl implements LakeviewService {
     String path = String.format("/api/2.0/lakeview/dashboards/%s", request.getDashboardId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Dashboard.class, headers);
+    return apiClient.execute("GET", path, request, Dashboard.class, headers);
   }
 
   @Override
@@ -82,7 +82,7 @@ class LakeviewImpl implements LakeviewService {
         String.format("/api/2.0/lakeview/dashboards/%s/published", request.getDashboardId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, PublishedDashboard.class, headers);
+    return apiClient.execute("GET", path, request, PublishedDashboard.class, headers);
   }
 
   @Override
@@ -93,7 +93,7 @@ class LakeviewImpl implements LakeviewService {
             request.getDashboardId(), request.getScheduleId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Schedule.class, headers);
+    return apiClient.execute("GET", path, request, Schedule.class, headers);
   }
 
   @Override
@@ -104,7 +104,7 @@ class LakeviewImpl implements LakeviewService {
             request.getDashboardId(), request.getScheduleId(), request.getSubscriptionId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Subscription.class, headers);
+    return apiClient.execute("GET", path, request, Subscription.class, headers);
   }
 
   @Override
@@ -112,7 +112,7 @@ class LakeviewImpl implements LakeviewService {
     String path = "/api/2.0/lakeview/dashboards";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListDashboardsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListDashboardsResponse.class, headers);
   }
 
   @Override
@@ -121,7 +121,7 @@ class LakeviewImpl implements LakeviewService {
         String.format("/api/2.0/lakeview/dashboards/%s/schedules", request.getDashboardId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListSchedulesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListSchedulesResponse.class, headers);
   }
 
   @Override
@@ -132,7 +132,7 @@ class LakeviewImpl implements LakeviewService {
             request.getDashboardId(), request.getScheduleId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListSubscriptionsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListSubscriptionsResponse.class, headers);
   }
 
   @Override
@@ -141,7 +141,7 @@ class LakeviewImpl implements LakeviewService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Dashboard.class, headers);
+    return apiClient.execute("POST", path, request, Dashboard.class, headers);
   }
 
   @Override
@@ -151,7 +151,7 @@ class LakeviewImpl implements LakeviewService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, PublishedDashboard.class, headers);
+    return apiClient.execute("POST", path, request, PublishedDashboard.class, headers);
   }
 
   @Override
@@ -159,7 +159,7 @@ class LakeviewImpl implements LakeviewService {
     String path = String.format("/api/2.0/lakeview/dashboards/%s", request.getDashboardId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, TrashDashboardResponse.class, headers);
+    apiClient.execute("DELETE", path, request, TrashDashboardResponse.class, headers);
   }
 
   @Override
@@ -168,7 +168,7 @@ class LakeviewImpl implements LakeviewService {
         String.format("/api/2.0/lakeview/dashboards/%s/published", request.getDashboardId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, UnpublishDashboardResponse.class, headers);
+    apiClient.execute("DELETE", path, request, UnpublishDashboardResponse.class, headers);
   }
 
   @Override
@@ -177,7 +177,7 @@ class LakeviewImpl implements LakeviewService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request.getDashboard(), Dashboard.class, headers);
+    return apiClient.execute("PATCH", path, request.getDashboard(), Dashboard.class, headers);
   }
 
   @Override
@@ -189,6 +189,6 @@ class LakeviewImpl implements LakeviewService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request.getSchedule(), Schedule.class, headers);
+    return apiClient.execute("PUT", path, request.getSchedule(), Schedule.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/DbfsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/DbfsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.files;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Dbfs */
 @Generated
@@ -18,87 +19,137 @@ class DbfsImpl implements DbfsService {
   @Override
   public void addBlock(AddBlock request) {
     String path = "/api/2.0/dbfs/add-block";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, AddBlockResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, AddBlockResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void close(Close request) {
     String path = "/api/2.0/dbfs/close";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, CloseResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, CloseResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CreateResponse create(Create request) {
     String path = "/api/2.0/dbfs/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(Delete request) {
     String path = "/api/2.0/dbfs/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public FileInfo getStatus(GetStatusRequest request) {
     String path = "/api/2.0/dbfs/get-status";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, FileInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, FileInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListStatusResponse list(ListDbfsRequest request) {
     String path = "/api/2.0/dbfs/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListStatusResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListStatusResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void mkdirs(MkDirs request) {
     String path = "/api/2.0/dbfs/mkdirs";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, MkDirsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, MkDirsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void move(Move request) {
     String path = "/api/2.0/dbfs/move";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, MoveResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, MoveResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void put(Put request) {
     String path = "/api/2.0/dbfs/put";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, PutResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PutResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ReadResponse read(ReadDbfsRequest request) {
     String path = "/api/2.0/dbfs/read";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ReadResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ReadResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/DbfsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/DbfsImpl.java
@@ -21,7 +21,7 @@ class DbfsImpl implements DbfsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, AddBlockResponse.class, headers);
+    apiClient.execute("POST", path, request, AddBlockResponse.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class DbfsImpl implements DbfsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, CloseResponse.class, headers);
+    apiClient.execute("POST", path, request, CloseResponse.class, headers);
   }
 
   @Override
@@ -39,7 +39,7 @@ class DbfsImpl implements DbfsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateResponse.class, headers);
   }
 
   @Override
@@ -48,7 +48,7 @@ class DbfsImpl implements DbfsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -56,7 +56,7 @@ class DbfsImpl implements DbfsService {
     String path = "/api/2.0/dbfs/get-status";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, FileInfo.class, headers);
+    return apiClient.execute("GET", path, request, FileInfo.class, headers);
   }
 
   @Override
@@ -64,7 +64,7 @@ class DbfsImpl implements DbfsService {
     String path = "/api/2.0/dbfs/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListStatusResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListStatusResponse.class, headers);
   }
 
   @Override
@@ -73,7 +73,7 @@ class DbfsImpl implements DbfsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, MkDirsResponse.class, headers);
+    apiClient.execute("POST", path, request, MkDirsResponse.class, headers);
   }
 
   @Override
@@ -82,7 +82,7 @@ class DbfsImpl implements DbfsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, MoveResponse.class, headers);
+    apiClient.execute("POST", path, request, MoveResponse.class, headers);
   }
 
   @Override
@@ -91,7 +91,7 @@ class DbfsImpl implements DbfsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, PutResponse.class, headers);
+    apiClient.execute("POST", path, request, PutResponse.class, headers);
   }
 
   @Override
@@ -99,6 +99,6 @@ class DbfsImpl implements DbfsService {
     String path = "/api/2.0/dbfs/read";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ReadResponse.class, headers);
+    return apiClient.execute("GET", path, request, ReadResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/FilesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/FilesImpl.java
@@ -2,10 +2,11 @@
 package com.databricks.sdk.service.files;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.core.http.Encoding;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Files */
 @Generated
@@ -22,8 +23,13 @@ class FilesImpl implements FilesService {
         String.format(
             "/api/2.0/fs/directories%s",
             Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("PUT", path, null, CreateDirectoryResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, CreateDirectoryResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,8 +37,13 @@ class FilesImpl implements FilesService {
     String path =
         String.format(
             "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -41,8 +52,13 @@ class FilesImpl implements FilesService {
         String.format(
             "/api/2.0/fs/directories%s",
             Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteDirectoryResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteDirectoryResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -50,9 +66,14 @@ class FilesImpl implements FilesService {
     String path =
         String.format(
             "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/octet-stream");
-    return apiClient.execute("GET", path, request, DownloadResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/octet-stream");
+      return apiClient.execute(req, DownloadResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -61,8 +82,13 @@ class FilesImpl implements FilesService {
         String.format(
             "/api/2.0/fs/directories%s",
             Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("HEAD", path, request, GetDirectoryMetadataResponse.class, headers);
+    try {
+      Request req = new Request("HEAD", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, GetDirectoryMetadataResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -70,8 +96,13 @@ class FilesImpl implements FilesService {
     String path =
         String.format(
             "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
-    Map<String, String> headers = new HashMap<>();
-    return apiClient.execute("HEAD", path, request, GetMetadataResponse.class, headers);
+    try {
+      Request req = new Request("HEAD", path);
+      ApiClient.setQuery(req, request);
+      return apiClient.execute(req, GetMetadataResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -80,9 +111,14 @@ class FilesImpl implements FilesService {
         String.format(
             "/api/2.0/fs/directories%s",
             Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListDirectoryResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListDirectoryResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -90,8 +126,13 @@ class FilesImpl implements FilesService {
     String path =
         String.format(
             "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Content-Type", "application/octet-stream");
-    apiClient.execute("PUT", path, request.getContents(), UploadResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, request.getContents());
+      ApiClient.setQuery(req, request);
+      req.withHeader("Content-Type", "application/octet-stream");
+      apiClient.execute(req, UploadResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/FilesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/files/FilesImpl.java
@@ -23,7 +23,7 @@ class FilesImpl implements FilesService {
             "/api/2.0/fs/directories%s",
             Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
     Map<String, String> headers = new HashMap<>();
-    apiClient.PUT(path, null, CreateDirectoryResponse.class, headers);
+    apiClient.execute("PUT", path, null, CreateDirectoryResponse.class, headers);
   }
 
   @Override
@@ -32,7 +32,7 @@ class FilesImpl implements FilesService {
         String.format(
             "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -42,7 +42,7 @@ class FilesImpl implements FilesService {
             "/api/2.0/fs/directories%s",
             Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteDirectoryResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteDirectoryResponse.class, headers);
   }
 
   @Override
@@ -52,7 +52,7 @@ class FilesImpl implements FilesService {
             "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/octet-stream");
-    return apiClient.GET(path, request, DownloadResponse.class, headers);
+    return apiClient.execute("GET", path, request, DownloadResponse.class, headers);
   }
 
   @Override
@@ -62,7 +62,7 @@ class FilesImpl implements FilesService {
             "/api/2.0/fs/directories%s",
             Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
     Map<String, String> headers = new HashMap<>();
-    apiClient.HEAD(path, request, GetDirectoryMetadataResponse.class, headers);
+    apiClient.execute("HEAD", path, request, GetDirectoryMetadataResponse.class, headers);
   }
 
   @Override
@@ -71,7 +71,7 @@ class FilesImpl implements FilesService {
         String.format(
             "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
     Map<String, String> headers = new HashMap<>();
-    return apiClient.HEAD(path, request, GetMetadataResponse.class, headers);
+    return apiClient.execute("HEAD", path, request, GetMetadataResponse.class, headers);
   }
 
   @Override
@@ -82,7 +82,7 @@ class FilesImpl implements FilesService {
             Encoding.encodeMultiSegmentPathParameter(request.getDirectoryPath()));
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListDirectoryResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListDirectoryResponse.class, headers);
   }
 
   @Override
@@ -92,6 +92,6 @@ class FilesImpl implements FilesService {
             "/api/2.0/fs/files%s", Encoding.encodeMultiSegmentPathParameter(request.getFilePath()));
     Map<String, String> headers = new HashMap<>();
     headers.put("Content-Type", "application/octet-stream");
-    apiClient.PUT(path, request.getContents(), UploadResponse.class, headers);
+    apiClient.execute("PUT", path, request.getContents(), UploadResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountAccessControlImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountAccessControlImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AccountAccessControl */
 @Generated
@@ -22,10 +23,14 @@ class AccountAccessControlImpl implements AccountAccessControlService {
         String.format(
             "/api/2.0/preview/accounts/%s/access-control/assignable-roles",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetAssignableRolesForResourceResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetAssignableRolesForResourceResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -34,9 +39,14 @@ class AccountAccessControlImpl implements AccountAccessControlService {
         String.format(
             "/api/2.0/preview/accounts/%s/access-control/rule-sets",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, RuleSetResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, RuleSetResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -45,9 +55,14 @@ class AccountAccessControlImpl implements AccountAccessControlService {
         String.format(
             "/api/2.0/preview/accounts/%s/access-control/rule-sets",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, RuleSetResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RuleSetResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountAccessControlImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountAccessControlImpl.java
@@ -24,7 +24,8 @@ class AccountAccessControlImpl implements AccountAccessControlService {
             apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetAssignableRolesForResourceResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetAssignableRolesForResourceResponse.class, headers);
   }
 
   @Override
@@ -35,7 +36,7 @@ class AccountAccessControlImpl implements AccountAccessControlService {
             apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, RuleSetResponse.class, headers);
+    return apiClient.execute("GET", path, request, RuleSetResponse.class, headers);
   }
 
   @Override
@@ -47,6 +48,6 @@ class AccountAccessControlImpl implements AccountAccessControlService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, RuleSetResponse.class, headers);
+    return apiClient.execute("PUT", path, request, RuleSetResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountAccessControlProxyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountAccessControlProxyImpl.java
@@ -21,7 +21,8 @@ class AccountAccessControlProxyImpl implements AccountAccessControlProxyService 
     String path = "/api/2.0/preview/accounts/access-control/assignable-roles";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetAssignableRolesForResourceResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetAssignableRolesForResourceResponse.class, headers);
   }
 
   @Override
@@ -29,7 +30,7 @@ class AccountAccessControlProxyImpl implements AccountAccessControlProxyService 
     String path = "/api/2.0/preview/accounts/access-control/rule-sets";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, RuleSetResponse.class, headers);
+    return apiClient.execute("GET", path, request, RuleSetResponse.class, headers);
   }
 
   @Override
@@ -38,6 +39,6 @@ class AccountAccessControlProxyImpl implements AccountAccessControlProxyService 
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, RuleSetResponse.class, headers);
+    return apiClient.execute("PUT", path, request, RuleSetResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountAccessControlProxyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountAccessControlProxyImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AccountAccessControlProxy */
 @Generated
@@ -19,26 +20,40 @@ class AccountAccessControlProxyImpl implements AccountAccessControlProxyService 
   public GetAssignableRolesForResourceResponse getAssignableRolesForResource(
       GetAssignableRolesForResourceRequest request) {
     String path = "/api/2.0/preview/accounts/access-control/assignable-roles";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetAssignableRolesForResourceResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetAssignableRolesForResourceResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RuleSetResponse getRuleSet(GetRuleSetRequest request) {
     String path = "/api/2.0/preview/accounts/access-control/rule-sets";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, RuleSetResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, RuleSetResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RuleSetResponse updateRuleSet(UpdateRuleSetRequest request) {
     String path = "/api/2.0/preview/accounts/access-control/rule-sets";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, RuleSetResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RuleSetResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountGroupsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountGroupsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AccountGroups */
 @Generated
@@ -19,10 +20,15 @@ class AccountGroupsImpl implements AccountGroupsService {
   public Group create(Group request) {
     String path =
         String.format("/api/2.0/accounts/%s/scim/v2/Groups", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Group.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Group.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,8 +37,13 @@ class AccountGroupsImpl implements AccountGroupsService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/Groups/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -41,18 +52,28 @@ class AccountGroupsImpl implements AccountGroupsService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/Groups/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Group.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Group.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListGroupsResponse list(ListAccountGroupsRequest request) {
     String path =
         String.format("/api/2.0/accounts/%s/scim/v2/Groups", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListGroupsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListGroupsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -61,10 +82,15 @@ class AccountGroupsImpl implements AccountGroupsService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/Groups/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PatchResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -73,9 +99,14 @@ class AccountGroupsImpl implements AccountGroupsService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/Groups/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountGroupsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountGroupsImpl.java
@@ -22,7 +22,7 @@ class AccountGroupsImpl implements AccountGroupsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Group.class, headers);
+    return apiClient.execute("POST", path, request, Group.class, headers);
   }
 
   @Override
@@ -32,7 +32,7 @@ class AccountGroupsImpl implements AccountGroupsService {
             "/api/2.0/accounts/%s/scim/v2/Groups/%s",
             apiClient.configuredAccountID(), request.getId());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -43,7 +43,7 @@ class AccountGroupsImpl implements AccountGroupsService {
             apiClient.configuredAccountID(), request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Group.class, headers);
+    return apiClient.execute("GET", path, request, Group.class, headers);
   }
 
   @Override
@@ -52,7 +52,7 @@ class AccountGroupsImpl implements AccountGroupsService {
         String.format("/api/2.0/accounts/%s/scim/v2/Groups", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListGroupsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListGroupsResponse.class, headers);
   }
 
   @Override
@@ -64,7 +64,7 @@ class AccountGroupsImpl implements AccountGroupsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, PatchResponse.class, headers);
+    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
   }
 
   @Override
@@ -76,6 +76,6 @@ class AccountGroupsImpl implements AccountGroupsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountServicePrincipalsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountServicePrincipalsImpl.java
@@ -23,7 +23,7 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ServicePrincipal.class, headers);
+    return apiClient.execute("POST", path, request, ServicePrincipal.class, headers);
   }
 
   @Override
@@ -33,7 +33,7 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
             "/api/2.0/accounts/%s/scim/v2/ServicePrincipals/%s",
             apiClient.configuredAccountID(), request.getId());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -44,7 +44,7 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
             apiClient.configuredAccountID(), request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ServicePrincipal.class, headers);
+    return apiClient.execute("GET", path, request, ServicePrincipal.class, headers);
   }
 
   @Override
@@ -54,7 +54,7 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
             "/api/2.0/accounts/%s/scim/v2/ServicePrincipals", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListServicePrincipalResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListServicePrincipalResponse.class, headers);
   }
 
   @Override
@@ -66,7 +66,7 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, PatchResponse.class, headers);
+    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
   }
 
   @Override
@@ -78,6 +78,6 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountServicePrincipalsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountServicePrincipalsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AccountServicePrincipals */
 @Generated
@@ -20,10 +21,15 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
     String path =
         String.format(
             "/api/2.0/accounts/%s/scim/v2/ServicePrincipals", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, ServicePrincipal.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ServicePrincipal.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -32,8 +38,13 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/ServicePrincipals/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -42,9 +53,14 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/ServicePrincipals/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ServicePrincipal.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ServicePrincipal.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -52,9 +68,14 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
     String path =
         String.format(
             "/api/2.0/accounts/%s/scim/v2/ServicePrincipals", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListServicePrincipalResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListServicePrincipalResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -63,10 +84,15 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/ServicePrincipals/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PatchResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -75,9 +101,14 @@ class AccountServicePrincipalsImpl implements AccountServicePrincipalsService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/ServicePrincipals/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountUsersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountUsersImpl.java
@@ -22,7 +22,7 @@ class AccountUsersImpl implements AccountUsersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, User.class, headers);
+    return apiClient.execute("POST", path, request, User.class, headers);
   }
 
   @Override
@@ -32,7 +32,7 @@ class AccountUsersImpl implements AccountUsersService {
             "/api/2.0/accounts/%s/scim/v2/Users/%s",
             apiClient.configuredAccountID(), request.getId());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -43,7 +43,7 @@ class AccountUsersImpl implements AccountUsersService {
             apiClient.configuredAccountID(), request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, User.class, headers);
+    return apiClient.execute("GET", path, request, User.class, headers);
   }
 
   @Override
@@ -52,7 +52,7 @@ class AccountUsersImpl implements AccountUsersService {
         String.format("/api/2.0/accounts/%s/scim/v2/Users", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListUsersResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListUsersResponse.class, headers);
   }
 
   @Override
@@ -64,7 +64,7 @@ class AccountUsersImpl implements AccountUsersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, PatchResponse.class, headers);
+    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
   }
 
   @Override
@@ -76,6 +76,6 @@ class AccountUsersImpl implements AccountUsersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountUsersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/AccountUsersImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AccountUsers */
 @Generated
@@ -19,10 +20,15 @@ class AccountUsersImpl implements AccountUsersService {
   public User create(User request) {
     String path =
         String.format("/api/2.0/accounts/%s/scim/v2/Users", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, User.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, User.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,8 +37,13 @@ class AccountUsersImpl implements AccountUsersService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/Users/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -41,18 +52,28 @@ class AccountUsersImpl implements AccountUsersService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/Users/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, User.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, User.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListUsersResponse list(ListAccountUsersRequest request) {
     String path =
         String.format("/api/2.0/accounts/%s/scim/v2/Users", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListUsersResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListUsersResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -61,10 +82,15 @@ class AccountUsersImpl implements AccountUsersService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/Users/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PatchResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -73,9 +99,14 @@ class AccountUsersImpl implements AccountUsersService {
         String.format(
             "/api/2.0/accounts/%s/scim/v2/Users/%s",
             apiClient.configuredAccountID(), request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/CurrentUserImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/CurrentUserImpl.java
@@ -20,6 +20,6 @@ class CurrentUserImpl implements CurrentUserService {
     String path = "/api/2.0/preview/scim/v2/Me";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, User.class, headers);
+    return apiClient.execute("GET", path, null, User.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/CurrentUserImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/CurrentUserImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of CurrentUser */
 @Generated
@@ -18,8 +19,13 @@ class CurrentUserImpl implements CurrentUserService {
   @Override
   public User me() {
     String path = "/api/2.0/preview/scim/v2/Me";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, User.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, User.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/GroupsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/GroupsImpl.java
@@ -21,14 +21,14 @@ class GroupsImpl implements GroupsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Group.class, headers);
+    return apiClient.execute("POST", path, request, Group.class, headers);
   }
 
   @Override
   public void delete(DeleteGroupRequest request) {
     String path = String.format("/api/2.0/preview/scim/v2/Groups/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -36,7 +36,7 @@ class GroupsImpl implements GroupsService {
     String path = String.format("/api/2.0/preview/scim/v2/Groups/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Group.class, headers);
+    return apiClient.execute("GET", path, request, Group.class, headers);
   }
 
   @Override
@@ -44,7 +44,7 @@ class GroupsImpl implements GroupsService {
     String path = "/api/2.0/preview/scim/v2/Groups";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListGroupsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListGroupsResponse.class, headers);
   }
 
   @Override
@@ -53,7 +53,7 @@ class GroupsImpl implements GroupsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, PatchResponse.class, headers);
+    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
   }
 
   @Override
@@ -62,6 +62,6 @@ class GroupsImpl implements GroupsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/GroupsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/GroupsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Groups */
 @Generated
@@ -18,50 +19,80 @@ class GroupsImpl implements GroupsService {
   @Override
   public Group create(Group request) {
     String path = "/api/2.0/preview/scim/v2/Groups";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Group.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Group.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteGroupRequest request) {
     String path = String.format("/api/2.0/preview/scim/v2/Groups/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Group get(GetGroupRequest request) {
     String path = String.format("/api/2.0/preview/scim/v2/Groups/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Group.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Group.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListGroupsResponse list(ListGroupsRequest request) {
     String path = "/api/2.0/preview/scim/v2/Groups";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListGroupsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListGroupsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void patch(PartialUpdate request) {
     String path = String.format("/api/2.0/preview/scim/v2/Groups/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PatchResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(Group request) {
     String path = String.format("/api/2.0/preview/scim/v2/Groups/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/PermissionMigrationImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/PermissionMigrationImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of PermissionMigration */
 @Generated
@@ -18,9 +19,14 @@ class PermissionMigrationImpl implements PermissionMigrationService {
   @Override
   public MigratePermissionsResponse migratePermissions(MigratePermissionsRequest request) {
     String path = "/api/2.0/permissionmigration";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, MigratePermissionsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, MigratePermissionsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/PermissionMigrationImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/PermissionMigrationImpl.java
@@ -21,6 +21,6 @@ class PermissionMigrationImpl implements PermissionMigrationService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, MigratePermissionsResponse.class, headers);
+    return apiClient.execute("POST", path, request, MigratePermissionsResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/PermissionsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/PermissionsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Permissions */
 @Generated
@@ -21,9 +22,14 @@ class PermissionsImpl implements PermissionsService {
         String.format(
             "/api/2.0/permissions/%s/%s",
             request.getRequestObjectType(), request.getRequestObjectId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ObjectPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ObjectPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -32,9 +38,14 @@ class PermissionsImpl implements PermissionsService {
         String.format(
             "/api/2.0/permissions/%s/%s/permissionLevels",
             request.getRequestObjectType(), request.getRequestObjectId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -43,10 +54,15 @@ class PermissionsImpl implements PermissionsService {
         String.format(
             "/api/2.0/permissions/%s/%s",
             request.getRequestObjectType(), request.getRequestObjectId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, ObjectPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ObjectPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -55,9 +71,14 @@ class PermissionsImpl implements PermissionsService {
         String.format(
             "/api/2.0/permissions/%s/%s",
             request.getRequestObjectType(), request.getRequestObjectId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, ObjectPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ObjectPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/PermissionsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/PermissionsImpl.java
@@ -23,7 +23,7 @@ class PermissionsImpl implements PermissionsService {
             request.getRequestObjectType(), request.getRequestObjectId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ObjectPermissions.class, headers);
+    return apiClient.execute("GET", path, request, ObjectPermissions.class, headers);
   }
 
   @Override
@@ -34,7 +34,7 @@ class PermissionsImpl implements PermissionsService {
             request.getRequestObjectType(), request.getRequestObjectId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetPermissionLevelsResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -46,7 +46,7 @@ class PermissionsImpl implements PermissionsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, ObjectPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, ObjectPermissions.class, headers);
   }
 
   @Override
@@ -58,6 +58,6 @@ class PermissionsImpl implements PermissionsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, ObjectPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, ObjectPermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/ServicePrincipalsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/ServicePrincipalsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ServicePrincipals */
 @Generated
@@ -18,50 +19,80 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
   @Override
   public ServicePrincipal create(ServicePrincipal request) {
     String path = "/api/2.0/preview/scim/v2/ServicePrincipals";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, ServicePrincipal.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ServicePrincipal.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteServicePrincipalRequest request) {
     String path = String.format("/api/2.0/preview/scim/v2/ServicePrincipals/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ServicePrincipal get(GetServicePrincipalRequest request) {
     String path = String.format("/api/2.0/preview/scim/v2/ServicePrincipals/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ServicePrincipal.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ServicePrincipal.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListServicePrincipalResponse list(ListServicePrincipalsRequest request) {
     String path = "/api/2.0/preview/scim/v2/ServicePrincipals";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListServicePrincipalResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListServicePrincipalResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void patch(PartialUpdate request) {
     String path = String.format("/api/2.0/preview/scim/v2/ServicePrincipals/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PatchResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(ServicePrincipal request) {
     String path = String.format("/api/2.0/preview/scim/v2/ServicePrincipals/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/ServicePrincipalsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/ServicePrincipalsImpl.java
@@ -21,14 +21,14 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ServicePrincipal.class, headers);
+    return apiClient.execute("POST", path, request, ServicePrincipal.class, headers);
   }
 
   @Override
   public void delete(DeleteServicePrincipalRequest request) {
     String path = String.format("/api/2.0/preview/scim/v2/ServicePrincipals/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -36,7 +36,7 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
     String path = String.format("/api/2.0/preview/scim/v2/ServicePrincipals/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ServicePrincipal.class, headers);
+    return apiClient.execute("GET", path, request, ServicePrincipal.class, headers);
   }
 
   @Override
@@ -44,7 +44,7 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
     String path = "/api/2.0/preview/scim/v2/ServicePrincipals";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListServicePrincipalResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListServicePrincipalResponse.class, headers);
   }
 
   @Override
@@ -53,7 +53,7 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, PatchResponse.class, headers);
+    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
   }
 
   @Override
@@ -62,6 +62,6 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/UsersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/UsersImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Users */
 @Generated
@@ -18,84 +19,134 @@ class UsersImpl implements UsersService {
   @Override
   public User create(User request) {
     String path = "/api/2.0/preview/scim/v2/Users";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, User.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, User.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteUserRequest request) {
     String path = String.format("/api/2.0/preview/scim/v2/Users/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public User get(GetUserRequest request) {
     String path = String.format("/api/2.0/preview/scim/v2/Users/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, User.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, User.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetPasswordPermissionLevelsResponse getPermissionLevels() {
     String path = "/api/2.0/permissions/authorization/passwords/permissionLevels";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, GetPasswordPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetPasswordPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public PasswordPermissions getPermissions() {
     String path = "/api/2.0/permissions/authorization/passwords";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, PasswordPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, PasswordPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListUsersResponse list(ListUsersRequest request) {
     String path = "/api/2.0/preview/scim/v2/Users";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListUsersResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListUsersResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void patch(PartialUpdate request) {
     String path = String.format("/api/2.0/preview/scim/v2/Users/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PatchResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public PasswordPermissions setPermissions(PasswordPermissionsRequest request) {
     String path = "/api/2.0/permissions/authorization/passwords";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, PasswordPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, PasswordPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(User request) {
     String path = String.format("/api/2.0/preview/scim/v2/Users/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public PasswordPermissions updatePermissions(PasswordPermissionsRequest request) {
     String path = "/api/2.0/permissions/authorization/passwords";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, PasswordPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, PasswordPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/UsersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/UsersImpl.java
@@ -21,14 +21,14 @@ class UsersImpl implements UsersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, User.class, headers);
+    return apiClient.execute("POST", path, request, User.class, headers);
   }
 
   @Override
   public void delete(DeleteUserRequest request) {
     String path = String.format("/api/2.0/preview/scim/v2/Users/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -36,7 +36,7 @@ class UsersImpl implements UsersService {
     String path = String.format("/api/2.0/preview/scim/v2/Users/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, User.class, headers);
+    return apiClient.execute("GET", path, request, User.class, headers);
   }
 
   @Override
@@ -44,7 +44,7 @@ class UsersImpl implements UsersService {
     String path = "/api/2.0/permissions/authorization/passwords/permissionLevels";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, GetPasswordPermissionLevelsResponse.class, headers);
+    return apiClient.execute("GET", path, null, GetPasswordPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -52,7 +52,7 @@ class UsersImpl implements UsersService {
     String path = "/api/2.0/permissions/authorization/passwords";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, PasswordPermissions.class, headers);
+    return apiClient.execute("GET", path, null, PasswordPermissions.class, headers);
   }
 
   @Override
@@ -60,7 +60,7 @@ class UsersImpl implements UsersService {
     String path = "/api/2.0/preview/scim/v2/Users";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListUsersResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListUsersResponse.class, headers);
   }
 
   @Override
@@ -69,7 +69,7 @@ class UsersImpl implements UsersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, PatchResponse.class, headers);
+    apiClient.execute("PATCH", path, request, PatchResponse.class, headers);
   }
 
   @Override
@@ -78,7 +78,7 @@ class UsersImpl implements UsersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, PasswordPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, PasswordPermissions.class, headers);
   }
 
   @Override
@@ -87,7 +87,7 @@ class UsersImpl implements UsersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
   }
 
   @Override
@@ -96,6 +96,6 @@ class UsersImpl implements UsersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, PasswordPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, PasswordPermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/WorkspaceAssignmentImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/WorkspaceAssignmentImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.iam;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of WorkspaceAssignment */
 @Generated
@@ -21,10 +22,14 @@ class WorkspaceAssignmentImpl implements WorkspaceAssignmentService {
         String.format(
             "/api/2.0/accounts/%s/workspaces/%s/permissionassignments/principals/%s",
             apiClient.configuredAccountID(), request.getWorkspaceId(), request.getPrincipalId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute(
-        "DELETE", path, request, DeleteWorkspacePermissionAssignmentResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteWorkspacePermissionAssignmentResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -33,9 +38,14 @@ class WorkspaceAssignmentImpl implements WorkspaceAssignmentService {
         String.format(
             "/api/2.0/accounts/%s/workspaces/%s/permissionassignments/permissions",
             apiClient.configuredAccountID(), request.getWorkspaceId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, WorkspacePermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, WorkspacePermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -44,9 +54,14 @@ class WorkspaceAssignmentImpl implements WorkspaceAssignmentService {
         String.format(
             "/api/2.0/accounts/%s/workspaces/%s/permissionassignments",
             apiClient.configuredAccountID(), request.getWorkspaceId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, PermissionAssignments.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, PermissionAssignments.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -55,9 +70,14 @@ class WorkspaceAssignmentImpl implements WorkspaceAssignmentService {
         String.format(
             "/api/2.0/accounts/%s/workspaces/%s/permissionassignments/principals/%s",
             apiClient.configuredAccountID(), request.getWorkspaceId(), request.getPrincipalId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, PermissionAssignment.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, PermissionAssignment.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/WorkspaceAssignmentImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/WorkspaceAssignmentImpl.java
@@ -23,7 +23,8 @@ class WorkspaceAssignmentImpl implements WorkspaceAssignmentService {
             apiClient.configuredAccountID(), request.getWorkspaceId(), request.getPrincipalId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteWorkspacePermissionAssignmentResponse.class, headers);
+    apiClient.execute(
+        "DELETE", path, request, DeleteWorkspacePermissionAssignmentResponse.class, headers);
   }
 
   @Override
@@ -34,7 +35,7 @@ class WorkspaceAssignmentImpl implements WorkspaceAssignmentService {
             apiClient.configuredAccountID(), request.getWorkspaceId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, WorkspacePermissions.class, headers);
+    return apiClient.execute("GET", path, request, WorkspacePermissions.class, headers);
   }
 
   @Override
@@ -45,7 +46,7 @@ class WorkspaceAssignmentImpl implements WorkspaceAssignmentService {
             apiClient.configuredAccountID(), request.getWorkspaceId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, PermissionAssignments.class, headers);
+    return apiClient.execute("GET", path, request, PermissionAssignments.class, headers);
   }
 
   @Override
@@ -57,6 +58,6 @@ class WorkspaceAssignmentImpl implements WorkspaceAssignmentService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, PermissionAssignment.class, headers);
+    return apiClient.execute("PUT", path, request, PermissionAssignment.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/JobsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/JobsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.jobs;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Jobs */
 @Generated
@@ -18,173 +19,273 @@ class JobsImpl implements JobsService {
   @Override
   public void cancelAllRuns(CancelAllRuns request) {
     String path = "/api/2.1/jobs/runs/cancel-all";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, CancelAllRunsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, CancelAllRunsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void cancelRun(CancelRun request) {
     String path = "/api/2.1/jobs/runs/cancel";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, CancelRunResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, CancelRunResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CreateResponse create(CreateJob request) {
     String path = "/api/2.1/jobs/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteJob request) {
     String path = "/api/2.1/jobs/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteRun(DeleteRun request) {
     String path = "/api/2.1/jobs/runs/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteRunResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteRunResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ExportRunOutput exportRun(ExportRunRequest request) {
     String path = "/api/2.1/jobs/runs/export";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ExportRunOutput.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ExportRunOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Job get(GetJobRequest request) {
     String path = "/api/2.1/jobs/get";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Job.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Job.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetJobPermissionLevelsResponse getPermissionLevels(GetJobPermissionLevelsRequest request) {
     String path =
         String.format("/api/2.0/permissions/jobs/%s/permissionLevels", request.getJobId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetJobPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetJobPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public JobPermissions getPermissions(GetJobPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/jobs/%s", request.getJobId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, JobPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, JobPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Run getRun(GetRunRequest request) {
     String path = "/api/2.1/jobs/runs/get";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Run.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Run.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RunOutput getRunOutput(GetRunOutputRequest request) {
     String path = "/api/2.1/jobs/runs/get-output";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, RunOutput.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, RunOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListJobsResponse list(ListJobsRequest request) {
     String path = "/api/2.1/jobs/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListJobsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListJobsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListRunsResponse listRuns(ListRunsRequest request) {
     String path = "/api/2.1/jobs/runs/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListRunsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListRunsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RepairRunResponse repairRun(RepairRun request) {
     String path = "/api/2.1/jobs/runs/repair";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, RepairRunResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RepairRunResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void reset(ResetJob request) {
     String path = "/api/2.1/jobs/reset";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, ResetResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, ResetResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RunNowResponse runNow(RunNow request) {
     String path = "/api/2.1/jobs/run-now";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, RunNowResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RunNowResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public JobPermissions setPermissions(JobPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/jobs/%s", request.getJobId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, JobPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, JobPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public SubmitRunResponse submit(SubmitRun request) {
     String path = "/api/2.1/jobs/runs/submit";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, SubmitRunResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, SubmitRunResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(UpdateJob request) {
     String path = "/api/2.1/jobs/update";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public JobPermissions updatePermissions(JobPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/jobs/%s", request.getJobId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, JobPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, JobPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/JobsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/JobsImpl.java
@@ -21,7 +21,7 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, CancelAllRunsResponse.class, headers);
+    apiClient.execute("POST", path, request, CancelAllRunsResponse.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, CancelRunResponse.class, headers);
+    apiClient.execute("POST", path, request, CancelRunResponse.class, headers);
   }
 
   @Override
@@ -39,7 +39,7 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateResponse.class, headers);
   }
 
   @Override
@@ -48,7 +48,7 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -57,7 +57,7 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteRunResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteRunResponse.class, headers);
   }
 
   @Override
@@ -65,7 +65,7 @@ class JobsImpl implements JobsService {
     String path = "/api/2.1/jobs/runs/export";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ExportRunOutput.class, headers);
+    return apiClient.execute("GET", path, request, ExportRunOutput.class, headers);
   }
 
   @Override
@@ -73,7 +73,7 @@ class JobsImpl implements JobsService {
     String path = "/api/2.1/jobs/get";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Job.class, headers);
+    return apiClient.execute("GET", path, request, Job.class, headers);
   }
 
   @Override
@@ -82,7 +82,7 @@ class JobsImpl implements JobsService {
         String.format("/api/2.0/permissions/jobs/%s/permissionLevels", request.getJobId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetJobPermissionLevelsResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetJobPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -90,7 +90,7 @@ class JobsImpl implements JobsService {
     String path = String.format("/api/2.0/permissions/jobs/%s", request.getJobId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, JobPermissions.class, headers);
+    return apiClient.execute("GET", path, request, JobPermissions.class, headers);
   }
 
   @Override
@@ -98,7 +98,7 @@ class JobsImpl implements JobsService {
     String path = "/api/2.1/jobs/runs/get";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Run.class, headers);
+    return apiClient.execute("GET", path, request, Run.class, headers);
   }
 
   @Override
@@ -106,7 +106,7 @@ class JobsImpl implements JobsService {
     String path = "/api/2.1/jobs/runs/get-output";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, RunOutput.class, headers);
+    return apiClient.execute("GET", path, request, RunOutput.class, headers);
   }
 
   @Override
@@ -114,7 +114,7 @@ class JobsImpl implements JobsService {
     String path = "/api/2.1/jobs/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListJobsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListJobsResponse.class, headers);
   }
 
   @Override
@@ -122,7 +122,7 @@ class JobsImpl implements JobsService {
     String path = "/api/2.1/jobs/runs/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListRunsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListRunsResponse.class, headers);
   }
 
   @Override
@@ -131,7 +131,7 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, RepairRunResponse.class, headers);
+    return apiClient.execute("POST", path, request, RepairRunResponse.class, headers);
   }
 
   @Override
@@ -140,7 +140,7 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, ResetResponse.class, headers);
+    apiClient.execute("POST", path, request, ResetResponse.class, headers);
   }
 
   @Override
@@ -149,7 +149,7 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, RunNowResponse.class, headers);
+    return apiClient.execute("POST", path, request, RunNowResponse.class, headers);
   }
 
   @Override
@@ -158,7 +158,7 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, JobPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, JobPermissions.class, headers);
   }
 
   @Override
@@ -167,7 +167,7 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, SubmitRunResponse.class, headers);
+    return apiClient.execute("POST", path, request, SubmitRunResponse.class, headers);
   }
 
   @Override
@@ -176,7 +176,7 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, UpdateResponse.class, headers);
+    apiClient.execute("POST", path, request, UpdateResponse.class, headers);
   }
 
   @Override
@@ -185,6 +185,6 @@ class JobsImpl implements JobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, JobPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, JobPermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/PolicyComplianceForJobsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/PolicyComplianceForJobsImpl.java
@@ -21,7 +21,7 @@ class PolicyComplianceForJobsImpl implements PolicyComplianceForJobsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, EnforcePolicyComplianceResponse.class, headers);
+    return apiClient.execute("POST", path, request, EnforcePolicyComplianceResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class PolicyComplianceForJobsImpl implements PolicyComplianceForJobsService {
     String path = "/api/2.0/policies/jobs/get-compliance";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetPolicyComplianceResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetPolicyComplianceResponse.class, headers);
   }
 
   @Override
@@ -37,6 +37,7 @@ class PolicyComplianceForJobsImpl implements PolicyComplianceForJobsService {
     String path = "/api/2.0/policies/jobs/list-compliance";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListJobComplianceForPolicyResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, ListJobComplianceForPolicyResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/PolicyComplianceForJobsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/jobs/PolicyComplianceForJobsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.jobs;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of PolicyComplianceForJobs */
 @Generated
@@ -18,26 +19,40 @@ class PolicyComplianceForJobsImpl implements PolicyComplianceForJobsService {
   @Override
   public EnforcePolicyComplianceResponse enforceCompliance(EnforcePolicyComplianceRequest request) {
     String path = "/api/2.0/policies/jobs/enforce-compliance";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, EnforcePolicyComplianceResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, EnforcePolicyComplianceResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetPolicyComplianceResponse getCompliance(GetPolicyComplianceRequest request) {
     String path = "/api/2.0/policies/jobs/get-compliance";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetPolicyComplianceResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetPolicyComplianceResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListJobComplianceForPolicyResponse listCompliance(ListJobComplianceRequest request) {
     String path = "/api/2.0/policies/jobs/list-compliance";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, ListJobComplianceForPolicyResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListJobComplianceForPolicyResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerFulfillmentsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerFulfillmentsImpl.java
@@ -21,7 +21,8 @@ class ConsumerFulfillmentsImpl implements ConsumerFulfillmentsService {
         String.format("/api/2.1/marketplace-consumer/listings/%s/content", request.getListingId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetListingContentMetadataResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetListingContentMetadataResponse.class, headers);
   }
 
   @Override
@@ -31,6 +32,6 @@ class ConsumerFulfillmentsImpl implements ConsumerFulfillmentsService {
             "/api/2.1/marketplace-consumer/listings/%s/fulfillments", request.getListingId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListFulfillmentsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListFulfillmentsResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerFulfillmentsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerFulfillmentsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ConsumerFulfillments */
 @Generated
@@ -19,10 +20,14 @@ class ConsumerFulfillmentsImpl implements ConsumerFulfillmentsService {
   public GetListingContentMetadataResponse get(GetListingContentMetadataRequest request) {
     String path =
         String.format("/api/2.1/marketplace-consumer/listings/%s/content", request.getListingId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetListingContentMetadataResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetListingContentMetadataResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -30,8 +35,13 @@ class ConsumerFulfillmentsImpl implements ConsumerFulfillmentsService {
     String path =
         String.format(
             "/api/2.1/marketplace-consumer/listings/%s/fulfillments", request.getListingId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListFulfillmentsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListFulfillmentsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerInstallationsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerInstallationsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ConsumerInstallations */
 @Generated
@@ -20,10 +21,15 @@ class ConsumerInstallationsImpl implements ConsumerInstallationsService {
     String path =
         String.format(
             "/api/2.1/marketplace-consumer/listings/%s/installations", request.getListingId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Installation.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Installation.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -32,17 +38,27 @@ class ConsumerInstallationsImpl implements ConsumerInstallationsService {
         String.format(
             "/api/2.1/marketplace-consumer/listings/%s/installations/%s",
             request.getListingId(), request.getInstallationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteInstallationResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteInstallationResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListAllInstallationsResponse list(ListAllInstallationsRequest request) {
     String path = "/api/2.1/marketplace-consumer/installations";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListAllInstallationsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListAllInstallationsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -50,9 +66,14 @@ class ConsumerInstallationsImpl implements ConsumerInstallationsService {
     String path =
         String.format(
             "/api/2.1/marketplace-consumer/listings/%s/installations", request.getListingId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListInstallationsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListInstallationsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -61,9 +82,14 @@ class ConsumerInstallationsImpl implements ConsumerInstallationsService {
         String.format(
             "/api/2.1/marketplace-consumer/listings/%s/installations/%s",
             request.getListingId(), request.getInstallationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, UpdateInstallationResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, UpdateInstallationResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerInstallationsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerInstallationsImpl.java
@@ -23,7 +23,7 @@ class ConsumerInstallationsImpl implements ConsumerInstallationsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Installation.class, headers);
+    return apiClient.execute("POST", path, request, Installation.class, headers);
   }
 
   @Override
@@ -34,7 +34,7 @@ class ConsumerInstallationsImpl implements ConsumerInstallationsService {
             request.getListingId(), request.getInstallationId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteInstallationResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteInstallationResponse.class, headers);
   }
 
   @Override
@@ -42,7 +42,7 @@ class ConsumerInstallationsImpl implements ConsumerInstallationsService {
     String path = "/api/2.1/marketplace-consumer/installations";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListAllInstallationsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListAllInstallationsResponse.class, headers);
   }
 
   @Override
@@ -52,7 +52,7 @@ class ConsumerInstallationsImpl implements ConsumerInstallationsService {
             "/api/2.1/marketplace-consumer/listings/%s/installations", request.getListingId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListInstallationsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListInstallationsResponse.class, headers);
   }
 
   @Override
@@ -64,6 +64,6 @@ class ConsumerInstallationsImpl implements ConsumerInstallationsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, UpdateInstallationResponse.class, headers);
+    return apiClient.execute("PUT", path, request, UpdateInstallationResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerListingsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerListingsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ConsumerListings */
 @Generated
@@ -18,32 +19,52 @@ class ConsumerListingsImpl implements ConsumerListingsService {
   @Override
   public BatchGetListingsResponse batchGet(BatchGetListingsRequest request) {
     String path = "/api/2.1/marketplace-consumer/listings:batchGet";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, BatchGetListingsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, BatchGetListingsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetListingResponse get(GetListingRequest request) {
     String path = String.format("/api/2.1/marketplace-consumer/listings/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetListingResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetListingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListListingsResponse list(ListListingsRequest request) {
     String path = "/api/2.1/marketplace-consumer/listings";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListListingsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListListingsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public SearchListingsResponse search(SearchListingsRequest request) {
     String path = "/api/2.1/marketplace-consumer/search-listings";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, SearchListingsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, SearchListingsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerListingsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerListingsImpl.java
@@ -20,7 +20,7 @@ class ConsumerListingsImpl implements ConsumerListingsService {
     String path = "/api/2.1/marketplace-consumer/listings:batchGet";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, BatchGetListingsResponse.class, headers);
+    return apiClient.execute("GET", path, request, BatchGetListingsResponse.class, headers);
   }
 
   @Override
@@ -28,7 +28,7 @@ class ConsumerListingsImpl implements ConsumerListingsService {
     String path = String.format("/api/2.1/marketplace-consumer/listings/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetListingResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetListingResponse.class, headers);
   }
 
   @Override
@@ -36,7 +36,7 @@ class ConsumerListingsImpl implements ConsumerListingsService {
     String path = "/api/2.1/marketplace-consumer/listings";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListListingsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListListingsResponse.class, headers);
   }
 
   @Override
@@ -44,6 +44,6 @@ class ConsumerListingsImpl implements ConsumerListingsService {
     String path = "/api/2.1/marketplace-consumer/search-listings";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, SearchListingsResponse.class, headers);
+    return apiClient.execute("GET", path, request, SearchListingsResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerPersonalizationRequestsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerPersonalizationRequestsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ConsumerPersonalizationRequests */
 @Generated
@@ -21,11 +22,15 @@ class ConsumerPersonalizationRequestsImpl implements ConsumerPersonalizationRequ
         String.format(
             "/api/2.1/marketplace-consumer/listings/%s/personalization-requests",
             request.getListingId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST", path, request, CreatePersonalizationRequestResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreatePersonalizationRequestResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -34,19 +39,27 @@ class ConsumerPersonalizationRequestsImpl implements ConsumerPersonalizationRequ
         String.format(
             "/api/2.1/marketplace-consumer/listings/%s/personalization-requests",
             request.getListingId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetPersonalizationRequestResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetPersonalizationRequestResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListAllPersonalizationRequestsResponse list(
       ListAllPersonalizationRequestsRequest request) {
     String path = "/api/2.1/marketplace-consumer/personalization-requests";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, ListAllPersonalizationRequestsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListAllPersonalizationRequestsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerPersonalizationRequestsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerPersonalizationRequestsImpl.java
@@ -24,7 +24,8 @@ class ConsumerPersonalizationRequestsImpl implements ConsumerPersonalizationRequ
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreatePersonalizationRequestResponse.class, headers);
+    return apiClient.execute(
+        "POST", path, request, CreatePersonalizationRequestResponse.class, headers);
   }
 
   @Override
@@ -35,7 +36,8 @@ class ConsumerPersonalizationRequestsImpl implements ConsumerPersonalizationRequ
             request.getListingId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetPersonalizationRequestResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetPersonalizationRequestResponse.class, headers);
   }
 
   @Override
@@ -44,6 +46,7 @@ class ConsumerPersonalizationRequestsImpl implements ConsumerPersonalizationRequ
     String path = "/api/2.1/marketplace-consumer/personalization-requests";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListAllPersonalizationRequestsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, ListAllPersonalizationRequestsResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerProvidersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerProvidersImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ConsumerProviders */
 @Generated
@@ -18,24 +19,39 @@ class ConsumerProvidersImpl implements ConsumerProvidersService {
   @Override
   public BatchGetProvidersResponse batchGet(BatchGetProvidersRequest request) {
     String path = "/api/2.1/marketplace-consumer/providers:batchGet";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, BatchGetProvidersResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, BatchGetProvidersResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetProviderResponse get(GetProviderRequest request) {
     String path = String.format("/api/2.1/marketplace-consumer/providers/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetProviderResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetProviderResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListProvidersResponse list(ListProvidersRequest request) {
     String path = "/api/2.1/marketplace-consumer/providers";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListProvidersResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListProvidersResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerProvidersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ConsumerProvidersImpl.java
@@ -20,7 +20,7 @@ class ConsumerProvidersImpl implements ConsumerProvidersService {
     String path = "/api/2.1/marketplace-consumer/providers:batchGet";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, BatchGetProvidersResponse.class, headers);
+    return apiClient.execute("GET", path, request, BatchGetProvidersResponse.class, headers);
   }
 
   @Override
@@ -28,7 +28,7 @@ class ConsumerProvidersImpl implements ConsumerProvidersService {
     String path = String.format("/api/2.1/marketplace-consumer/providers/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetProviderResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetProviderResponse.class, headers);
   }
 
   @Override
@@ -36,6 +36,6 @@ class ConsumerProvidersImpl implements ConsumerProvidersService {
     String path = "/api/2.1/marketplace-consumer/providers";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListProvidersResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListProvidersResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderExchangeFiltersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderExchangeFiltersImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ProviderExchangeFilters */
 @Generated
@@ -18,34 +19,54 @@ class ProviderExchangeFiltersImpl implements ProviderExchangeFiltersService {
   @Override
   public CreateExchangeFilterResponse create(CreateExchangeFilterRequest request) {
     String path = "/api/2.0/marketplace-exchange/filters";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateExchangeFilterResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateExchangeFilterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteExchangeFilterRequest request) {
     String path = String.format("/api/2.0/marketplace-exchange/filters/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteExchangeFilterResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteExchangeFilterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListExchangeFiltersResponse list(ListExchangeFiltersRequest request) {
     String path = "/api/2.0/marketplace-exchange/filters";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListExchangeFiltersResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListExchangeFiltersResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public UpdateExchangeFilterResponse update(UpdateExchangeFilterRequest request) {
     String path = String.format("/api/2.0/marketplace-exchange/filters/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, UpdateExchangeFilterResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, UpdateExchangeFilterResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderExchangeFiltersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderExchangeFiltersImpl.java
@@ -21,7 +21,7 @@ class ProviderExchangeFiltersImpl implements ProviderExchangeFiltersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateExchangeFilterResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateExchangeFilterResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class ProviderExchangeFiltersImpl implements ProviderExchangeFiltersService {
     String path = String.format("/api/2.0/marketplace-exchange/filters/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteExchangeFilterResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteExchangeFilterResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class ProviderExchangeFiltersImpl implements ProviderExchangeFiltersService {
     String path = "/api/2.0/marketplace-exchange/filters";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListExchangeFiltersResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListExchangeFiltersResponse.class, headers);
   }
 
   @Override
@@ -46,6 +46,6 @@ class ProviderExchangeFiltersImpl implements ProviderExchangeFiltersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, UpdateExchangeFilterResponse.class, headers);
+    return apiClient.execute("PUT", path, request, UpdateExchangeFilterResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderExchangesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderExchangesImpl.java
@@ -21,7 +21,7 @@ class ProviderExchangesImpl implements ProviderExchangesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, AddExchangeForListingResponse.class, headers);
+    return apiClient.execute("POST", path, request, AddExchangeForListingResponse.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class ProviderExchangesImpl implements ProviderExchangesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateExchangeResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateExchangeResponse.class, headers);
   }
 
   @Override
@@ -38,7 +38,7 @@ class ProviderExchangesImpl implements ProviderExchangesService {
     String path = String.format("/api/2.0/marketplace-exchange/exchanges/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteExchangeResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteExchangeResponse.class, headers);
   }
 
   @Override
@@ -47,7 +47,7 @@ class ProviderExchangesImpl implements ProviderExchangesService {
         String.format("/api/2.0/marketplace-exchange/exchanges-for-listing/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, RemoveExchangeForListingResponse.class, headers);
+    apiClient.execute("DELETE", path, request, RemoveExchangeForListingResponse.class, headers);
   }
 
   @Override
@@ -55,7 +55,7 @@ class ProviderExchangesImpl implements ProviderExchangesService {
     String path = String.format("/api/2.0/marketplace-exchange/exchanges/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetExchangeResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetExchangeResponse.class, headers);
   }
 
   @Override
@@ -63,7 +63,7 @@ class ProviderExchangesImpl implements ProviderExchangesService {
     String path = "/api/2.0/marketplace-exchange/exchanges";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListExchangesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListExchangesResponse.class, headers);
   }
 
   @Override
@@ -72,7 +72,7 @@ class ProviderExchangesImpl implements ProviderExchangesService {
     String path = "/api/2.0/marketplace-exchange/exchanges-for-listing";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListExchangesForListingResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListExchangesForListingResponse.class, headers);
   }
 
   @Override
@@ -81,7 +81,7 @@ class ProviderExchangesImpl implements ProviderExchangesService {
     String path = "/api/2.0/marketplace-exchange/listings-for-exchange";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListListingsForExchangeResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListListingsForExchangeResponse.class, headers);
   }
 
   @Override
@@ -90,6 +90,6 @@ class ProviderExchangesImpl implements ProviderExchangesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, UpdateExchangeResponse.class, headers);
+    return apiClient.execute("PUT", path, request, UpdateExchangeResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderExchangesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderExchangesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ProviderExchanges */
 @Generated
@@ -18,78 +19,123 @@ class ProviderExchangesImpl implements ProviderExchangesService {
   @Override
   public AddExchangeForListingResponse addListingToExchange(AddExchangeForListingRequest request) {
     String path = "/api/2.0/marketplace-exchange/exchanges-for-listing";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, AddExchangeForListingResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, AddExchangeForListingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CreateExchangeResponse create(CreateExchangeRequest request) {
     String path = "/api/2.0/marketplace-exchange/exchanges";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateExchangeResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateExchangeResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteExchangeRequest request) {
     String path = String.format("/api/2.0/marketplace-exchange/exchanges/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteExchangeResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteExchangeResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteListingFromExchange(RemoveExchangeForListingRequest request) {
     String path =
         String.format("/api/2.0/marketplace-exchange/exchanges-for-listing/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, RemoveExchangeForListingResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, RemoveExchangeForListingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetExchangeResponse get(GetExchangeRequest request) {
     String path = String.format("/api/2.0/marketplace-exchange/exchanges/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetExchangeResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetExchangeResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListExchangesResponse list(ListExchangesRequest request) {
     String path = "/api/2.0/marketplace-exchange/exchanges";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListExchangesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListExchangesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListExchangesForListingResponse listExchangesForListing(
       ListExchangesForListingRequest request) {
     String path = "/api/2.0/marketplace-exchange/exchanges-for-listing";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListExchangesForListingResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListExchangesForListingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListListingsForExchangeResponse listListingsForExchange(
       ListListingsForExchangeRequest request) {
     String path = "/api/2.0/marketplace-exchange/listings-for-exchange";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListListingsForExchangeResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListListingsForExchangeResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public UpdateExchangeResponse update(UpdateExchangeRequest request) {
     String path = String.format("/api/2.0/marketplace-exchange/exchanges/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, UpdateExchangeResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, UpdateExchangeResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderFilesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderFilesImpl.java
@@ -21,7 +21,7 @@ class ProviderFilesImpl implements ProviderFilesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateFileResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateFileResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class ProviderFilesImpl implements ProviderFilesService {
     String path = String.format("/api/2.0/marketplace-provider/files/%s", request.getFileId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteFileResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteFileResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class ProviderFilesImpl implements ProviderFilesService {
     String path = String.format("/api/2.0/marketplace-provider/files/%s", request.getFileId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetFileResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetFileResponse.class, headers);
   }
 
   @Override
@@ -45,6 +45,6 @@ class ProviderFilesImpl implements ProviderFilesService {
     String path = "/api/2.0/marketplace-provider/files";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListFilesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListFilesResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderFilesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderFilesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ProviderFiles */
 @Generated
@@ -18,33 +19,53 @@ class ProviderFilesImpl implements ProviderFilesService {
   @Override
   public CreateFileResponse create(CreateFileRequest request) {
     String path = "/api/2.0/marketplace-provider/files";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateFileResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateFileResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteFileRequest request) {
     String path = String.format("/api/2.0/marketplace-provider/files/%s", request.getFileId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteFileResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteFileResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetFileResponse get(GetFileRequest request) {
     String path = String.format("/api/2.0/marketplace-provider/files/%s", request.getFileId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetFileResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetFileResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListFilesResponse list(ListFilesRequest request) {
     String path = "/api/2.0/marketplace-provider/files";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListFilesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListFilesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderListingsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderListingsImpl.java
@@ -21,7 +21,7 @@ class ProviderListingsImpl implements ProviderListingsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateListingResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateListingResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class ProviderListingsImpl implements ProviderListingsService {
     String path = String.format("/api/2.0/marketplace-provider/listings/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteListingResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteListingResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class ProviderListingsImpl implements ProviderListingsService {
     String path = String.format("/api/2.0/marketplace-provider/listings/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetListingResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetListingResponse.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class ProviderListingsImpl implements ProviderListingsService {
     String path = "/api/2.0/marketplace-provider/listings";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetListingsResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetListingsResponse.class, headers);
   }
 
   @Override
@@ -54,6 +54,6 @@ class ProviderListingsImpl implements ProviderListingsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, UpdateListingResponse.class, headers);
+    return apiClient.execute("PUT", path, request, UpdateListingResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderListingsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderListingsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ProviderListings */
 @Generated
@@ -18,42 +19,67 @@ class ProviderListingsImpl implements ProviderListingsService {
   @Override
   public CreateListingResponse create(CreateListingRequest request) {
     String path = "/api/2.0/marketplace-provider/listing";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateListingResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateListingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteListingRequest request) {
     String path = String.format("/api/2.0/marketplace-provider/listings/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteListingResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteListingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetListingResponse get(GetListingRequest request) {
     String path = String.format("/api/2.0/marketplace-provider/listings/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetListingResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetListingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetListingsResponse list(GetListingsRequest request) {
     String path = "/api/2.0/marketplace-provider/listings";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetListingsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetListingsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public UpdateListingResponse update(UpdateListingRequest request) {
     String path = String.format("/api/2.0/marketplace-provider/listings/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, UpdateListingResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, UpdateListingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderPersonalizationRequestsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderPersonalizationRequestsImpl.java
@@ -21,7 +21,8 @@ class ProviderPersonalizationRequestsImpl implements ProviderPersonalizationRequ
     String path = "/api/2.0/marketplace-provider/personalization-requests";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListAllPersonalizationRequestsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, ListAllPersonalizationRequestsResponse.class, headers);
   }
 
   @Override
@@ -33,6 +34,7 @@ class ProviderPersonalizationRequestsImpl implements ProviderPersonalizationRequ
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, UpdatePersonalizationRequestResponse.class, headers);
+    return apiClient.execute(
+        "PUT", path, request, UpdatePersonalizationRequestResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderPersonalizationRequestsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderPersonalizationRequestsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ProviderPersonalizationRequests */
 @Generated
@@ -19,10 +20,14 @@ class ProviderPersonalizationRequestsImpl implements ProviderPersonalizationRequ
   public ListAllPersonalizationRequestsResponse list(
       ListAllPersonalizationRequestsRequest request) {
     String path = "/api/2.0/marketplace-provider/personalization-requests";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, ListAllPersonalizationRequestsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListAllPersonalizationRequestsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,10 +36,14 @@ class ProviderPersonalizationRequestsImpl implements ProviderPersonalizationRequ
         String.format(
             "/api/2.0/marketplace-provider/listings/%s/personalization-requests/%s/request-status",
             request.getListingId(), request.getRequestId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "PUT", path, request, UpdatePersonalizationRequestResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, UpdatePersonalizationRequestResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderProviderAnalyticsDashboardsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderProviderAnalyticsDashboardsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ProviderProviderAnalyticsDashboards */
 @Generated
@@ -19,27 +20,40 @@ class ProviderProviderAnalyticsDashboardsImpl
   @Override
   public ProviderAnalyticsDashboard create() {
     String path = "/api/2.0/marketplace-provider/analytics_dashboard";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("POST", path, null, ProviderAnalyticsDashboard.class, headers);
+    try {
+      Request req = new Request("POST", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ProviderAnalyticsDashboard.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListProviderAnalyticsDashboardResponse get() {
     String path = "/api/2.0/marketplace-provider/analytics_dashboard";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, null, ListProviderAnalyticsDashboardResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListProviderAnalyticsDashboardResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetLatestVersionProviderAnalyticsDashboardResponse getLatestVersion() {
     String path = "/api/2.0/marketplace-provider/analytics_dashboard/latest";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, null, GetLatestVersionProviderAnalyticsDashboardResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetLatestVersionProviderAnalyticsDashboardResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -47,10 +61,14 @@ class ProviderProviderAnalyticsDashboardsImpl
       UpdateProviderAnalyticsDashboardRequest request) {
     String path =
         String.format("/api/2.0/marketplace-provider/analytics_dashboard/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "PUT", path, request, UpdateProviderAnalyticsDashboardResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, UpdateProviderAnalyticsDashboardResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderProviderAnalyticsDashboardsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderProviderAnalyticsDashboardsImpl.java
@@ -21,7 +21,7 @@ class ProviderProviderAnalyticsDashboardsImpl
     String path = "/api/2.0/marketplace-provider/analytics_dashboard";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.POST(path, ProviderAnalyticsDashboard.class, headers);
+    return apiClient.execute("POST", path, null, ProviderAnalyticsDashboard.class, headers);
   }
 
   @Override
@@ -29,7 +29,8 @@ class ProviderProviderAnalyticsDashboardsImpl
     String path = "/api/2.0/marketplace-provider/analytics_dashboard";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListProviderAnalyticsDashboardResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, null, ListProviderAnalyticsDashboardResponse.class, headers);
   }
 
   @Override
@@ -37,7 +38,8 @@ class ProviderProviderAnalyticsDashboardsImpl
     String path = "/api/2.0/marketplace-provider/analytics_dashboard/latest";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, GetLatestVersionProviderAnalyticsDashboardResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, null, GetLatestVersionProviderAnalyticsDashboardResponse.class, headers);
   }
 
   @Override
@@ -48,6 +50,7 @@ class ProviderProviderAnalyticsDashboardsImpl
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, UpdateProviderAnalyticsDashboardResponse.class, headers);
+    return apiClient.execute(
+        "PUT", path, request, UpdateProviderAnalyticsDashboardResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderProvidersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderProvidersImpl.java
@@ -21,7 +21,7 @@ class ProviderProvidersImpl implements ProviderProvidersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateProviderResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateProviderResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class ProviderProvidersImpl implements ProviderProvidersService {
     String path = String.format("/api/2.0/marketplace-provider/providers/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteProviderResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteProviderResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class ProviderProvidersImpl implements ProviderProvidersService {
     String path = String.format("/api/2.0/marketplace-provider/providers/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetProviderResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetProviderResponse.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class ProviderProvidersImpl implements ProviderProvidersService {
     String path = "/api/2.0/marketplace-provider/providers";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListProvidersResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListProvidersResponse.class, headers);
   }
 
   @Override
@@ -54,6 +54,6 @@ class ProviderProvidersImpl implements ProviderProvidersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, UpdateProviderResponse.class, headers);
+    return apiClient.execute("PUT", path, request, UpdateProviderResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderProvidersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/marketplace/ProviderProvidersImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.marketplace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ProviderProviders */
 @Generated
@@ -18,42 +19,67 @@ class ProviderProvidersImpl implements ProviderProvidersService {
   @Override
   public CreateProviderResponse create(CreateProviderRequest request) {
     String path = "/api/2.0/marketplace-provider/provider";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateProviderResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateProviderResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteProviderRequest request) {
     String path = String.format("/api/2.0/marketplace-provider/providers/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteProviderResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteProviderResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetProviderResponse get(GetProviderRequest request) {
     String path = String.format("/api/2.0/marketplace-provider/providers/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetProviderResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetProviderResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListProvidersResponse list(ListProvidersRequest request) {
     String path = "/api/2.0/marketplace-provider/providers";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListProvidersResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListProvidersResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public UpdateProviderResponse update(UpdateProviderRequest request) {
     String path = String.format("/api/2.0/marketplace-provider/providers/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, UpdateProviderResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, UpdateProviderResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ml/ExperimentsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ml/ExperimentsImpl.java
@@ -21,7 +21,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateExperimentResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateExperimentResponse.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateRunResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateRunResponse.class, headers);
   }
 
   @Override
@@ -39,7 +39,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteExperimentResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteExperimentResponse.class, headers);
   }
 
   @Override
@@ -48,7 +48,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteRunResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteRunResponse.class, headers);
   }
 
   @Override
@@ -57,7 +57,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, DeleteRunsResponse.class, headers);
+    return apiClient.execute("POST", path, request, DeleteRunsResponse.class, headers);
   }
 
   @Override
@@ -66,7 +66,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteTagResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteTagResponse.class, headers);
   }
 
   @Override
@@ -74,7 +74,7 @@ class ExperimentsImpl implements ExperimentsService {
     String path = "/api/2.0/mlflow/experiments/get-by-name";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetExperimentResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetExperimentResponse.class, headers);
   }
 
   @Override
@@ -82,7 +82,7 @@ class ExperimentsImpl implements ExperimentsService {
     String path = "/api/2.0/mlflow/experiments/get";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetExperimentResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetExperimentResponse.class, headers);
   }
 
   @Override
@@ -90,7 +90,7 @@ class ExperimentsImpl implements ExperimentsService {
     String path = "/api/2.0/mlflow/metrics/get-history";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetMetricHistoryResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetMetricHistoryResponse.class, headers);
   }
 
   @Override
@@ -101,7 +101,8 @@ class ExperimentsImpl implements ExperimentsService {
             "/api/2.0/permissions/experiments/%s/permissionLevels", request.getExperimentId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetExperimentPermissionLevelsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetExperimentPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -109,7 +110,7 @@ class ExperimentsImpl implements ExperimentsService {
     String path = String.format("/api/2.0/permissions/experiments/%s", request.getExperimentId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ExperimentPermissions.class, headers);
+    return apiClient.execute("GET", path, request, ExperimentPermissions.class, headers);
   }
 
   @Override
@@ -117,7 +118,7 @@ class ExperimentsImpl implements ExperimentsService {
     String path = "/api/2.0/mlflow/runs/get";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetRunResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetRunResponse.class, headers);
   }
 
   @Override
@@ -125,7 +126,7 @@ class ExperimentsImpl implements ExperimentsService {
     String path = "/api/2.0/mlflow/artifacts/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListArtifactsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListArtifactsResponse.class, headers);
   }
 
   @Override
@@ -133,7 +134,7 @@ class ExperimentsImpl implements ExperimentsService {
     String path = "/api/2.0/mlflow/experiments/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListExperimentsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListExperimentsResponse.class, headers);
   }
 
   @Override
@@ -142,7 +143,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, LogBatchResponse.class, headers);
+    apiClient.execute("POST", path, request, LogBatchResponse.class, headers);
   }
 
   @Override
@@ -151,7 +152,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, LogInputsResponse.class, headers);
+    apiClient.execute("POST", path, request, LogInputsResponse.class, headers);
   }
 
   @Override
@@ -160,7 +161,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, LogMetricResponse.class, headers);
+    apiClient.execute("POST", path, request, LogMetricResponse.class, headers);
   }
 
   @Override
@@ -169,7 +170,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, LogModelResponse.class, headers);
+    apiClient.execute("POST", path, request, LogModelResponse.class, headers);
   }
 
   @Override
@@ -178,7 +179,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, LogParamResponse.class, headers);
+    apiClient.execute("POST", path, request, LogParamResponse.class, headers);
   }
 
   @Override
@@ -187,7 +188,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, RestoreExperimentResponse.class, headers);
+    apiClient.execute("POST", path, request, RestoreExperimentResponse.class, headers);
   }
 
   @Override
@@ -196,7 +197,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, RestoreRunResponse.class, headers);
+    apiClient.execute("POST", path, request, RestoreRunResponse.class, headers);
   }
 
   @Override
@@ -205,7 +206,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, RestoreRunsResponse.class, headers);
+    return apiClient.execute("POST", path, request, RestoreRunsResponse.class, headers);
   }
 
   @Override
@@ -214,7 +215,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, SearchExperimentsResponse.class, headers);
+    return apiClient.execute("POST", path, request, SearchExperimentsResponse.class, headers);
   }
 
   @Override
@@ -223,7 +224,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, SearchRunsResponse.class, headers);
+    return apiClient.execute("POST", path, request, SearchRunsResponse.class, headers);
   }
 
   @Override
@@ -232,7 +233,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, SetExperimentTagResponse.class, headers);
+    apiClient.execute("POST", path, request, SetExperimentTagResponse.class, headers);
   }
 
   @Override
@@ -241,7 +242,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, ExperimentPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, ExperimentPermissions.class, headers);
   }
 
   @Override
@@ -250,7 +251,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, SetTagResponse.class, headers);
+    apiClient.execute("POST", path, request, SetTagResponse.class, headers);
   }
 
   @Override
@@ -259,7 +260,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, UpdateExperimentResponse.class, headers);
+    apiClient.execute("POST", path, request, UpdateExperimentResponse.class, headers);
   }
 
   @Override
@@ -268,7 +269,7 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, ExperimentPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, ExperimentPermissions.class, headers);
   }
 
   @Override
@@ -277,6 +278,6 @@ class ExperimentsImpl implements ExperimentsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, UpdateRunResponse.class, headers);
+    return apiClient.execute("POST", path, request, UpdateRunResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ml/ExperimentsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ml/ExperimentsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.ml;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Experiments */
 @Generated
@@ -18,79 +19,124 @@ class ExperimentsImpl implements ExperimentsService {
   @Override
   public CreateExperimentResponse createExperiment(CreateExperiment request) {
     String path = "/api/2.0/mlflow/experiments/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateExperimentResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateExperimentResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CreateRunResponse createRun(CreateRun request) {
     String path = "/api/2.0/mlflow/runs/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateRunResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateRunResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteExperiment(DeleteExperiment request) {
     String path = "/api/2.0/mlflow/experiments/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteExperimentResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteExperimentResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteRun(DeleteRun request) {
     String path = "/api/2.0/mlflow/runs/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteRunResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteRunResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public DeleteRunsResponse deleteRuns(DeleteRuns request) {
     String path = "/api/2.0/mlflow/databricks/runs/delete-runs";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, DeleteRunsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, DeleteRunsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteTag(DeleteTag request) {
     String path = "/api/2.0/mlflow/runs/delete-tag";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteTagResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteTagResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetExperimentResponse getByName(GetByNameRequest request) {
     String path = "/api/2.0/mlflow/experiments/get-by-name";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetExperimentResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetExperimentResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetExperimentResponse getExperiment(GetExperimentRequest request) {
     String path = "/api/2.0/mlflow/experiments/get";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetExperimentResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetExperimentResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetMetricHistoryResponse getHistory(GetHistoryRequest request) {
     String path = "/api/2.0/mlflow/metrics/get-history";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetMetricHistoryResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetMetricHistoryResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -99,185 +145,289 @@ class ExperimentsImpl implements ExperimentsService {
     String path =
         String.format(
             "/api/2.0/permissions/experiments/%s/permissionLevels", request.getExperimentId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetExperimentPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetExperimentPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ExperimentPermissions getPermissions(GetExperimentPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/experiments/%s", request.getExperimentId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ExperimentPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ExperimentPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetRunResponse getRun(GetRunRequest request) {
     String path = "/api/2.0/mlflow/runs/get";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetRunResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetRunResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListArtifactsResponse listArtifacts(ListArtifactsRequest request) {
     String path = "/api/2.0/mlflow/artifacts/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListArtifactsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListArtifactsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListExperimentsResponse listExperiments(ListExperimentsRequest request) {
     String path = "/api/2.0/mlflow/experiments/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListExperimentsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListExperimentsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void logBatch(LogBatch request) {
     String path = "/api/2.0/mlflow/runs/log-batch";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, LogBatchResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, LogBatchResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void logInputs(LogInputs request) {
     String path = "/api/2.0/mlflow/runs/log-inputs";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, LogInputsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, LogInputsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void logMetric(LogMetric request) {
     String path = "/api/2.0/mlflow/runs/log-metric";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, LogMetricResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, LogMetricResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void logModel(LogModel request) {
     String path = "/api/2.0/mlflow/runs/log-model";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, LogModelResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, LogModelResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void logParam(LogParam request) {
     String path = "/api/2.0/mlflow/runs/log-parameter";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, LogParamResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, LogParamResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void restoreExperiment(RestoreExperiment request) {
     String path = "/api/2.0/mlflow/experiments/restore";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, RestoreExperimentResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, RestoreExperimentResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void restoreRun(RestoreRun request) {
     String path = "/api/2.0/mlflow/runs/restore";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, RestoreRunResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, RestoreRunResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RestoreRunsResponse restoreRuns(RestoreRuns request) {
     String path = "/api/2.0/mlflow/databricks/runs/restore-runs";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, RestoreRunsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RestoreRunsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public SearchExperimentsResponse searchExperiments(SearchExperiments request) {
     String path = "/api/2.0/mlflow/experiments/search";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, SearchExperimentsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, SearchExperimentsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public SearchRunsResponse searchRuns(SearchRuns request) {
     String path = "/api/2.0/mlflow/runs/search";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, SearchRunsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, SearchRunsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void setExperimentTag(SetExperimentTag request) {
     String path = "/api/2.0/mlflow/experiments/set-experiment-tag";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, SetExperimentTagResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, SetExperimentTagResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ExperimentPermissions setPermissions(ExperimentPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/experiments/%s", request.getExperimentId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, ExperimentPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ExperimentPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void setTag(SetTag request) {
     String path = "/api/2.0/mlflow/runs/set-tag";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, SetTagResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, SetTagResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void updateExperiment(UpdateExperiment request) {
     String path = "/api/2.0/mlflow/experiments/update";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, UpdateExperimentResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateExperimentResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ExperimentPermissions updatePermissions(ExperimentPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/experiments/%s", request.getExperimentId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, ExperimentPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ExperimentPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public UpdateRunResponse updateRun(UpdateRun request) {
     String path = "/api/2.0/mlflow/runs/update";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, UpdateRunResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, UpdateRunResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ml/ModelRegistryImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ml/ModelRegistryImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.ml;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ModelRegistry */
 @Generated
@@ -19,147 +20,230 @@ class ModelRegistryImpl implements ModelRegistryService {
   public ApproveTransitionRequestResponse approveTransitionRequest(
       ApproveTransitionRequest request) {
     String path = "/api/2.0/mlflow/transition-requests/approve";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST", path, request, ApproveTransitionRequestResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ApproveTransitionRequestResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CreateCommentResponse createComment(CreateComment request) {
     String path = "/api/2.0/mlflow/comments/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateCommentResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateCommentResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CreateModelResponse createModel(CreateModelRequest request) {
     String path = "/api/2.0/mlflow/registered-models/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateModelResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateModelResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CreateModelVersionResponse createModelVersion(CreateModelVersionRequest request) {
     String path = "/api/2.0/mlflow/model-versions/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateModelVersionResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateModelVersionResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CreateTransitionRequestResponse createTransitionRequest(CreateTransitionRequest request) {
     String path = "/api/2.0/mlflow/transition-requests/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateTransitionRequestResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateTransitionRequestResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public CreateWebhookResponse createWebhook(CreateRegistryWebhook request) {
     String path = "/api/2.0/mlflow/registry-webhooks/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateWebhookResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateWebhookResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteComment(DeleteCommentRequest request) {
     String path = "/api/2.0/mlflow/comments/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteCommentResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteCommentResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteModel(DeleteModelRequest request) {
     String path = "/api/2.0/mlflow/registered-models/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteModelResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteModelResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteModelTag(DeleteModelTagRequest request) {
     String path = "/api/2.0/mlflow/registered-models/delete-tag";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteModelTagResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteModelTagResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteModelVersion(DeleteModelVersionRequest request) {
     String path = "/api/2.0/mlflow/model-versions/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteModelVersionResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteModelVersionResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteModelVersionTag(DeleteModelVersionTagRequest request) {
     String path = "/api/2.0/mlflow/model-versions/delete-tag";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteModelVersionTagResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteModelVersionTagResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteTransitionRequest(DeleteTransitionRequestRequest request) {
     String path = "/api/2.0/mlflow/transition-requests/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteTransitionRequestResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteTransitionRequestResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteWebhook(DeleteWebhookRequest request) {
     String path = "/api/2.0/mlflow/registry-webhooks/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteWebhookResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteWebhookResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetLatestVersionsResponse getLatestVersions(GetLatestVersionsRequest request) {
     String path = "/api/2.0/mlflow/registered-models/get-latest-versions";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, GetLatestVersionsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, GetLatestVersionsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetModelResponse getModel(GetModelRequest request) {
     String path = "/api/2.0/mlflow/databricks/registered-models/get";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetModelResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetModelResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetModelVersionResponse getModelVersion(GetModelVersionRequest request) {
     String path = "/api/2.0/mlflow/model-versions/get";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetModelVersionResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetModelVersionResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetModelVersionDownloadUriResponse getModelVersionDownloadUri(
       GetModelVersionDownloadUriRequest request) {
     String path = "/api/2.0/mlflow/model-versions/get-download-uri";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetModelVersionDownloadUriResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetModelVersionDownloadUriResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -169,169 +253,263 @@ class ModelRegistryImpl implements ModelRegistryService {
         String.format(
             "/api/2.0/permissions/registered-models/%s/permissionLevels",
             request.getRegisteredModelId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetRegisteredModelPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetRegisteredModelPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RegisteredModelPermissions getPermissions(GetRegisteredModelPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/registered-models/%s", request.getRegisteredModelId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, RegisteredModelPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, RegisteredModelPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListModelsResponse listModels(ListModelsRequest request) {
     String path = "/api/2.0/mlflow/registered-models/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListModelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListModelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListTransitionRequestsResponse listTransitionRequests(
       ListTransitionRequestsRequest request) {
     String path = "/api/2.0/mlflow/transition-requests/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListTransitionRequestsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListTransitionRequestsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListRegistryWebhooks listWebhooks(ListWebhooksRequest request) {
     String path = "/api/2.0/mlflow/registry-webhooks/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListRegistryWebhooks.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListRegistryWebhooks.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RejectTransitionRequestResponse rejectTransitionRequest(RejectTransitionRequest request) {
     String path = "/api/2.0/mlflow/transition-requests/reject";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, RejectTransitionRequestResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RejectTransitionRequestResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RenameModelResponse renameModel(RenameModelRequest request) {
     String path = "/api/2.0/mlflow/registered-models/rename";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, RenameModelResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RenameModelResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public SearchModelVersionsResponse searchModelVersions(SearchModelVersionsRequest request) {
     String path = "/api/2.0/mlflow/model-versions/search";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, SearchModelVersionsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, SearchModelVersionsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public SearchModelsResponse searchModels(SearchModelsRequest request) {
     String path = "/api/2.0/mlflow/registered-models/search";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, SearchModelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, SearchModelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void setModelTag(SetModelTagRequest request) {
     String path = "/api/2.0/mlflow/registered-models/set-tag";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, SetModelTagResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, SetModelTagResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void setModelVersionTag(SetModelVersionTagRequest request) {
     String path = "/api/2.0/mlflow/model-versions/set-tag";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, SetModelVersionTagResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, SetModelVersionTagResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RegisteredModelPermissions setPermissions(RegisteredModelPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/registered-models/%s", request.getRegisteredModelId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, RegisteredModelPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RegisteredModelPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public TestRegistryWebhookResponse testRegistryWebhook(TestRegistryWebhookRequest request) {
     String path = "/api/2.0/mlflow/registry-webhooks/test";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, TestRegistryWebhookResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, TestRegistryWebhookResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public TransitionStageResponse transitionStage(TransitionModelVersionStageDatabricks request) {
     String path = "/api/2.0/mlflow/databricks/model-versions/transition-stage";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, TransitionStageResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, TransitionStageResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public UpdateCommentResponse updateComment(UpdateComment request) {
     String path = "/api/2.0/mlflow/comments/update";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, UpdateCommentResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, UpdateCommentResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void updateModel(UpdateModelRequest request) {
     String path = "/api/2.0/mlflow/registered-models/update";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateModelResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateModelResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void updateModelVersion(UpdateModelVersionRequest request) {
     String path = "/api/2.0/mlflow/model-versions/update";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateModelVersionResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateModelVersionResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RegisteredModelPermissions updatePermissions(RegisteredModelPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/registered-models/%s", request.getRegisteredModelId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, RegisteredModelPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RegisteredModelPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void updateWebhook(UpdateRegistryWebhook request) {
     String path = "/api/2.0/mlflow/registry-webhooks/update";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateWebhookResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateWebhookResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ml/ModelRegistryImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/ml/ModelRegistryImpl.java
@@ -22,7 +22,8 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ApproveTransitionRequestResponse.class, headers);
+    return apiClient.execute(
+        "POST", path, request, ApproveTransitionRequestResponse.class, headers);
   }
 
   @Override
@@ -31,7 +32,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateCommentResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateCommentResponse.class, headers);
   }
 
   @Override
@@ -40,7 +41,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateModelResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateModelResponse.class, headers);
   }
 
   @Override
@@ -49,7 +50,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateModelVersionResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateModelVersionResponse.class, headers);
   }
 
   @Override
@@ -58,7 +59,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateTransitionRequestResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateTransitionRequestResponse.class, headers);
   }
 
   @Override
@@ -67,7 +68,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateWebhookResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateWebhookResponse.class, headers);
   }
 
   @Override
@@ -75,7 +76,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/comments/delete";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteCommentResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteCommentResponse.class, headers);
   }
 
   @Override
@@ -83,7 +84,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/registered-models/delete";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteModelResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteModelResponse.class, headers);
   }
 
   @Override
@@ -91,7 +92,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/registered-models/delete-tag";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteModelTagResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteModelTagResponse.class, headers);
   }
 
   @Override
@@ -99,7 +100,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/model-versions/delete";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteModelVersionResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteModelVersionResponse.class, headers);
   }
 
   @Override
@@ -107,7 +108,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/model-versions/delete-tag";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteModelVersionTagResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteModelVersionTagResponse.class, headers);
   }
 
   @Override
@@ -115,7 +116,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/transition-requests/delete";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteTransitionRequestResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteTransitionRequestResponse.class, headers);
   }
 
   @Override
@@ -123,7 +124,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/registry-webhooks/delete";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteWebhookResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteWebhookResponse.class, headers);
   }
 
   @Override
@@ -132,7 +133,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, GetLatestVersionsResponse.class, headers);
+    return apiClient.execute("POST", path, request, GetLatestVersionsResponse.class, headers);
   }
 
   @Override
@@ -140,7 +141,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/databricks/registered-models/get";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetModelResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetModelResponse.class, headers);
   }
 
   @Override
@@ -148,7 +149,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/model-versions/get";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetModelVersionResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetModelVersionResponse.class, headers);
   }
 
   @Override
@@ -157,7 +158,8 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/model-versions/get-download-uri";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetModelVersionDownloadUriResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetModelVersionDownloadUriResponse.class, headers);
   }
 
   @Override
@@ -169,7 +171,8 @@ class ModelRegistryImpl implements ModelRegistryService {
             request.getRegisteredModelId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetRegisteredModelPermissionLevelsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetRegisteredModelPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -178,7 +181,7 @@ class ModelRegistryImpl implements ModelRegistryService {
         String.format("/api/2.0/permissions/registered-models/%s", request.getRegisteredModelId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, RegisteredModelPermissions.class, headers);
+    return apiClient.execute("GET", path, request, RegisteredModelPermissions.class, headers);
   }
 
   @Override
@@ -186,7 +189,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/registered-models/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListModelsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListModelsResponse.class, headers);
   }
 
   @Override
@@ -195,7 +198,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/transition-requests/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListTransitionRequestsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListTransitionRequestsResponse.class, headers);
   }
 
   @Override
@@ -203,7 +206,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/registry-webhooks/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListRegistryWebhooks.class, headers);
+    return apiClient.execute("GET", path, request, ListRegistryWebhooks.class, headers);
   }
 
   @Override
@@ -212,7 +215,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, RejectTransitionRequestResponse.class, headers);
+    return apiClient.execute("POST", path, request, RejectTransitionRequestResponse.class, headers);
   }
 
   @Override
@@ -221,7 +224,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, RenameModelResponse.class, headers);
+    return apiClient.execute("POST", path, request, RenameModelResponse.class, headers);
   }
 
   @Override
@@ -229,7 +232,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/model-versions/search";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, SearchModelVersionsResponse.class, headers);
+    return apiClient.execute("GET", path, request, SearchModelVersionsResponse.class, headers);
   }
 
   @Override
@@ -237,7 +240,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     String path = "/api/2.0/mlflow/registered-models/search";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, SearchModelsResponse.class, headers);
+    return apiClient.execute("GET", path, request, SearchModelsResponse.class, headers);
   }
 
   @Override
@@ -246,7 +249,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, SetModelTagResponse.class, headers);
+    apiClient.execute("POST", path, request, SetModelTagResponse.class, headers);
   }
 
   @Override
@@ -255,7 +258,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, SetModelVersionTagResponse.class, headers);
+    apiClient.execute("POST", path, request, SetModelVersionTagResponse.class, headers);
   }
 
   @Override
@@ -265,7 +268,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, RegisteredModelPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, RegisteredModelPermissions.class, headers);
   }
 
   @Override
@@ -274,7 +277,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, TestRegistryWebhookResponse.class, headers);
+    return apiClient.execute("POST", path, request, TestRegistryWebhookResponse.class, headers);
   }
 
   @Override
@@ -283,7 +286,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, TransitionStageResponse.class, headers);
+    return apiClient.execute("POST", path, request, TransitionStageResponse.class, headers);
   }
 
   @Override
@@ -292,7 +295,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, UpdateCommentResponse.class, headers);
+    return apiClient.execute("PATCH", path, request, UpdateCommentResponse.class, headers);
   }
 
   @Override
@@ -301,7 +304,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateModelResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateModelResponse.class, headers);
   }
 
   @Override
@@ -310,7 +313,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateModelVersionResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateModelVersionResponse.class, headers);
   }
 
   @Override
@@ -320,7 +323,7 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, RegisteredModelPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, RegisteredModelPermissions.class, headers);
   }
 
   @Override
@@ -329,6 +332,6 @@ class ModelRegistryImpl implements ModelRegistryService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateWebhookResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateWebhookResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/AccountFederationPolicyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/AccountFederationPolicyImpl.java
@@ -22,7 +22,7 @@ class AccountFederationPolicyImpl implements AccountFederationPolicyService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request.getPolicy(), FederationPolicy.class, headers);
+    return apiClient.execute("POST", path, request.getPolicy(), FederationPolicy.class, headers);
   }
 
   @Override
@@ -33,7 +33,7 @@ class AccountFederationPolicyImpl implements AccountFederationPolicyService {
             apiClient.configuredAccountID(), request.getPolicyId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -44,7 +44,7 @@ class AccountFederationPolicyImpl implements AccountFederationPolicyService {
             apiClient.configuredAccountID(), request.getPolicyId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, FederationPolicy.class, headers);
+    return apiClient.execute("GET", path, request, FederationPolicy.class, headers);
   }
 
   @Override
@@ -53,7 +53,7 @@ class AccountFederationPolicyImpl implements AccountFederationPolicyService {
         String.format("/api/2.0/accounts/%s/federationPolicies", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListFederationPoliciesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListFederationPoliciesResponse.class, headers);
   }
 
   @Override
@@ -65,6 +65,6 @@ class AccountFederationPolicyImpl implements AccountFederationPolicyService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request.getPolicy(), FederationPolicy.class, headers);
+    return apiClient.execute("PATCH", path, request.getPolicy(), FederationPolicy.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/AccountFederationPolicyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/AccountFederationPolicyImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AccountFederationPolicy */
 @Generated
@@ -19,10 +20,15 @@ class AccountFederationPolicyImpl implements AccountFederationPolicyService {
   public FederationPolicy create(CreateAccountFederationPolicyRequest request) {
     String path =
         String.format("/api/2.0/accounts/%s/federationPolicies", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request.getPolicy(), FederationPolicy.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request.getPolicy()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, FederationPolicy.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,9 +37,14 @@ class AccountFederationPolicyImpl implements AccountFederationPolicyService {
         String.format(
             "/api/2.0/accounts/%s/federationPolicies/%s",
             apiClient.configuredAccountID(), request.getPolicyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -42,18 +53,28 @@ class AccountFederationPolicyImpl implements AccountFederationPolicyService {
         String.format(
             "/api/2.0/accounts/%s/federationPolicies/%s",
             apiClient.configuredAccountID(), request.getPolicyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, FederationPolicy.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, FederationPolicy.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListFederationPoliciesResponse list(ListAccountFederationPoliciesRequest request) {
     String path =
         String.format("/api/2.0/accounts/%s/federationPolicies", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListFederationPoliciesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListFederationPoliciesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -62,9 +83,14 @@ class AccountFederationPolicyImpl implements AccountFederationPolicyService {
         String.format(
             "/api/2.0/accounts/%s/federationPolicies/%s",
             apiClient.configuredAccountID(), request.getPolicyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request.getPolicy(), FederationPolicy.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request.getPolicy()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, FederationPolicy.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/CustomAppIntegrationImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/CustomAppIntegrationImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of CustomAppIntegration */
 @Generated
@@ -20,11 +21,15 @@ class CustomAppIntegrationImpl implements CustomAppIntegrationService {
     String path =
         String.format(
             "/api/2.0/accounts/%s/oauth2/custom-app-integrations", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST", path, request, CreateCustomAppIntegrationOutput.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateCustomAppIntegrationOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -33,9 +38,14 @@ class CustomAppIntegrationImpl implements CustomAppIntegrationService {
         String.format(
             "/api/2.0/accounts/%s/oauth2/custom-app-integrations/%s",
             apiClient.configuredAccountID(), request.getIntegrationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteCustomAppIntegrationOutput.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteCustomAppIntegrationOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -44,9 +54,14 @@ class CustomAppIntegrationImpl implements CustomAppIntegrationService {
         String.format(
             "/api/2.0/accounts/%s/oauth2/custom-app-integrations/%s",
             apiClient.configuredAccountID(), request.getIntegrationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetCustomAppIntegrationOutput.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetCustomAppIntegrationOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -54,9 +69,14 @@ class CustomAppIntegrationImpl implements CustomAppIntegrationService {
     String path =
         String.format(
             "/api/2.0/accounts/%s/oauth2/custom-app-integrations", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetCustomAppIntegrationsOutput.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetCustomAppIntegrationsOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -65,9 +85,14 @@ class CustomAppIntegrationImpl implements CustomAppIntegrationService {
         String.format(
             "/api/2.0/accounts/%s/oauth2/custom-app-integrations/%s",
             apiClient.configuredAccountID(), request.getIntegrationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateCustomAppIntegrationOutput.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateCustomAppIntegrationOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/CustomAppIntegrationImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/CustomAppIntegrationImpl.java
@@ -23,7 +23,8 @@ class CustomAppIntegrationImpl implements CustomAppIntegrationService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateCustomAppIntegrationOutput.class, headers);
+    return apiClient.execute(
+        "POST", path, request, CreateCustomAppIntegrationOutput.class, headers);
   }
 
   @Override
@@ -34,7 +35,7 @@ class CustomAppIntegrationImpl implements CustomAppIntegrationService {
             apiClient.configuredAccountID(), request.getIntegrationId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteCustomAppIntegrationOutput.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteCustomAppIntegrationOutput.class, headers);
   }
 
   @Override
@@ -45,7 +46,7 @@ class CustomAppIntegrationImpl implements CustomAppIntegrationService {
             apiClient.configuredAccountID(), request.getIntegrationId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetCustomAppIntegrationOutput.class, headers);
+    return apiClient.execute("GET", path, request, GetCustomAppIntegrationOutput.class, headers);
   }
 
   @Override
@@ -55,7 +56,7 @@ class CustomAppIntegrationImpl implements CustomAppIntegrationService {
             "/api/2.0/accounts/%s/oauth2/custom-app-integrations", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetCustomAppIntegrationsOutput.class, headers);
+    return apiClient.execute("GET", path, request, GetCustomAppIntegrationsOutput.class, headers);
   }
 
   @Override
@@ -67,6 +68,6 @@ class CustomAppIntegrationImpl implements CustomAppIntegrationService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateCustomAppIntegrationOutput.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateCustomAppIntegrationOutput.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/OAuthPublishedAppsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/OAuthPublishedAppsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of OAuthPublishedApps */
 @Generated
@@ -20,8 +21,13 @@ class OAuthPublishedAppsImpl implements OAuthPublishedAppsService {
     String path =
         String.format(
             "/api/2.0/accounts/%s/oauth2/published-apps", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetPublishedAppsOutput.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetPublishedAppsOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/OAuthPublishedAppsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/OAuthPublishedAppsImpl.java
@@ -22,6 +22,6 @@ class OAuthPublishedAppsImpl implements OAuthPublishedAppsService {
             "/api/2.0/accounts/%s/oauth2/published-apps", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetPublishedAppsOutput.class, headers);
+    return apiClient.execute("GET", path, request, GetPublishedAppsOutput.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/PublishedAppIntegrationImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/PublishedAppIntegrationImpl.java
@@ -24,7 +24,8 @@ class PublishedAppIntegrationImpl implements PublishedAppIntegrationService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreatePublishedAppIntegrationOutput.class, headers);
+    return apiClient.execute(
+        "POST", path, request, CreatePublishedAppIntegrationOutput.class, headers);
   }
 
   @Override
@@ -35,7 +36,7 @@ class PublishedAppIntegrationImpl implements PublishedAppIntegrationService {
             apiClient.configuredAccountID(), request.getIntegrationId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeletePublishedAppIntegrationOutput.class, headers);
+    apiClient.execute("DELETE", path, request, DeletePublishedAppIntegrationOutput.class, headers);
   }
 
   @Override
@@ -46,7 +47,7 @@ class PublishedAppIntegrationImpl implements PublishedAppIntegrationService {
             apiClient.configuredAccountID(), request.getIntegrationId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetPublishedAppIntegrationOutput.class, headers);
+    return apiClient.execute("GET", path, request, GetPublishedAppIntegrationOutput.class, headers);
   }
 
   @Override
@@ -57,7 +58,8 @@ class PublishedAppIntegrationImpl implements PublishedAppIntegrationService {
             apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetPublishedAppIntegrationsOutput.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetPublishedAppIntegrationsOutput.class, headers);
   }
 
   @Override
@@ -69,6 +71,6 @@ class PublishedAppIntegrationImpl implements PublishedAppIntegrationService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdatePublishedAppIntegrationOutput.class, headers);
+    apiClient.execute("PATCH", path, request, UpdatePublishedAppIntegrationOutput.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/PublishedAppIntegrationImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/PublishedAppIntegrationImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of PublishedAppIntegration */
 @Generated
@@ -21,11 +22,15 @@ class PublishedAppIntegrationImpl implements PublishedAppIntegrationService {
         String.format(
             "/api/2.0/accounts/%s/oauth2/published-app-integrations",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST", path, request, CreatePublishedAppIntegrationOutput.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreatePublishedAppIntegrationOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -34,9 +39,14 @@ class PublishedAppIntegrationImpl implements PublishedAppIntegrationService {
         String.format(
             "/api/2.0/accounts/%s/oauth2/published-app-integrations/%s",
             apiClient.configuredAccountID(), request.getIntegrationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeletePublishedAppIntegrationOutput.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeletePublishedAppIntegrationOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -45,9 +55,14 @@ class PublishedAppIntegrationImpl implements PublishedAppIntegrationService {
         String.format(
             "/api/2.0/accounts/%s/oauth2/published-app-integrations/%s",
             apiClient.configuredAccountID(), request.getIntegrationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetPublishedAppIntegrationOutput.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetPublishedAppIntegrationOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -56,10 +71,14 @@ class PublishedAppIntegrationImpl implements PublishedAppIntegrationService {
         String.format(
             "/api/2.0/accounts/%s/oauth2/published-app-integrations",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetPublishedAppIntegrationsOutput.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetPublishedAppIntegrationsOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -68,9 +87,14 @@ class PublishedAppIntegrationImpl implements PublishedAppIntegrationService {
         String.format(
             "/api/2.0/accounts/%s/oauth2/published-app-integrations/%s",
             apiClient.configuredAccountID(), request.getIntegrationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdatePublishedAppIntegrationOutput.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdatePublishedAppIntegrationOutput.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/ServicePrincipalFederationPolicyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/ServicePrincipalFederationPolicyImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ServicePrincipalFederationPolicy */
 @Generated
@@ -21,10 +22,15 @@ class ServicePrincipalFederationPolicyImpl implements ServicePrincipalFederation
         String.format(
             "/api/2.0/accounts/%s/servicePrincipals/%s/federationPolicies",
             apiClient.configuredAccountID(), request.getServicePrincipalId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request.getPolicy(), FederationPolicy.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request.getPolicy()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, FederationPolicy.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -35,9 +41,14 @@ class ServicePrincipalFederationPolicyImpl implements ServicePrincipalFederation
             apiClient.configuredAccountID(),
             request.getServicePrincipalId(),
             request.getPolicyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -48,9 +59,14 @@ class ServicePrincipalFederationPolicyImpl implements ServicePrincipalFederation
             apiClient.configuredAccountID(),
             request.getServicePrincipalId(),
             request.getPolicyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, FederationPolicy.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, FederationPolicy.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -60,9 +76,14 @@ class ServicePrincipalFederationPolicyImpl implements ServicePrincipalFederation
         String.format(
             "/api/2.0/accounts/%s/servicePrincipals/%s/federationPolicies",
             apiClient.configuredAccountID(), request.getServicePrincipalId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListFederationPoliciesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListFederationPoliciesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -73,9 +94,14 @@ class ServicePrincipalFederationPolicyImpl implements ServicePrincipalFederation
             apiClient.configuredAccountID(),
             request.getServicePrincipalId(),
             request.getPolicyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request.getPolicy(), FederationPolicy.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request.getPolicy()));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, FederationPolicy.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/ServicePrincipalFederationPolicyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/ServicePrincipalFederationPolicyImpl.java
@@ -24,7 +24,7 @@ class ServicePrincipalFederationPolicyImpl implements ServicePrincipalFederation
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request.getPolicy(), FederationPolicy.class, headers);
+    return apiClient.execute("POST", path, request.getPolicy(), FederationPolicy.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class ServicePrincipalFederationPolicyImpl implements ServicePrincipalFederation
             request.getPolicyId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -50,7 +50,7 @@ class ServicePrincipalFederationPolicyImpl implements ServicePrincipalFederation
             request.getPolicyId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, FederationPolicy.class, headers);
+    return apiClient.execute("GET", path, request, FederationPolicy.class, headers);
   }
 
   @Override
@@ -62,7 +62,7 @@ class ServicePrincipalFederationPolicyImpl implements ServicePrincipalFederation
             apiClient.configuredAccountID(), request.getServicePrincipalId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListFederationPoliciesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListFederationPoliciesResponse.class, headers);
   }
 
   @Override
@@ -76,6 +76,6 @@ class ServicePrincipalFederationPolicyImpl implements ServicePrincipalFederation
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request.getPolicy(), FederationPolicy.class, headers);
+    return apiClient.execute("PATCH", path, request.getPolicy(), FederationPolicy.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/ServicePrincipalSecretsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/ServicePrincipalSecretsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.oauth2;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ServicePrincipalSecrets */
 @Generated
@@ -21,10 +22,14 @@ class ServicePrincipalSecretsImpl implements ServicePrincipalSecretsService {
         String.format(
             "/api/2.0/accounts/%s/servicePrincipals/%s/credentials/secrets",
             apiClient.configuredAccountID(), request.getServicePrincipalId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "POST", path, null, CreateServicePrincipalSecretResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, CreateServicePrincipalSecretResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -35,8 +40,13 @@ class ServicePrincipalSecretsImpl implements ServicePrincipalSecretsService {
             apiClient.configuredAccountID(),
             request.getServicePrincipalId(),
             request.getSecretId());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -45,9 +55,13 @@ class ServicePrincipalSecretsImpl implements ServicePrincipalSecretsService {
         String.format(
             "/api/2.0/accounts/%s/servicePrincipals/%s/credentials/secrets",
             apiClient.configuredAccountID(), request.getServicePrincipalId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, ListServicePrincipalSecretsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListServicePrincipalSecretsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/ServicePrincipalSecretsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/oauth2/ServicePrincipalSecretsImpl.java
@@ -23,7 +23,8 @@ class ServicePrincipalSecretsImpl implements ServicePrincipalSecretsService {
             apiClient.configuredAccountID(), request.getServicePrincipalId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.POST(path, null, CreateServicePrincipalSecretResponse.class, headers);
+    return apiClient.execute(
+        "POST", path, null, CreateServicePrincipalSecretResponse.class, headers);
   }
 
   @Override
@@ -35,7 +36,7 @@ class ServicePrincipalSecretsImpl implements ServicePrincipalSecretsService {
             request.getServicePrincipalId(),
             request.getSecretId());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -46,6 +47,7 @@ class ServicePrincipalSecretsImpl implements ServicePrincipalSecretsService {
             apiClient.configuredAccountID(), request.getServicePrincipalId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListServicePrincipalSecretsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, ListServicePrincipalSecretsResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.pipelines;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Pipelines */
 @Generated
@@ -18,26 +19,41 @@ class PipelinesImpl implements PipelinesService {
   @Override
   public CreatePipelineResponse create(CreatePipeline request) {
     String path = "/api/2.0/pipelines";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreatePipelineResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreatePipelineResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeletePipelineRequest request) {
     String path = String.format("/api/2.0/pipelines/%s", request.getPipelineId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeletePipelineResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeletePipelineResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetPipelineResponse get(GetPipelineRequest request) {
     String path = String.format("/api/2.0/pipelines/%s", request.getPipelineId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetPipelineResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetPipelineResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -46,18 +62,27 @@ class PipelinesImpl implements PipelinesService {
     String path =
         String.format(
             "/api/2.0/permissions/pipelines/%s/permissionLevels", request.getPipelineId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetPipelinePermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetPipelinePermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public PipelinePermissions getPermissions(GetPipelinePermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/pipelines/%s", request.getPipelineId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, PipelinePermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, PipelinePermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -65,76 +90,121 @@ class PipelinesImpl implements PipelinesService {
     String path =
         String.format(
             "/api/2.0/pipelines/%s/updates/%s", request.getPipelineId(), request.getUpdateId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetUpdateResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetUpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListPipelineEventsResponse listPipelineEvents(ListPipelineEventsRequest request) {
     String path = String.format("/api/2.0/pipelines/%s/events", request.getPipelineId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListPipelineEventsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListPipelineEventsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListPipelinesResponse listPipelines(ListPipelinesRequest request) {
     String path = "/api/2.0/pipelines";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListPipelinesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListPipelinesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListUpdatesResponse listUpdates(ListUpdatesRequest request) {
     String path = String.format("/api/2.0/pipelines/%s/updates", request.getPipelineId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListUpdatesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListUpdatesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public PipelinePermissions setPermissions(PipelinePermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/pipelines/%s", request.getPipelineId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, PipelinePermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, PipelinePermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public StartUpdateResponse startUpdate(StartUpdate request) {
     String path = String.format("/api/2.0/pipelines/%s/updates", request.getPipelineId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, StartUpdateResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, StartUpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void stop(StopRequest request) {
     String path = String.format("/api/2.0/pipelines/%s/stop", request.getPipelineId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("POST", path, null, StopPipelineResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, StopPipelineResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(EditPipeline request) {
     String path = String.format("/api/2.0/pipelines/%s", request.getPipelineId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, EditPipelineResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, EditPipelineResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public PipelinePermissions updatePermissions(PipelinePermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/pipelines/%s", request.getPipelineId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, PipelinePermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, PipelinePermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/pipelines/PipelinesImpl.java
@@ -21,7 +21,7 @@ class PipelinesImpl implements PipelinesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreatePipelineResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreatePipelineResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class PipelinesImpl implements PipelinesService {
     String path = String.format("/api/2.0/pipelines/%s", request.getPipelineId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeletePipelineResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeletePipelineResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class PipelinesImpl implements PipelinesService {
     String path = String.format("/api/2.0/pipelines/%s", request.getPipelineId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetPipelineResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetPipelineResponse.class, headers);
   }
 
   @Override
@@ -48,7 +48,8 @@ class PipelinesImpl implements PipelinesService {
             "/api/2.0/permissions/pipelines/%s/permissionLevels", request.getPipelineId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetPipelinePermissionLevelsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetPipelinePermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -56,7 +57,7 @@ class PipelinesImpl implements PipelinesService {
     String path = String.format("/api/2.0/permissions/pipelines/%s", request.getPipelineId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, PipelinePermissions.class, headers);
+    return apiClient.execute("GET", path, request, PipelinePermissions.class, headers);
   }
 
   @Override
@@ -66,7 +67,7 @@ class PipelinesImpl implements PipelinesService {
             "/api/2.0/pipelines/%s/updates/%s", request.getPipelineId(), request.getUpdateId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetUpdateResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetUpdateResponse.class, headers);
   }
 
   @Override
@@ -74,7 +75,7 @@ class PipelinesImpl implements PipelinesService {
     String path = String.format("/api/2.0/pipelines/%s/events", request.getPipelineId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListPipelineEventsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListPipelineEventsResponse.class, headers);
   }
 
   @Override
@@ -82,7 +83,7 @@ class PipelinesImpl implements PipelinesService {
     String path = "/api/2.0/pipelines";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListPipelinesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListPipelinesResponse.class, headers);
   }
 
   @Override
@@ -90,7 +91,7 @@ class PipelinesImpl implements PipelinesService {
     String path = String.format("/api/2.0/pipelines/%s/updates", request.getPipelineId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListUpdatesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListUpdatesResponse.class, headers);
   }
 
   @Override
@@ -99,7 +100,7 @@ class PipelinesImpl implements PipelinesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, PipelinePermissions.class, headers);
+    return apiClient.execute("PUT", path, request, PipelinePermissions.class, headers);
   }
 
   @Override
@@ -108,7 +109,7 @@ class PipelinesImpl implements PipelinesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, StartUpdateResponse.class, headers);
+    return apiClient.execute("POST", path, request, StartUpdateResponse.class, headers);
   }
 
   @Override
@@ -116,7 +117,7 @@ class PipelinesImpl implements PipelinesService {
     String path = String.format("/api/2.0/pipelines/%s/stop", request.getPipelineId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.POST(path, null, StopPipelineResponse.class, headers);
+    apiClient.execute("POST", path, null, StopPipelineResponse.class, headers);
   }
 
   @Override
@@ -125,7 +126,7 @@ class PipelinesImpl implements PipelinesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, EditPipelineResponse.class, headers);
+    apiClient.execute("PUT", path, request, EditPipelineResponse.class, headers);
   }
 
   @Override
@@ -134,6 +135,6 @@ class PipelinesImpl implements PipelinesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, PipelinePermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, PipelinePermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/CredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/CredentialsImpl.java
@@ -2,7 +2,10 @@
 package com.databricks.sdk.service.provisioning;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,10 +23,15 @@ class CredentialsImpl implements CredentialsService {
   public Credential create(CreateCredentialRequest request) {
     String path =
         String.format("/api/2.0/accounts/%s/credentials", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Credential.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Credential.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -32,9 +40,14 @@ class CredentialsImpl implements CredentialsService {
         String.format(
             "/api/2.0/accounts/%s/credentials/%s",
             apiClient.configuredAccountID(), request.getCredentialsId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -43,9 +56,14 @@ class CredentialsImpl implements CredentialsService {
         String.format(
             "/api/2.0/accounts/%s/credentials/%s",
             apiClient.configuredAccountID(), request.getCredentialsId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Credential.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Credential.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/CredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/CredentialsImpl.java
@@ -23,7 +23,7 @@ class CredentialsImpl implements CredentialsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Credential.class, headers);
+    return apiClient.execute("POST", path, request, Credential.class, headers);
   }
 
   @Override
@@ -34,7 +34,7 @@ class CredentialsImpl implements CredentialsService {
             apiClient.configuredAccountID(), request.getCredentialsId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class CredentialsImpl implements CredentialsService {
             apiClient.configuredAccountID(), request.getCredentialsId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Credential.class, headers);
+    return apiClient.execute("GET", path, request, Credential.class, headers);
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/EncryptionKeysImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/EncryptionKeysImpl.java
@@ -2,7 +2,10 @@
 package com.databricks.sdk.service.provisioning;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,10 +24,15 @@ class EncryptionKeysImpl implements EncryptionKeysService {
     String path =
         String.format(
             "/api/2.0/accounts/%s/customer-managed-keys", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CustomerManagedKey.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CustomerManagedKey.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -33,9 +41,14 @@ class EncryptionKeysImpl implements EncryptionKeysService {
         String.format(
             "/api/2.0/accounts/%s/customer-managed-keys/%s",
             apiClient.configuredAccountID(), request.getCustomerManagedKeyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -44,9 +57,14 @@ class EncryptionKeysImpl implements EncryptionKeysService {
         String.format(
             "/api/2.0/accounts/%s/customer-managed-keys/%s",
             apiClient.configuredAccountID(), request.getCustomerManagedKeyId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, CustomerManagedKey.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, CustomerManagedKey.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/EncryptionKeysImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/EncryptionKeysImpl.java
@@ -24,7 +24,7 @@ class EncryptionKeysImpl implements EncryptionKeysService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CustomerManagedKey.class, headers);
+    return apiClient.execute("POST", path, request, CustomerManagedKey.class, headers);
   }
 
   @Override
@@ -35,7 +35,7 @@ class EncryptionKeysImpl implements EncryptionKeysService {
             apiClient.configuredAccountID(), request.getCustomerManagedKeyId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -46,7 +46,7 @@ class EncryptionKeysImpl implements EncryptionKeysService {
             apiClient.configuredAccountID(), request.getCustomerManagedKeyId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, CustomerManagedKey.class, headers);
+    return apiClient.execute("GET", path, request, CustomerManagedKey.class, headers);
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/NetworksImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/NetworksImpl.java
@@ -2,7 +2,10 @@
 package com.databricks.sdk.service.provisioning;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,10 +22,15 @@ class NetworksImpl implements NetworksService {
   @Override
   public Network create(CreateNetworkRequest request) {
     String path = String.format("/api/2.0/accounts/%s/networks", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Network.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Network.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,9 +39,14 @@ class NetworksImpl implements NetworksService {
         String.format(
             "/api/2.0/accounts/%s/networks/%s",
             apiClient.configuredAccountID(), request.getNetworkId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -42,9 +55,14 @@ class NetworksImpl implements NetworksService {
         String.format(
             "/api/2.0/accounts/%s/networks/%s",
             apiClient.configuredAccountID(), request.getNetworkId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Network.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Network.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/NetworksImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/NetworksImpl.java
@@ -22,7 +22,7 @@ class NetworksImpl implements NetworksService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Network.class, headers);
+    return apiClient.execute("POST", path, request, Network.class, headers);
   }
 
   @Override
@@ -33,7 +33,7 @@ class NetworksImpl implements NetworksService {
             apiClient.configuredAccountID(), request.getNetworkId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -44,7 +44,7 @@ class NetworksImpl implements NetworksService {
             apiClient.configuredAccountID(), request.getNetworkId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Network.class, headers);
+    return apiClient.execute("GET", path, request, Network.class, headers);
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/PrivateAccessImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/PrivateAccessImpl.java
@@ -24,7 +24,7 @@ class PrivateAccessImpl implements PrivateAccessService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, PrivateAccessSettings.class, headers);
+    return apiClient.execute("POST", path, request, PrivateAccessSettings.class, headers);
   }
 
   @Override
@@ -35,7 +35,7 @@ class PrivateAccessImpl implements PrivateAccessService {
             apiClient.configuredAccountID(), request.getPrivateAccessSettingsId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -46,7 +46,7 @@ class PrivateAccessImpl implements PrivateAccessService {
             apiClient.configuredAccountID(), request.getPrivateAccessSettingsId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, PrivateAccessSettings.class, headers);
+    return apiClient.execute("GET", path, request, PrivateAccessSettings.class, headers);
   }
 
   @Override
@@ -68,6 +68,6 @@ class PrivateAccessImpl implements PrivateAccessService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, ReplaceResponse.class, headers);
+    apiClient.execute("PUT", path, request, ReplaceResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/PrivateAccessImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/PrivateAccessImpl.java
@@ -2,7 +2,10 @@
 package com.databricks.sdk.service.provisioning;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,10 +24,15 @@ class PrivateAccessImpl implements PrivateAccessService {
     String path =
         String.format(
             "/api/2.0/accounts/%s/private-access-settings", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, PrivateAccessSettings.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, PrivateAccessSettings.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -33,9 +41,14 @@ class PrivateAccessImpl implements PrivateAccessService {
         String.format(
             "/api/2.0/accounts/%s/private-access-settings/%s",
             apiClient.configuredAccountID(), request.getPrivateAccessSettingsId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -44,9 +57,14 @@ class PrivateAccessImpl implements PrivateAccessService {
         String.format(
             "/api/2.0/accounts/%s/private-access-settings/%s",
             apiClient.configuredAccountID(), request.getPrivateAccessSettingsId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, PrivateAccessSettings.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, PrivateAccessSettings.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -65,9 +83,14 @@ class PrivateAccessImpl implements PrivateAccessService {
         String.format(
             "/api/2.0/accounts/%s/private-access-settings/%s",
             apiClient.configuredAccountID(), request.getPrivateAccessSettingsId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, ReplaceResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, ReplaceResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/StorageImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/StorageImpl.java
@@ -2,7 +2,10 @@
 package com.databricks.sdk.service.provisioning;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,10 +24,15 @@ class StorageImpl implements StorageService {
     String path =
         String.format(
             "/api/2.0/accounts/%s/storage-configurations", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, StorageConfiguration.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, StorageConfiguration.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -33,9 +41,14 @@ class StorageImpl implements StorageService {
         String.format(
             "/api/2.0/accounts/%s/storage-configurations/%s",
             apiClient.configuredAccountID(), request.getStorageConfigurationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -44,9 +57,14 @@ class StorageImpl implements StorageService {
         String.format(
             "/api/2.0/accounts/%s/storage-configurations/%s",
             apiClient.configuredAccountID(), request.getStorageConfigurationId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, StorageConfiguration.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, StorageConfiguration.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/StorageImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/StorageImpl.java
@@ -24,7 +24,7 @@ class StorageImpl implements StorageService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, StorageConfiguration.class, headers);
+    return apiClient.execute("POST", path, request, StorageConfiguration.class, headers);
   }
 
   @Override
@@ -35,7 +35,7 @@ class StorageImpl implements StorageService {
             apiClient.configuredAccountID(), request.getStorageConfigurationId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -46,7 +46,7 @@ class StorageImpl implements StorageService {
             apiClient.configuredAccountID(), request.getStorageConfigurationId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, StorageConfiguration.class, headers);
+    return apiClient.execute("GET", path, request, StorageConfiguration.class, headers);
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/VpcEndpointsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/VpcEndpointsImpl.java
@@ -23,7 +23,7 @@ class VpcEndpointsImpl implements VpcEndpointsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, VpcEndpoint.class, headers);
+    return apiClient.execute("POST", path, request, VpcEndpoint.class, headers);
   }
 
   @Override
@@ -34,7 +34,7 @@ class VpcEndpointsImpl implements VpcEndpointsService {
             apiClient.configuredAccountID(), request.getVpcEndpointId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class VpcEndpointsImpl implements VpcEndpointsService {
             apiClient.configuredAccountID(), request.getVpcEndpointId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, VpcEndpoint.class, headers);
+    return apiClient.execute("GET", path, request, VpcEndpoint.class, headers);
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/VpcEndpointsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/VpcEndpointsImpl.java
@@ -2,7 +2,10 @@
 package com.databricks.sdk.service.provisioning;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,10 +23,15 @@ class VpcEndpointsImpl implements VpcEndpointsService {
   public VpcEndpoint create(CreateVpcEndpointRequest request) {
     String path =
         String.format("/api/2.0/accounts/%s/vpc-endpoints", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, VpcEndpoint.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, VpcEndpoint.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -32,9 +40,14 @@ class VpcEndpointsImpl implements VpcEndpointsService {
         String.format(
             "/api/2.0/accounts/%s/vpc-endpoints/%s",
             apiClient.configuredAccountID(), request.getVpcEndpointId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -43,9 +56,14 @@ class VpcEndpointsImpl implements VpcEndpointsService {
         String.format(
             "/api/2.0/accounts/%s/vpc-endpoints/%s",
             apiClient.configuredAccountID(), request.getVpcEndpointId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, VpcEndpoint.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, VpcEndpoint.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/WorkspacesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/WorkspacesImpl.java
@@ -2,7 +2,10 @@
 package com.databricks.sdk.service.provisioning;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,10 +22,15 @@ class WorkspacesImpl implements WorkspacesService {
   @Override
   public Workspace create(CreateWorkspaceRequest request) {
     String path = String.format("/api/2.0/accounts/%s/workspaces", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Workspace.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Workspace.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,9 +39,14 @@ class WorkspacesImpl implements WorkspacesService {
         String.format(
             "/api/2.0/accounts/%s/workspaces/%s",
             apiClient.configuredAccountID(), request.getWorkspaceId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -42,9 +55,14 @@ class WorkspacesImpl implements WorkspacesService {
         String.format(
             "/api/2.0/accounts/%s/workspaces/%s",
             apiClient.configuredAccountID(), request.getWorkspaceId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Workspace.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Workspace.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -61,9 +79,14 @@ class WorkspacesImpl implements WorkspacesService {
         String.format(
             "/api/2.0/accounts/%s/workspaces/%s",
             apiClient.configuredAccountID(), request.getWorkspaceId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/WorkspacesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/provisioning/WorkspacesImpl.java
@@ -22,7 +22,7 @@ class WorkspacesImpl implements WorkspacesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Workspace.class, headers);
+    return apiClient.execute("POST", path, request, Workspace.class, headers);
   }
 
   @Override
@@ -33,7 +33,7 @@ class WorkspacesImpl implements WorkspacesService {
             apiClient.configuredAccountID(), request.getWorkspaceId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -44,7 +44,7 @@ class WorkspacesImpl implements WorkspacesService {
             apiClient.configuredAccountID(), request.getWorkspaceId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Workspace.class, headers);
+    return apiClient.execute("GET", path, request, Workspace.class, headers);
   }
 
   @Override
@@ -64,6 +64,6 @@ class WorkspacesImpl implements WorkspacesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsDataPlaneImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsDataPlaneImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.serving;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ServingEndpointsDataPlane */
 @Generated
@@ -18,9 +19,14 @@ class ServingEndpointsDataPlaneImpl implements ServingEndpointsDataPlaneService 
   @Override
   public QueryEndpointResponse query(QueryEndpointInput request) {
     String path = String.format("/serving-endpoints/%s/invocations", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, QueryEndpointResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, QueryEndpointResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsDataPlaneImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsDataPlaneImpl.java
@@ -21,6 +21,6 @@ class ServingEndpointsDataPlaneImpl implements ServingEndpointsDataPlaneService 
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, QueryEndpointResponse.class, headers);
+    return apiClient.execute("POST", path, request, QueryEndpointResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsImpl.java
@@ -24,7 +24,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
             request.getName(), request.getServedModelName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, BuildLogsResponse.class, headers);
+    return apiClient.execute("GET", path, request, BuildLogsResponse.class, headers);
   }
 
   @Override
@@ -33,7 +33,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ServingEndpointDetailed.class, headers);
+    return apiClient.execute("POST", path, request, ServingEndpointDetailed.class, headers);
   }
 
   @Override
@@ -41,7 +41,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     String path = String.format("/api/2.0/serving-endpoints/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -49,7 +49,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     String path = String.format("/api/2.0/serving-endpoints/%s/metrics", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "text/plain");
-    return apiClient.GET(path, request, ExportMetricsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ExportMetricsResponse.class, headers);
   }
 
   @Override
@@ -57,7 +57,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     String path = String.format("/api/2.0/serving-endpoints/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ServingEndpointDetailed.class, headers);
+    return apiClient.execute("GET", path, request, ServingEndpointDetailed.class, headers);
   }
 
   @Override
@@ -65,7 +65,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     String path = String.format("/api/2.0/serving-endpoints/%s/openapi", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.GET(path, request, GetOpenApiResponse.class, headers);
+    apiClient.execute("GET", path, request, GetOpenApiResponse.class, headers);
   }
 
   @Override
@@ -77,7 +77,8 @@ class ServingEndpointsImpl implements ServingEndpointsService {
             request.getServingEndpointId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetServingEndpointPermissionLevelsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetServingEndpointPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -86,7 +87,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
         String.format("/api/2.0/permissions/serving-endpoints/%s", request.getServingEndpointId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ServingEndpointPermissions.class, headers);
+    return apiClient.execute("GET", path, request, ServingEndpointPermissions.class, headers);
   }
 
   @Override
@@ -94,7 +95,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     String path = "/api/2.0/serving-endpoints";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListEndpointsResponse.class, headers);
+    return apiClient.execute("GET", path, null, ListEndpointsResponse.class, headers);
   }
 
   @Override
@@ -105,7 +106,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
             request.getName(), request.getServedModelName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ServerLogsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ServerLogsResponse.class, headers);
   }
 
   @Override
@@ -123,7 +124,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, PutResponse.class, headers);
+    return apiClient.execute("PUT", path, request, PutResponse.class, headers);
   }
 
   @Override
@@ -132,7 +133,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, PutAiGatewayResponse.class, headers);
+    return apiClient.execute("PUT", path, request, PutAiGatewayResponse.class, headers);
   }
 
   @Override
@@ -141,7 +142,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, QueryEndpointResponse.class, headers);
+    return apiClient.execute("POST", path, request, QueryEndpointResponse.class, headers);
   }
 
   @Override
@@ -151,7 +152,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, ServingEndpointPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, ServingEndpointPermissions.class, headers);
   }
 
   @Override
@@ -160,7 +161,7 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, ServingEndpointDetailed.class, headers);
+    return apiClient.execute("PUT", path, request, ServingEndpointDetailed.class, headers);
   }
 
   @Override
@@ -170,6 +171,6 @@ class ServingEndpointsImpl implements ServingEndpointsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, ServingEndpointPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, ServingEndpointPermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/serving/ServingEndpointsImpl.java
@@ -2,7 +2,10 @@
 package com.databricks.sdk.service.serving;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,50 +25,80 @@ class ServingEndpointsImpl implements ServingEndpointsService {
         String.format(
             "/api/2.0/serving-endpoints/%s/served-models/%s/build-logs",
             request.getName(), request.getServedModelName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, BuildLogsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, BuildLogsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ServingEndpointDetailed create(CreateServingEndpoint request) {
     String path = "/api/2.0/serving-endpoints";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, ServingEndpointDetailed.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ServingEndpointDetailed.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteServingEndpointRequest request) {
     String path = String.format("/api/2.0/serving-endpoints/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ExportMetricsResponse exportMetrics(ExportMetricsRequest request) {
     String path = String.format("/api/2.0/serving-endpoints/%s/metrics", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "text/plain");
-    return apiClient.execute("GET", path, request, ExportMetricsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "text/plain");
+      return apiClient.execute(req, ExportMetricsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ServingEndpointDetailed get(GetServingEndpointRequest request) {
     String path = String.format("/api/2.0/serving-endpoints/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ServingEndpointDetailed.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ServingEndpointDetailed.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void getOpenApi(GetOpenApiRequest request) {
     String path = String.format("/api/2.0/serving-endpoints/%s/openapi", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("GET", path, request, GetOpenApiResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, GetOpenApiResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -75,27 +108,41 @@ class ServingEndpointsImpl implements ServingEndpointsService {
         String.format(
             "/api/2.0/permissions/serving-endpoints/%s/permissionLevels",
             request.getServingEndpointId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetServingEndpointPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetServingEndpointPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ServingEndpointPermissions getPermissions(GetServingEndpointPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/serving-endpoints/%s", request.getServingEndpointId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ServingEndpointPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ServingEndpointPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListEndpointsResponse list() {
     String path = "/api/2.0/serving-endpoints";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListEndpointsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListEndpointsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -104,9 +151,14 @@ class ServingEndpointsImpl implements ServingEndpointsService {
         String.format(
             "/api/2.0/serving-endpoints/%s/served-models/%s/logs",
             request.getName(), request.getServedModelName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ServerLogsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ServerLogsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -121,56 +173,86 @@ class ServingEndpointsImpl implements ServingEndpointsService {
   @Override
   public PutResponse put(PutRequest request) {
     String path = String.format("/api/2.0/serving-endpoints/%s/rate-limits", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, PutResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, PutResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public PutAiGatewayResponse putAiGateway(PutAiGatewayRequest request) {
     String path = String.format("/api/2.0/serving-endpoints/%s/ai-gateway", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, PutAiGatewayResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, PutAiGatewayResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public QueryEndpointResponse query(QueryEndpointInput request) {
     String path = String.format("/serving-endpoints/%s/invocations", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, QueryEndpointResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, QueryEndpointResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ServingEndpointPermissions setPermissions(ServingEndpointPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/serving-endpoints/%s", request.getServingEndpointId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, ServingEndpointPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ServingEndpointPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ServingEndpointDetailed updateConfig(EndpointCoreConfigInput request) {
     String path = String.format("/api/2.0/serving-endpoints/%s/config", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, ServingEndpointDetailed.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ServingEndpointDetailed.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ServingEndpointPermissions updatePermissions(ServingEndpointPermissionsRequest request) {
     String path =
         String.format("/api/2.0/permissions/serving-endpoints/%s", request.getServingEndpointId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, ServingEndpointPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ServingEndpointPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AccountIpAccessListsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AccountIpAccessListsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AccountIpAccessLists */
 @Generated
@@ -19,10 +20,15 @@ class AccountIpAccessListsImpl implements AccountIpAccessListsService {
   public CreateIpAccessListResponse create(CreateIpAccessList request) {
     String path =
         String.format("/api/2.0/accounts/%s/ip-access-lists", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateIpAccessListResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateIpAccessListResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,9 +37,14 @@ class AccountIpAccessListsImpl implements AccountIpAccessListsService {
         String.format(
             "/api/2.0/accounts/%s/ip-access-lists/%s",
             apiClient.configuredAccountID(), request.getIpAccessListId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -42,18 +53,28 @@ class AccountIpAccessListsImpl implements AccountIpAccessListsService {
         String.format(
             "/api/2.0/accounts/%s/ip-access-lists/%s",
             apiClient.configuredAccountID(), request.getIpAccessListId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetIpAccessListResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetIpAccessListResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetIpAccessListsResponse list() {
     String path =
         String.format("/api/2.0/accounts/%s/ip-access-lists", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, GetIpAccessListsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetIpAccessListsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -62,10 +83,15 @@ class AccountIpAccessListsImpl implements AccountIpAccessListsService {
         String.format(
             "/api/2.0/accounts/%s/ip-access-lists/%s",
             apiClient.configuredAccountID(), request.getIpAccessListId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, ReplaceResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, ReplaceResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -74,9 +100,14 @@ class AccountIpAccessListsImpl implements AccountIpAccessListsService {
         String.format(
             "/api/2.0/accounts/%s/ip-access-lists/%s",
             apiClient.configuredAccountID(), request.getIpAccessListId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AccountIpAccessListsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AccountIpAccessListsImpl.java
@@ -22,7 +22,7 @@ class AccountIpAccessListsImpl implements AccountIpAccessListsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateIpAccessListResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateIpAccessListResponse.class, headers);
   }
 
   @Override
@@ -33,7 +33,7 @@ class AccountIpAccessListsImpl implements AccountIpAccessListsService {
             apiClient.configuredAccountID(), request.getIpAccessListId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -44,7 +44,7 @@ class AccountIpAccessListsImpl implements AccountIpAccessListsService {
             apiClient.configuredAccountID(), request.getIpAccessListId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetIpAccessListResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetIpAccessListResponse.class, headers);
   }
 
   @Override
@@ -53,7 +53,7 @@ class AccountIpAccessListsImpl implements AccountIpAccessListsService {
         String.format("/api/2.0/accounts/%s/ip-access-lists", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, GetIpAccessListsResponse.class, headers);
+    return apiClient.execute("GET", path, null, GetIpAccessListsResponse.class, headers);
   }
 
   @Override
@@ -65,7 +65,7 @@ class AccountIpAccessListsImpl implements AccountIpAccessListsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, ReplaceResponse.class, headers);
+    apiClient.execute("PUT", path, request, ReplaceResponse.class, headers);
   }
 
   @Override
@@ -77,6 +77,6 @@ class AccountIpAccessListsImpl implements AccountIpAccessListsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AibiDashboardEmbeddingAccessPolicyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AibiDashboardEmbeddingAccessPolicyImpl.java
@@ -21,8 +21,12 @@ class AibiDashboardEmbeddingAccessPolicyImpl implements AibiDashboardEmbeddingAc
     String path = "/api/2.0/settings/types/aibi_dash_embed_ws_acc_policy/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.DELETE(
-        path, request, DeleteAibiDashboardEmbeddingAccessPolicySettingResponse.class, headers);
+    return apiClient.execute(
+        "DELETE",
+        path,
+        request,
+        DeleteAibiDashboardEmbeddingAccessPolicySettingResponse.class,
+        headers);
   }
 
   @Override
@@ -31,7 +35,8 @@ class AibiDashboardEmbeddingAccessPolicyImpl implements AibiDashboardEmbeddingAc
     String path = "/api/2.0/settings/types/aibi_dash_embed_ws_acc_policy/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, AibiDashboardEmbeddingAccessPolicySetting.class, headers);
+    return apiClient.execute(
+        "GET", path, request, AibiDashboardEmbeddingAccessPolicySetting.class, headers);
   }
 
   @Override
@@ -41,6 +46,7 @@ class AibiDashboardEmbeddingAccessPolicyImpl implements AibiDashboardEmbeddingAc
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, AibiDashboardEmbeddingAccessPolicySetting.class, headers);
+    return apiClient.execute(
+        "PATCH", path, request, AibiDashboardEmbeddingAccessPolicySetting.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AibiDashboardEmbeddingAccessPolicyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AibiDashboardEmbeddingAccessPolicyImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AibiDashboardEmbeddingAccessPolicy */
 @Generated
@@ -19,34 +20,42 @@ class AibiDashboardEmbeddingAccessPolicyImpl implements AibiDashboardEmbeddingAc
   public DeleteAibiDashboardEmbeddingAccessPolicySettingResponse delete(
       DeleteAibiDashboardEmbeddingAccessPolicySettingRequest request) {
     String path = "/api/2.0/settings/types/aibi_dash_embed_ws_acc_policy/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "DELETE",
-        path,
-        request,
-        DeleteAibiDashboardEmbeddingAccessPolicySettingResponse.class,
-        headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, DeleteAibiDashboardEmbeddingAccessPolicySettingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public AibiDashboardEmbeddingAccessPolicySetting get(
       GetAibiDashboardEmbeddingAccessPolicySettingRequest request) {
     String path = "/api/2.0/settings/types/aibi_dash_embed_ws_acc_policy/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, AibiDashboardEmbeddingAccessPolicySetting.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, AibiDashboardEmbeddingAccessPolicySetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public AibiDashboardEmbeddingAccessPolicySetting update(
       UpdateAibiDashboardEmbeddingAccessPolicySettingRequest request) {
     String path = "/api/2.0/settings/types/aibi_dash_embed_ws_acc_policy/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "PATCH", path, request, AibiDashboardEmbeddingAccessPolicySetting.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, AibiDashboardEmbeddingAccessPolicySetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AibiDashboardEmbeddingApprovedDomainsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AibiDashboardEmbeddingApprovedDomainsImpl.java
@@ -22,8 +22,12 @@ class AibiDashboardEmbeddingApprovedDomainsImpl
     String path = "/api/2.0/settings/types/aibi_dash_embed_ws_apprvd_domains/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.DELETE(
-        path, request, DeleteAibiDashboardEmbeddingApprovedDomainsSettingResponse.class, headers);
+    return apiClient.execute(
+        "DELETE",
+        path,
+        request,
+        DeleteAibiDashboardEmbeddingApprovedDomainsSettingResponse.class,
+        headers);
   }
 
   @Override
@@ -32,8 +36,8 @@ class AibiDashboardEmbeddingApprovedDomainsImpl
     String path = "/api/2.0/settings/types/aibi_dash_embed_ws_apprvd_domains/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(
-        path, request, AibiDashboardEmbeddingApprovedDomainsSetting.class, headers);
+    return apiClient.execute(
+        "GET", path, request, AibiDashboardEmbeddingApprovedDomainsSetting.class, headers);
   }
 
   @Override
@@ -43,7 +47,7 @@ class AibiDashboardEmbeddingApprovedDomainsImpl
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(
-        path, request, AibiDashboardEmbeddingApprovedDomainsSetting.class, headers);
+    return apiClient.execute(
+        "PATCH", path, request, AibiDashboardEmbeddingApprovedDomainsSetting.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AibiDashboardEmbeddingApprovedDomainsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AibiDashboardEmbeddingApprovedDomainsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AibiDashboardEmbeddingApprovedDomains */
 @Generated
@@ -20,34 +21,43 @@ class AibiDashboardEmbeddingApprovedDomainsImpl
   public DeleteAibiDashboardEmbeddingApprovedDomainsSettingResponse delete(
       DeleteAibiDashboardEmbeddingApprovedDomainsSettingRequest request) {
     String path = "/api/2.0/settings/types/aibi_dash_embed_ws_apprvd_domains/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "DELETE",
-        path,
-        request,
-        DeleteAibiDashboardEmbeddingApprovedDomainsSettingResponse.class,
-        headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(
+          req, DeleteAibiDashboardEmbeddingApprovedDomainsSettingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public AibiDashboardEmbeddingApprovedDomainsSetting get(
       GetAibiDashboardEmbeddingApprovedDomainsSettingRequest request) {
     String path = "/api/2.0/settings/types/aibi_dash_embed_ws_apprvd_domains/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, AibiDashboardEmbeddingApprovedDomainsSetting.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, AibiDashboardEmbeddingApprovedDomainsSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public AibiDashboardEmbeddingApprovedDomainsSetting update(
       UpdateAibiDashboardEmbeddingApprovedDomainsSettingRequest request) {
     String path = "/api/2.0/settings/types/aibi_dash_embed_ws_apprvd_domains/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "PATCH", path, request, AibiDashboardEmbeddingApprovedDomainsSetting.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, AibiDashboardEmbeddingApprovedDomainsSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AutomaticClusterUpdateImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AutomaticClusterUpdateImpl.java
@@ -20,7 +20,7 @@ class AutomaticClusterUpdateImpl implements AutomaticClusterUpdateService {
     String path = "/api/2.0/settings/types/automatic_cluster_update/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, AutomaticClusterUpdateSetting.class, headers);
+    return apiClient.execute("GET", path, request, AutomaticClusterUpdateSetting.class, headers);
   }
 
   @Override
@@ -29,6 +29,6 @@ class AutomaticClusterUpdateImpl implements AutomaticClusterUpdateService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, AutomaticClusterUpdateSetting.class, headers);
+    return apiClient.execute("PATCH", path, request, AutomaticClusterUpdateSetting.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AutomaticClusterUpdateImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/AutomaticClusterUpdateImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of AutomaticClusterUpdate */
 @Generated
@@ -18,17 +19,27 @@ class AutomaticClusterUpdateImpl implements AutomaticClusterUpdateService {
   @Override
   public AutomaticClusterUpdateSetting get(GetAutomaticClusterUpdateSettingRequest request) {
     String path = "/api/2.0/settings/types/automatic_cluster_update/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, AutomaticClusterUpdateSetting.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, AutomaticClusterUpdateSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public AutomaticClusterUpdateSetting update(UpdateAutomaticClusterUpdateSettingRequest request) {
     String path = "/api/2.0/settings/types/automatic_cluster_update/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, AutomaticClusterUpdateSetting.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, AutomaticClusterUpdateSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/ComplianceSecurityProfileImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/ComplianceSecurityProfileImpl.java
@@ -20,7 +20,7 @@ class ComplianceSecurityProfileImpl implements ComplianceSecurityProfileService 
     String path = "/api/2.0/settings/types/shield_csp_enablement_ws_db/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ComplianceSecurityProfileSetting.class, headers);
+    return apiClient.execute("GET", path, request, ComplianceSecurityProfileSetting.class, headers);
   }
 
   @Override
@@ -30,6 +30,7 @@ class ComplianceSecurityProfileImpl implements ComplianceSecurityProfileService 
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, ComplianceSecurityProfileSetting.class, headers);
+    return apiClient.execute(
+        "PATCH", path, request, ComplianceSecurityProfileSetting.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/ComplianceSecurityProfileImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/ComplianceSecurityProfileImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of ComplianceSecurityProfile */
 @Generated
@@ -18,19 +19,28 @@ class ComplianceSecurityProfileImpl implements ComplianceSecurityProfileService 
   @Override
   public ComplianceSecurityProfileSetting get(GetComplianceSecurityProfileSettingRequest request) {
     String path = "/api/2.0/settings/types/shield_csp_enablement_ws_db/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ComplianceSecurityProfileSetting.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ComplianceSecurityProfileSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ComplianceSecurityProfileSetting update(
       UpdateComplianceSecurityProfileSettingRequest request) {
     String path = "/api/2.0/settings/types/shield_csp_enablement_ws_db/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "PATCH", path, request, ComplianceSecurityProfileSetting.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ComplianceSecurityProfileSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/CredentialsManagerImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/CredentialsManagerImpl.java
@@ -21,6 +21,6 @@ class CredentialsManagerImpl implements CredentialsManagerService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ExchangeTokenResponse.class, headers);
+    return apiClient.execute("POST", path, request, ExchangeTokenResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/CredentialsManagerImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/CredentialsManagerImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of CredentialsManager */
 @Generated
@@ -18,9 +19,14 @@ class CredentialsManagerImpl implements CredentialsManagerService {
   @Override
   public ExchangeTokenResponse exchangeToken(ExchangeTokenRequest request) {
     String path = "/api/2.0/credentials-manager/exchange-tokens/token";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, ExchangeTokenResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ExchangeTokenResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/CspEnablementAccountImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/CspEnablementAccountImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of CspEnablementAccount */
 @Generated
@@ -21,9 +22,14 @@ class CspEnablementAccountImpl implements CspEnablementAccountService {
         String.format(
             "/api/2.0/accounts/%s/settings/types/shield_csp_enablement_ac/names/default",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, CspEnablementAccountSetting.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, CspEnablementAccountSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -32,9 +38,14 @@ class CspEnablementAccountImpl implements CspEnablementAccountService {
         String.format(
             "/api/2.0/accounts/%s/settings/types/shield_csp_enablement_ac/names/default",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, CspEnablementAccountSetting.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CspEnablementAccountSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/CspEnablementAccountImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/CspEnablementAccountImpl.java
@@ -23,7 +23,7 @@ class CspEnablementAccountImpl implements CspEnablementAccountService {
             apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, CspEnablementAccountSetting.class, headers);
+    return apiClient.execute("GET", path, request, CspEnablementAccountSetting.class, headers);
   }
 
   @Override
@@ -35,6 +35,6 @@ class CspEnablementAccountImpl implements CspEnablementAccountService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, CspEnablementAccountSetting.class, headers);
+    return apiClient.execute("PATCH", path, request, CspEnablementAccountSetting.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DefaultNamespaceImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DefaultNamespaceImpl.java
@@ -21,7 +21,8 @@ class DefaultNamespaceImpl implements DefaultNamespaceService {
     String path = "/api/2.0/settings/types/default_namespace_ws/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.DELETE(path, request, DeleteDefaultNamespaceSettingResponse.class, headers);
+    return apiClient.execute(
+        "DELETE", path, request, DeleteDefaultNamespaceSettingResponse.class, headers);
   }
 
   @Override
@@ -29,7 +30,7 @@ class DefaultNamespaceImpl implements DefaultNamespaceService {
     String path = "/api/2.0/settings/types/default_namespace_ws/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, DefaultNamespaceSetting.class, headers);
+    return apiClient.execute("GET", path, request, DefaultNamespaceSetting.class, headers);
   }
 
   @Override
@@ -38,6 +39,6 @@ class DefaultNamespaceImpl implements DefaultNamespaceService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, DefaultNamespaceSetting.class, headers);
+    return apiClient.execute("PATCH", path, request, DefaultNamespaceSetting.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DefaultNamespaceImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DefaultNamespaceImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of DefaultNamespace */
 @Generated
@@ -19,26 +20,40 @@ class DefaultNamespaceImpl implements DefaultNamespaceService {
   public DeleteDefaultNamespaceSettingResponse delete(
       DeleteDefaultNamespaceSettingRequest request) {
     String path = "/api/2.0/settings/types/default_namespace_ws/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "DELETE", path, request, DeleteDefaultNamespaceSettingResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, DeleteDefaultNamespaceSettingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public DefaultNamespaceSetting get(GetDefaultNamespaceSettingRequest request) {
     String path = "/api/2.0/settings/types/default_namespace_ws/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, DefaultNamespaceSetting.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, DefaultNamespaceSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public DefaultNamespaceSetting update(UpdateDefaultNamespaceSettingRequest request) {
     String path = "/api/2.0/settings/types/default_namespace_ws/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, DefaultNamespaceSetting.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, DefaultNamespaceSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyAccessImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyAccessImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of DisableLegacyAccess */
 @Generated
@@ -18,26 +19,40 @@ class DisableLegacyAccessImpl implements DisableLegacyAccessService {
   @Override
   public DeleteDisableLegacyAccessResponse delete(DeleteDisableLegacyAccessRequest request) {
     String path = "/api/2.0/settings/types/disable_legacy_access/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "DELETE", path, request, DeleteDisableLegacyAccessResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, DeleteDisableLegacyAccessResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public DisableLegacyAccess get(GetDisableLegacyAccessRequest request) {
     String path = "/api/2.0/settings/types/disable_legacy_access/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, DisableLegacyAccess.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, DisableLegacyAccess.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public DisableLegacyAccess update(UpdateDisableLegacyAccessRequest request) {
     String path = "/api/2.0/settings/types/disable_legacy_access/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, DisableLegacyAccess.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, DisableLegacyAccess.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyAccessImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyAccessImpl.java
@@ -20,7 +20,8 @@ class DisableLegacyAccessImpl implements DisableLegacyAccessService {
     String path = "/api/2.0/settings/types/disable_legacy_access/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.DELETE(path, request, DeleteDisableLegacyAccessResponse.class, headers);
+    return apiClient.execute(
+        "DELETE", path, request, DeleteDisableLegacyAccessResponse.class, headers);
   }
 
   @Override
@@ -28,7 +29,7 @@ class DisableLegacyAccessImpl implements DisableLegacyAccessService {
     String path = "/api/2.0/settings/types/disable_legacy_access/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, DisableLegacyAccess.class, headers);
+    return apiClient.execute("GET", path, request, DisableLegacyAccess.class, headers);
   }
 
   @Override
@@ -37,6 +38,6 @@ class DisableLegacyAccessImpl implements DisableLegacyAccessService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, DisableLegacyAccess.class, headers);
+    return apiClient.execute("PATCH", path, request, DisableLegacyAccess.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyDbfsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyDbfsImpl.java
@@ -20,7 +20,8 @@ class DisableLegacyDbfsImpl implements DisableLegacyDbfsService {
     String path = "/api/2.0/settings/types/disable_legacy_dbfs/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.DELETE(path, request, DeleteDisableLegacyDbfsResponse.class, headers);
+    return apiClient.execute(
+        "DELETE", path, request, DeleteDisableLegacyDbfsResponse.class, headers);
   }
 
   @Override
@@ -28,7 +29,7 @@ class DisableLegacyDbfsImpl implements DisableLegacyDbfsService {
     String path = "/api/2.0/settings/types/disable_legacy_dbfs/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, DisableLegacyDbfs.class, headers);
+    return apiClient.execute("GET", path, request, DisableLegacyDbfs.class, headers);
   }
 
   @Override
@@ -37,6 +38,6 @@ class DisableLegacyDbfsImpl implements DisableLegacyDbfsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, DisableLegacyDbfs.class, headers);
+    return apiClient.execute("PATCH", path, request, DisableLegacyDbfs.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyDbfsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyDbfsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of DisableLegacyDbfs */
 @Generated
@@ -18,26 +19,40 @@ class DisableLegacyDbfsImpl implements DisableLegacyDbfsService {
   @Override
   public DeleteDisableLegacyDbfsResponse delete(DeleteDisableLegacyDbfsRequest request) {
     String path = "/api/2.0/settings/types/disable_legacy_dbfs/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "DELETE", path, request, DeleteDisableLegacyDbfsResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, DeleteDisableLegacyDbfsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public DisableLegacyDbfs get(GetDisableLegacyDbfsRequest request) {
     String path = "/api/2.0/settings/types/disable_legacy_dbfs/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, DisableLegacyDbfs.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, DisableLegacyDbfs.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public DisableLegacyDbfs update(UpdateDisableLegacyDbfsRequest request) {
     String path = "/api/2.0/settings/types/disable_legacy_dbfs/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, DisableLegacyDbfs.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, DisableLegacyDbfs.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyFeaturesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyFeaturesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of DisableLegacyFeatures */
 @Generated
@@ -21,10 +22,14 @@ class DisableLegacyFeaturesImpl implements DisableLegacyFeaturesService {
         String.format(
             "/api/2.0/accounts/%s/settings/types/disable_legacy_features/names/default",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "DELETE", path, request, DeleteDisableLegacyFeaturesResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, DeleteDisableLegacyFeaturesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -33,9 +38,14 @@ class DisableLegacyFeaturesImpl implements DisableLegacyFeaturesService {
         String.format(
             "/api/2.0/accounts/%s/settings/types/disable_legacy_features/names/default",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, DisableLegacyFeatures.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, DisableLegacyFeatures.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -44,9 +54,14 @@ class DisableLegacyFeaturesImpl implements DisableLegacyFeaturesService {
         String.format(
             "/api/2.0/accounts/%s/settings/types/disable_legacy_features/names/default",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, DisableLegacyFeatures.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, DisableLegacyFeatures.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyFeaturesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/DisableLegacyFeaturesImpl.java
@@ -23,7 +23,8 @@ class DisableLegacyFeaturesImpl implements DisableLegacyFeaturesService {
             apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.DELETE(path, request, DeleteDisableLegacyFeaturesResponse.class, headers);
+    return apiClient.execute(
+        "DELETE", path, request, DeleteDisableLegacyFeaturesResponse.class, headers);
   }
 
   @Override
@@ -34,7 +35,7 @@ class DisableLegacyFeaturesImpl implements DisableLegacyFeaturesService {
             apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, DisableLegacyFeatures.class, headers);
+    return apiClient.execute("GET", path, request, DisableLegacyFeatures.class, headers);
   }
 
   @Override
@@ -46,6 +47,6 @@ class DisableLegacyFeaturesImpl implements DisableLegacyFeaturesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, DisableLegacyFeatures.class, headers);
+    return apiClient.execute("PATCH", path, request, DisableLegacyFeatures.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/EnhancedSecurityMonitoringImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/EnhancedSecurityMonitoringImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of EnhancedSecurityMonitoring */
 @Generated
@@ -19,20 +20,28 @@ class EnhancedSecurityMonitoringImpl implements EnhancedSecurityMonitoringServic
   public EnhancedSecurityMonitoringSetting get(
       GetEnhancedSecurityMonitoringSettingRequest request) {
     String path = "/api/2.0/settings/types/shield_esm_enablement_ws_db/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, EnhancedSecurityMonitoringSetting.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, EnhancedSecurityMonitoringSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public EnhancedSecurityMonitoringSetting update(
       UpdateEnhancedSecurityMonitoringSettingRequest request) {
     String path = "/api/2.0/settings/types/shield_esm_enablement_ws_db/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "PATCH", path, request, EnhancedSecurityMonitoringSetting.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, EnhancedSecurityMonitoringSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/EnhancedSecurityMonitoringImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/EnhancedSecurityMonitoringImpl.java
@@ -21,7 +21,8 @@ class EnhancedSecurityMonitoringImpl implements EnhancedSecurityMonitoringServic
     String path = "/api/2.0/settings/types/shield_esm_enablement_ws_db/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, EnhancedSecurityMonitoringSetting.class, headers);
+    return apiClient.execute(
+        "GET", path, request, EnhancedSecurityMonitoringSetting.class, headers);
   }
 
   @Override
@@ -31,6 +32,7 @@ class EnhancedSecurityMonitoringImpl implements EnhancedSecurityMonitoringServic
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, EnhancedSecurityMonitoringSetting.class, headers);
+    return apiClient.execute(
+        "PATCH", path, request, EnhancedSecurityMonitoringSetting.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/EsmEnablementAccountImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/EsmEnablementAccountImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of EsmEnablementAccount */
 @Generated
@@ -21,9 +22,14 @@ class EsmEnablementAccountImpl implements EsmEnablementAccountService {
         String.format(
             "/api/2.0/accounts/%s/settings/types/shield_esm_enablement_ac/names/default",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, EsmEnablementAccountSetting.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, EsmEnablementAccountSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -32,9 +38,14 @@ class EsmEnablementAccountImpl implements EsmEnablementAccountService {
         String.format(
             "/api/2.0/accounts/%s/settings/types/shield_esm_enablement_ac/names/default",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, EsmEnablementAccountSetting.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, EsmEnablementAccountSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/EsmEnablementAccountImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/EsmEnablementAccountImpl.java
@@ -23,7 +23,7 @@ class EsmEnablementAccountImpl implements EsmEnablementAccountService {
             apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, EsmEnablementAccountSetting.class, headers);
+    return apiClient.execute("GET", path, request, EsmEnablementAccountSetting.class, headers);
   }
 
   @Override
@@ -35,6 +35,6 @@ class EsmEnablementAccountImpl implements EsmEnablementAccountService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, EsmEnablementAccountSetting.class, headers);
+    return apiClient.execute("PATCH", path, request, EsmEnablementAccountSetting.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/IpAccessListsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/IpAccessListsImpl.java
@@ -21,7 +21,7 @@ class IpAccessListsImpl implements IpAccessListsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateIpAccessListResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateIpAccessListResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class IpAccessListsImpl implements IpAccessListsService {
     String path = String.format("/api/2.0/ip-access-lists/%s", request.getIpAccessListId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class IpAccessListsImpl implements IpAccessListsService {
     String path = String.format("/api/2.0/ip-access-lists/%s", request.getIpAccessListId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, FetchIpAccessListResponse.class, headers);
+    return apiClient.execute("GET", path, request, FetchIpAccessListResponse.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class IpAccessListsImpl implements IpAccessListsService {
     String path = "/api/2.0/ip-access-lists";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListIpAccessListResponse.class, headers);
+    return apiClient.execute("GET", path, null, ListIpAccessListResponse.class, headers);
   }
 
   @Override
@@ -54,7 +54,7 @@ class IpAccessListsImpl implements IpAccessListsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, ReplaceResponse.class, headers);
+    apiClient.execute("PUT", path, request, ReplaceResponse.class, headers);
   }
 
   @Override
@@ -63,6 +63,6 @@ class IpAccessListsImpl implements IpAccessListsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/IpAccessListsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/IpAccessListsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of IpAccessLists */
 @Generated
@@ -18,51 +19,81 @@ class IpAccessListsImpl implements IpAccessListsService {
   @Override
   public CreateIpAccessListResponse create(CreateIpAccessList request) {
     String path = "/api/2.0/ip-access-lists";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateIpAccessListResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateIpAccessListResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteIpAccessListRequest request) {
     String path = String.format("/api/2.0/ip-access-lists/%s", request.getIpAccessListId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public FetchIpAccessListResponse get(GetIpAccessListRequest request) {
     String path = String.format("/api/2.0/ip-access-lists/%s", request.getIpAccessListId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, FetchIpAccessListResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, FetchIpAccessListResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListIpAccessListResponse list() {
     String path = "/api/2.0/ip-access-lists";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListIpAccessListResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListIpAccessListResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void replace(ReplaceIpAccessList request) {
     String path = String.format("/api/2.0/ip-access-lists/%s", request.getIpAccessListId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, ReplaceResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, ReplaceResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(UpdateIpAccessList request) {
     String path = String.format("/api/2.0/ip-access-lists/%s", request.getIpAccessListId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/NetworkConnectivityImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/NetworkConnectivityImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of NetworkConnectivity */
 @Generated
@@ -21,11 +22,15 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
     String path =
         String.format(
             "/api/2.0/accounts/%s/network-connectivity-configs", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute(
-        "POST", path, request, NetworkConnectivityConfiguration.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, NetworkConnectivityConfiguration.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -35,10 +40,15 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
         String.format(
             "/api/2.0/accounts/%s/network-connectivity-configs/%s/private-endpoint-rules",
             apiClient.configuredAccountID(), request.getNetworkConnectivityConfigId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, NccAzurePrivateEndpointRule.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, NccAzurePrivateEndpointRule.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -48,10 +58,14 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
         String.format(
             "/api/2.0/accounts/%s/network-connectivity-configs/%s",
             apiClient.configuredAccountID(), request.getNetworkConnectivityConfigId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute(
-        "DELETE", path, request, DeleteNetworkConnectivityConfigurationResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteNetworkConnectivityConfigurationResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -63,9 +77,14 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
             apiClient.configuredAccountID(),
             request.getNetworkConnectivityConfigId(),
             request.getPrivateEndpointRuleId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("DELETE", path, request, NccAzurePrivateEndpointRule.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, NccAzurePrivateEndpointRule.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -75,9 +94,14 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
         String.format(
             "/api/2.0/accounts/%s/network-connectivity-configs/%s",
             apiClient.configuredAccountID(), request.getNetworkConnectivityConfigId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, NetworkConnectivityConfiguration.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, NetworkConnectivityConfiguration.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -88,9 +112,14 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
             apiClient.configuredAccountID(),
             request.getNetworkConnectivityConfigId(),
             request.getPrivateEndpointRuleId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, NccAzurePrivateEndpointRule.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, NccAzurePrivateEndpointRule.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -99,10 +128,14 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
     String path =
         String.format(
             "/api/2.0/accounts/%s/network-connectivity-configs", apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, ListNetworkConnectivityConfigurationsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListNetworkConnectivityConfigurationsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -112,9 +145,13 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
         String.format(
             "/api/2.0/accounts/%s/network-connectivity-configs/%s/private-endpoint-rules",
             apiClient.configuredAccountID(), request.getNetworkConnectivityConfigId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, ListNccAzurePrivateEndpointRulesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListNccAzurePrivateEndpointRulesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/NetworkConnectivityImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/NetworkConnectivityImpl.java
@@ -24,7 +24,8 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, NetworkConnectivityConfiguration.class, headers);
+    return apiClient.execute(
+        "POST", path, request, NetworkConnectivityConfiguration.class, headers);
   }
 
   @Override
@@ -37,7 +38,7 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, NccAzurePrivateEndpointRule.class, headers);
+    return apiClient.execute("POST", path, request, NccAzurePrivateEndpointRule.class, headers);
   }
 
   @Override
@@ -49,7 +50,8 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
             apiClient.configuredAccountID(), request.getNetworkConnectivityConfigId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteNetworkConnectivityConfigurationResponse.class, headers);
+    apiClient.execute(
+        "DELETE", path, request, DeleteNetworkConnectivityConfigurationResponse.class, headers);
   }
 
   @Override
@@ -63,7 +65,7 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
             request.getPrivateEndpointRuleId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.DELETE(path, request, NccAzurePrivateEndpointRule.class, headers);
+    return apiClient.execute("DELETE", path, request, NccAzurePrivateEndpointRule.class, headers);
   }
 
   @Override
@@ -75,7 +77,7 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
             apiClient.configuredAccountID(), request.getNetworkConnectivityConfigId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, NetworkConnectivityConfiguration.class, headers);
+    return apiClient.execute("GET", path, request, NetworkConnectivityConfiguration.class, headers);
   }
 
   @Override
@@ -88,7 +90,7 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
             request.getPrivateEndpointRuleId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, NccAzurePrivateEndpointRule.class, headers);
+    return apiClient.execute("GET", path, request, NccAzurePrivateEndpointRule.class, headers);
   }
 
   @Override
@@ -99,8 +101,8 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
             "/api/2.0/accounts/%s/network-connectivity-configs", apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(
-        path, request, ListNetworkConnectivityConfigurationsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, ListNetworkConnectivityConfigurationsResponse.class, headers);
   }
 
   @Override
@@ -112,6 +114,7 @@ class NetworkConnectivityImpl implements NetworkConnectivityService {
             apiClient.configuredAccountID(), request.getNetworkConnectivityConfigId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListNccAzurePrivateEndpointRulesResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, ListNccAzurePrivateEndpointRulesResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/NotificationDestinationsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/NotificationDestinationsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of NotificationDestinations */
 @Generated
@@ -18,43 +19,67 @@ class NotificationDestinationsImpl implements NotificationDestinationsService {
   @Override
   public NotificationDestination create(CreateNotificationDestinationRequest request) {
     String path = "/api/2.0/notification-destinations";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, NotificationDestination.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, NotificationDestination.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteNotificationDestinationRequest request) {
     String path = String.format("/api/2.0/notification-destinations/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, Empty.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, Empty.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public NotificationDestination get(GetNotificationDestinationRequest request) {
     String path = String.format("/api/2.0/notification-destinations/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, NotificationDestination.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, NotificationDestination.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListNotificationDestinationsResponse list(ListNotificationDestinationsRequest request) {
     String path = "/api/2.0/notification-destinations";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, ListNotificationDestinationsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListNotificationDestinationsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public NotificationDestination update(UpdateNotificationDestinationRequest request) {
     String path = String.format("/api/2.0/notification-destinations/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, NotificationDestination.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, NotificationDestination.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/NotificationDestinationsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/NotificationDestinationsImpl.java
@@ -21,7 +21,7 @@ class NotificationDestinationsImpl implements NotificationDestinationsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, NotificationDestination.class, headers);
+    return apiClient.execute("POST", path, request, NotificationDestination.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class NotificationDestinationsImpl implements NotificationDestinationsService {
     String path = String.format("/api/2.0/notification-destinations/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, Empty.class, headers);
+    apiClient.execute("DELETE", path, request, Empty.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class NotificationDestinationsImpl implements NotificationDestinationsService {
     String path = String.format("/api/2.0/notification-destinations/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, NotificationDestination.class, headers);
+    return apiClient.execute("GET", path, request, NotificationDestination.class, headers);
   }
 
   @Override
@@ -45,7 +45,8 @@ class NotificationDestinationsImpl implements NotificationDestinationsService {
     String path = "/api/2.0/notification-destinations";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListNotificationDestinationsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, ListNotificationDestinationsResponse.class, headers);
   }
 
   @Override
@@ -54,6 +55,6 @@ class NotificationDestinationsImpl implements NotificationDestinationsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, NotificationDestination.class, headers);
+    return apiClient.execute("PATCH", path, request, NotificationDestination.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/PersonalComputeImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/PersonalComputeImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of PersonalCompute */
 @Generated
@@ -21,10 +22,14 @@ class PersonalComputeImpl implements PersonalComputeService {
         String.format(
             "/api/2.0/accounts/%s/settings/types/dcp_acct_enable/names/default",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "DELETE", path, request, DeletePersonalComputeSettingResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, DeletePersonalComputeSettingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -33,9 +38,14 @@ class PersonalComputeImpl implements PersonalComputeService {
         String.format(
             "/api/2.0/accounts/%s/settings/types/dcp_acct_enable/names/default",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, PersonalComputeSetting.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, PersonalComputeSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -44,9 +54,14 @@ class PersonalComputeImpl implements PersonalComputeService {
         String.format(
             "/api/2.0/accounts/%s/settings/types/dcp_acct_enable/names/default",
             apiClient.configuredAccountID());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, PersonalComputeSetting.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, PersonalComputeSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/PersonalComputeImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/PersonalComputeImpl.java
@@ -23,7 +23,8 @@ class PersonalComputeImpl implements PersonalComputeService {
             apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.DELETE(path, request, DeletePersonalComputeSettingResponse.class, headers);
+    return apiClient.execute(
+        "DELETE", path, request, DeletePersonalComputeSettingResponse.class, headers);
   }
 
   @Override
@@ -34,7 +35,7 @@ class PersonalComputeImpl implements PersonalComputeService {
             apiClient.configuredAccountID());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, PersonalComputeSetting.class, headers);
+    return apiClient.execute("GET", path, request, PersonalComputeSetting.class, headers);
   }
 
   @Override
@@ -46,6 +47,6 @@ class PersonalComputeImpl implements PersonalComputeService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, PersonalComputeSetting.class, headers);
+    return apiClient.execute("PATCH", path, request, PersonalComputeSetting.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/RestrictWorkspaceAdminsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/RestrictWorkspaceAdminsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of RestrictWorkspaceAdmins */
 @Generated
@@ -19,27 +20,41 @@ class RestrictWorkspaceAdminsImpl implements RestrictWorkspaceAdminsService {
   public DeleteRestrictWorkspaceAdminsSettingResponse delete(
       DeleteRestrictWorkspaceAdminsSettingRequest request) {
     String path = "/api/2.0/settings/types/restrict_workspace_admins/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "DELETE", path, request, DeleteRestrictWorkspaceAdminsSettingResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, DeleteRestrictWorkspaceAdminsSettingResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RestrictWorkspaceAdminsSetting get(GetRestrictWorkspaceAdminsSettingRequest request) {
     String path = "/api/2.0/settings/types/restrict_workspace_admins/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, RestrictWorkspaceAdminsSetting.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, RestrictWorkspaceAdminsSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RestrictWorkspaceAdminsSetting update(
       UpdateRestrictWorkspaceAdminsSettingRequest request) {
     String path = "/api/2.0/settings/types/restrict_workspace_admins/names/default";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, RestrictWorkspaceAdminsSetting.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RestrictWorkspaceAdminsSetting.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/RestrictWorkspaceAdminsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/RestrictWorkspaceAdminsImpl.java
@@ -21,8 +21,8 @@ class RestrictWorkspaceAdminsImpl implements RestrictWorkspaceAdminsService {
     String path = "/api/2.0/settings/types/restrict_workspace_admins/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.DELETE(
-        path, request, DeleteRestrictWorkspaceAdminsSettingResponse.class, headers);
+    return apiClient.execute(
+        "DELETE", path, request, DeleteRestrictWorkspaceAdminsSettingResponse.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class RestrictWorkspaceAdminsImpl implements RestrictWorkspaceAdminsService {
     String path = "/api/2.0/settings/types/restrict_workspace_admins/names/default";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, RestrictWorkspaceAdminsSetting.class, headers);
+    return apiClient.execute("GET", path, request, RestrictWorkspaceAdminsSetting.class, headers);
   }
 
   @Override
@@ -40,6 +40,6 @@ class RestrictWorkspaceAdminsImpl implements RestrictWorkspaceAdminsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, RestrictWorkspaceAdminsSetting.class, headers);
+    return apiClient.execute("PATCH", path, request, RestrictWorkspaceAdminsSetting.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokenManagementImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokenManagementImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of TokenManagement */
 @Generated
@@ -18,67 +19,107 @@ class TokenManagementImpl implements TokenManagementService {
   @Override
   public CreateOboTokenResponse createOboToken(CreateOboTokenRequest request) {
     String path = "/api/2.0/token-management/on-behalf-of/tokens";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateOboTokenResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateOboTokenResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteTokenManagementRequest request) {
     String path = String.format("/api/2.0/token-management/tokens/%s", request.getTokenId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetTokenResponse get(GetTokenManagementRequest request) {
     String path = String.format("/api/2.0/token-management/tokens/%s", request.getTokenId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetTokenResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetTokenResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetTokenPermissionLevelsResponse getPermissionLevels() {
     String path = "/api/2.0/permissions/authorization/tokens/permissionLevels";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, GetTokenPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetTokenPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public TokenPermissions getPermissions() {
     String path = "/api/2.0/permissions/authorization/tokens";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, TokenPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, TokenPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListTokensResponse list(ListTokenManagementRequest request) {
     String path = "/api/2.0/token-management/tokens";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListTokensResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListTokensResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public TokenPermissions setPermissions(TokenPermissionsRequest request) {
     String path = "/api/2.0/permissions/authorization/tokens";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, TokenPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, TokenPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public TokenPermissions updatePermissions(TokenPermissionsRequest request) {
     String path = "/api/2.0/permissions/authorization/tokens";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, TokenPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, TokenPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokenManagementImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokenManagementImpl.java
@@ -21,7 +21,7 @@ class TokenManagementImpl implements TokenManagementService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateOboTokenResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateOboTokenResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class TokenManagementImpl implements TokenManagementService {
     String path = String.format("/api/2.0/token-management/tokens/%s", request.getTokenId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class TokenManagementImpl implements TokenManagementService {
     String path = String.format("/api/2.0/token-management/tokens/%s", request.getTokenId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetTokenResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetTokenResponse.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class TokenManagementImpl implements TokenManagementService {
     String path = "/api/2.0/permissions/authorization/tokens/permissionLevels";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, GetTokenPermissionLevelsResponse.class, headers);
+    return apiClient.execute("GET", path, null, GetTokenPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -53,7 +53,7 @@ class TokenManagementImpl implements TokenManagementService {
     String path = "/api/2.0/permissions/authorization/tokens";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, TokenPermissions.class, headers);
+    return apiClient.execute("GET", path, null, TokenPermissions.class, headers);
   }
 
   @Override
@@ -61,7 +61,7 @@ class TokenManagementImpl implements TokenManagementService {
     String path = "/api/2.0/token-management/tokens";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListTokensResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListTokensResponse.class, headers);
   }
 
   @Override
@@ -70,7 +70,7 @@ class TokenManagementImpl implements TokenManagementService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, TokenPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, TokenPermissions.class, headers);
   }
 
   @Override
@@ -79,6 +79,6 @@ class TokenManagementImpl implements TokenManagementService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, TokenPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, TokenPermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokensImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokensImpl.java
@@ -21,7 +21,7 @@ class TokensImpl implements TokensService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateTokenResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateTokenResponse.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class TokensImpl implements TokensService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, RevokeTokenResponse.class, headers);
+    apiClient.execute("POST", path, request, RevokeTokenResponse.class, headers);
   }
 
   @Override
@@ -38,6 +38,6 @@ class TokensImpl implements TokensService {
     String path = "/api/2.0/token/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListPublicTokensResponse.class, headers);
+    return apiClient.execute("GET", path, null, ListPublicTokensResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokensImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/TokensImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Tokens */
 @Generated
@@ -18,26 +19,41 @@ class TokensImpl implements TokensService {
   @Override
   public CreateTokenResponse create(CreateTokenRequest request) {
     String path = "/api/2.0/token/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateTokenResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateTokenResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(RevokeTokenRequest request) {
     String path = "/api/2.0/token/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, RevokeTokenResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, RevokeTokenResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListPublicTokensResponse list() {
     String path = "/api/2.0/token/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListPublicTokensResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListPublicTokensResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/WorkspaceConfImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/WorkspaceConfImpl.java
@@ -28,6 +28,6 @@ class WorkspaceConfImpl implements WorkspaceConfService {
     String path = "/api/2.0/workspace-conf";
     Map<String, String> headers = new HashMap<>();
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, SetStatusResponse.class, headers);
+    apiClient.execute("PATCH", path, request, SetStatusResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/WorkspaceConfImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/settings/WorkspaceConfImpl.java
@@ -2,7 +2,10 @@
 package com.databricks.sdk.service.settings;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,8 +29,13 @@ class WorkspaceConfImpl implements WorkspaceConfService {
   @Override
   public void setStatus(Map<String, String> request) {
     String path = "/api/2.0/workspace-conf";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, SetStatusResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, SetStatusResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/ProvidersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/ProvidersImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sharing;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Providers */
 @Generated
@@ -18,50 +19,80 @@ class ProvidersImpl implements ProvidersService {
   @Override
   public ProviderInfo create(CreateProvider request) {
     String path = "/api/2.1/unity-catalog/providers";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, ProviderInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ProviderInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteProviderRequest request) {
     String path = String.format("/api/2.1/unity-catalog/providers/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ProviderInfo get(GetProviderRequest request) {
     String path = String.format("/api/2.1/unity-catalog/providers/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ProviderInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ProviderInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListProvidersResponse list(ListProvidersRequest request) {
     String path = "/api/2.1/unity-catalog/providers";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListProvidersResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListProvidersResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListProviderSharesResponse listShares(ListSharesRequest request) {
     String path = String.format("/api/2.1/unity-catalog/providers/%s/shares", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListProviderSharesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListProviderSharesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ProviderInfo update(UpdateProvider request) {
     String path = String.format("/api/2.1/unity-catalog/providers/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, ProviderInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ProviderInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/ProvidersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/ProvidersImpl.java
@@ -21,7 +21,7 @@ class ProvidersImpl implements ProvidersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ProviderInfo.class, headers);
+    return apiClient.execute("POST", path, request, ProviderInfo.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class ProvidersImpl implements ProvidersService {
     String path = String.format("/api/2.1/unity-catalog/providers/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class ProvidersImpl implements ProvidersService {
     String path = String.format("/api/2.1/unity-catalog/providers/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ProviderInfo.class, headers);
+    return apiClient.execute("GET", path, request, ProviderInfo.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class ProvidersImpl implements ProvidersService {
     String path = "/api/2.1/unity-catalog/providers";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListProvidersResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListProvidersResponse.class, headers);
   }
 
   @Override
@@ -53,7 +53,7 @@ class ProvidersImpl implements ProvidersService {
     String path = String.format("/api/2.1/unity-catalog/providers/%s/shares", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListProviderSharesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListProviderSharesResponse.class, headers);
   }
 
   @Override
@@ -62,6 +62,6 @@ class ProvidersImpl implements ProvidersService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, ProviderInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, ProviderInfo.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/RecipientActivationImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/RecipientActivationImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sharing;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of RecipientActivation */
 @Generated
@@ -21,9 +22,14 @@ class RecipientActivationImpl implements RecipientActivationService {
         String.format(
             "/api/2.1/unity-catalog/public/data_sharing_activation_info/%s",
             request.getActivationUrl());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("GET", path, request, GetActivationUrlInfoResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, GetActivationUrlInfoResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -31,8 +37,13 @@ class RecipientActivationImpl implements RecipientActivationService {
     String path =
         String.format(
             "/api/2.1/unity-catalog/public/data_sharing_activation/%s", request.getActivationUrl());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, RetrieveTokenResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, RetrieveTokenResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/RecipientActivationImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/RecipientActivationImpl.java
@@ -23,7 +23,7 @@ class RecipientActivationImpl implements RecipientActivationService {
             request.getActivationUrl());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.GET(path, request, GetActivationUrlInfoResponse.class, headers);
+    apiClient.execute("GET", path, request, GetActivationUrlInfoResponse.class, headers);
   }
 
   @Override
@@ -33,6 +33,6 @@ class RecipientActivationImpl implements RecipientActivationService {
             "/api/2.1/unity-catalog/public/data_sharing_activation/%s", request.getActivationUrl());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, RetrieveTokenResponse.class, headers);
+    return apiClient.execute("GET", path, request, RetrieveTokenResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/RecipientsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/RecipientsImpl.java
@@ -21,7 +21,7 @@ class RecipientsImpl implements RecipientsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, RecipientInfo.class, headers);
+    return apiClient.execute("POST", path, request, RecipientInfo.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class RecipientsImpl implements RecipientsService {
     String path = String.format("/api/2.1/unity-catalog/recipients/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class RecipientsImpl implements RecipientsService {
     String path = String.format("/api/2.1/unity-catalog/recipients/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, RecipientInfo.class, headers);
+    return apiClient.execute("GET", path, request, RecipientInfo.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class RecipientsImpl implements RecipientsService {
     String path = "/api/2.1/unity-catalog/recipients";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListRecipientsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListRecipientsResponse.class, headers);
   }
 
   @Override
@@ -55,7 +55,7 @@ class RecipientsImpl implements RecipientsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, RecipientInfo.class, headers);
+    return apiClient.execute("POST", path, request, RecipientInfo.class, headers);
   }
 
   @Override
@@ -64,7 +64,8 @@ class RecipientsImpl implements RecipientsService {
         String.format("/api/2.1/unity-catalog/recipients/%s/share-permissions", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetRecipientSharePermissionsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetRecipientSharePermissionsResponse.class, headers);
   }
 
   @Override
@@ -73,6 +74,6 @@ class RecipientsImpl implements RecipientsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/RecipientsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/RecipientsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sharing;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Recipients */
 @Generated
@@ -18,62 +19,96 @@ class RecipientsImpl implements RecipientsService {
   @Override
   public RecipientInfo create(CreateRecipient request) {
     String path = "/api/2.1/unity-catalog/recipients";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, RecipientInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RecipientInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteRecipientRequest request) {
     String path = String.format("/api/2.1/unity-catalog/recipients/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RecipientInfo get(GetRecipientRequest request) {
     String path = String.format("/api/2.1/unity-catalog/recipients/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, RecipientInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, RecipientInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListRecipientsResponse list(ListRecipientsRequest request) {
     String path = "/api/2.1/unity-catalog/recipients";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListRecipientsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListRecipientsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RecipientInfo rotateToken(RotateRecipientToken request) {
     String path =
         String.format("/api/2.1/unity-catalog/recipients/%s/rotate-token", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, RecipientInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RecipientInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetRecipientSharePermissionsResponse sharePermissions(SharePermissionsRequest request) {
     String path =
         String.format("/api/2.1/unity-catalog/recipients/%s/share-permissions", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetRecipientSharePermissionsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetRecipientSharePermissionsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(UpdateRecipient request) {
     String path = String.format("/api/2.1/unity-catalog/recipients/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/SharesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/SharesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sharing;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Shares */
 @Generated
@@ -18,61 +19,95 @@ class SharesImpl implements SharesService {
   @Override
   public ShareInfo create(CreateShare request) {
     String path = "/api/2.1/unity-catalog/shares";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, ShareInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ShareInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteShareRequest request) {
     String path = String.format("/api/2.1/unity-catalog/shares/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ShareInfo get(GetShareRequest request) {
     String path = String.format("/api/2.1/unity-catalog/shares/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ShareInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ShareInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListSharesResponse list(ListSharesRequest request) {
     String path = "/api/2.1/unity-catalog/shares";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListSharesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListSharesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public com.databricks.sdk.service.catalog.PermissionsList sharePermissions(
       SharePermissionsRequest request) {
     String path = String.format("/api/2.1/unity-catalog/shares/%s/permissions", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, com.databricks.sdk.service.catalog.PermissionsList.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, com.databricks.sdk.service.catalog.PermissionsList.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ShareInfo update(UpdateShare request) {
     String path = String.format("/api/2.1/unity-catalog/shares/%s", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, ShareInfo.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ShareInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void updatePermissions(UpdateSharePermissions request) {
     String path = String.format("/api/2.1/unity-catalog/shares/%s/permissions", request.getName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdatePermissionsResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdatePermissionsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/SharesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/SharesImpl.java
@@ -21,7 +21,7 @@ class SharesImpl implements SharesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ShareInfo.class, headers);
+    return apiClient.execute("POST", path, request, ShareInfo.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class SharesImpl implements SharesService {
     String path = String.format("/api/2.1/unity-catalog/shares/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class SharesImpl implements SharesService {
     String path = String.format("/api/2.1/unity-catalog/shares/%s", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ShareInfo.class, headers);
+    return apiClient.execute("GET", path, request, ShareInfo.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class SharesImpl implements SharesService {
     String path = "/api/2.1/unity-catalog/shares";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListSharesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListSharesResponse.class, headers);
   }
 
   @Override
@@ -54,8 +54,8 @@ class SharesImpl implements SharesService {
     String path = String.format("/api/2.1/unity-catalog/shares/%s/permissions", request.getName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(
-        path, request, com.databricks.sdk.service.catalog.PermissionsList.class, headers);
+    return apiClient.execute(
+        "GET", path, request, com.databricks.sdk.service.catalog.PermissionsList.class, headers);
   }
 
   @Override
@@ -64,7 +64,7 @@ class SharesImpl implements SharesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, ShareInfo.class, headers);
+    return apiClient.execute("PATCH", path, request, ShareInfo.class, headers);
   }
 
   @Override
@@ -73,6 +73,6 @@ class SharesImpl implements SharesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdatePermissionsResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdatePermissionsResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsImpl.java
@@ -21,7 +21,7 @@ class AlertsImpl implements AlertsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Alert.class, headers);
+    return apiClient.execute("POST", path, request, Alert.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class AlertsImpl implements AlertsService {
     String path = String.format("/api/2.0/sql/alerts/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, Empty.class, headers);
+    apiClient.execute("DELETE", path, request, Empty.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class AlertsImpl implements AlertsService {
     String path = String.format("/api/2.0/sql/alerts/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Alert.class, headers);
+    return apiClient.execute("GET", path, request, Alert.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class AlertsImpl implements AlertsService {
     String path = "/api/2.0/sql/alerts";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListAlertsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListAlertsResponse.class, headers);
   }
 
   @Override
@@ -54,6 +54,6 @@ class AlertsImpl implements AlertsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, Alert.class, headers);
+    return apiClient.execute("PATCH", path, request, Alert.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Alerts */
 @Generated
@@ -18,42 +19,67 @@ class AlertsImpl implements AlertsService {
   @Override
   public Alert create(CreateAlertRequest request) {
     String path = "/api/2.0/sql/alerts";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Alert.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Alert.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(TrashAlertRequest request) {
     String path = String.format("/api/2.0/sql/alerts/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, Empty.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, Empty.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Alert get(GetAlertRequest request) {
     String path = String.format("/api/2.0/sql/alerts/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Alert.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Alert.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListAlertsResponse list(ListAlertsRequest request) {
     String path = "/api/2.0/sql/alerts";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListAlertsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListAlertsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Alert update(UpdateAlertRequest request) {
     String path = String.format("/api/2.0/sql/alerts/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, Alert.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Alert.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsLegacyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsLegacyImpl.java
@@ -22,7 +22,7 @@ class AlertsLegacyImpl implements AlertsLegacyService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, LegacyAlert.class, headers);
+    return apiClient.execute("POST", path, request, LegacyAlert.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class AlertsLegacyImpl implements AlertsLegacyService {
     String path = String.format("/api/2.0/preview/sql/alerts/%s", request.getAlertId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -38,7 +38,7 @@ class AlertsLegacyImpl implements AlertsLegacyService {
     String path = String.format("/api/2.0/preview/sql/alerts/%s", request.getAlertId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, LegacyAlert.class, headers);
+    return apiClient.execute("GET", path, request, LegacyAlert.class, headers);
   }
 
   @Override
@@ -55,6 +55,6 @@ class AlertsLegacyImpl implements AlertsLegacyService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, UpdateResponse.class, headers);
+    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsLegacyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/AlertsLegacyImpl.java
@@ -2,7 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,26 +22,41 @@ class AlertsLegacyImpl implements AlertsLegacyService {
   @Override
   public LegacyAlert create(CreateAlert request) {
     String path = "/api/2.0/preview/sql/alerts";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, LegacyAlert.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, LegacyAlert.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteAlertsLegacyRequest request) {
     String path = String.format("/api/2.0/preview/sql/alerts/%s", request.getAlertId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public LegacyAlert get(GetAlertsLegacyRequest request) {
     String path = String.format("/api/2.0/preview/sql/alerts/%s", request.getAlertId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, LegacyAlert.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, LegacyAlert.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -52,9 +70,14 @@ class AlertsLegacyImpl implements AlertsLegacyService {
   @Override
   public void update(EditAlert request) {
     String path = String.format("/api/2.0/preview/sql/alerts/%s", request.getAlertId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, UpdateResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardWidgetsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardWidgetsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of DashboardWidgets */
 @Generated
@@ -18,26 +19,41 @@ class DashboardWidgetsImpl implements DashboardWidgetsService {
   @Override
   public Widget create(CreateWidget request) {
     String path = "/api/2.0/preview/sql/widgets";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Widget.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Widget.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteDashboardWidgetRequest request) {
     String path = String.format("/api/2.0/preview/sql/widgets/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Widget update(CreateWidget request) {
     String path = String.format("/api/2.0/preview/sql/widgets/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Widget.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Widget.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardWidgetsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardWidgetsImpl.java
@@ -21,7 +21,7 @@ class DashboardWidgetsImpl implements DashboardWidgetsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Widget.class, headers);
+    return apiClient.execute("POST", path, request, Widget.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class DashboardWidgetsImpl implements DashboardWidgetsService {
     String path = String.format("/api/2.0/preview/sql/widgets/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -38,6 +38,6 @@ class DashboardWidgetsImpl implements DashboardWidgetsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Widget.class, headers);
+    return apiClient.execute("POST", path, request, Widget.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Dashboards */
 @Generated
@@ -18,51 +19,81 @@ class DashboardsImpl implements DashboardsService {
   @Override
   public Dashboard create(DashboardPostContent request) {
     String path = "/api/2.0/preview/sql/dashboards";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Dashboard.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Dashboard.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteDashboardRequest request) {
     String path = String.format("/api/2.0/preview/sql/dashboards/%s", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Dashboard get(GetDashboardRequest request) {
     String path = String.format("/api/2.0/preview/sql/dashboards/%s", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Dashboard.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Dashboard.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListResponse list(ListDashboardsRequest request) {
     String path = "/api/2.0/preview/sql/dashboards";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void restore(RestoreDashboardRequest request) {
     String path =
         String.format("/api/2.0/preview/sql/dashboards/trash/%s", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("POST", path, null, RestoreResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, RestoreResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Dashboard update(DashboardEditContent request) {
     String path = String.format("/api/2.0/preview/sql/dashboards/%s", request.getDashboardId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Dashboard.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Dashboard.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DashboardsImpl.java
@@ -21,7 +21,7 @@ class DashboardsImpl implements DashboardsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Dashboard.class, headers);
+    return apiClient.execute("POST", path, request, Dashboard.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class DashboardsImpl implements DashboardsService {
     String path = String.format("/api/2.0/preview/sql/dashboards/%s", request.getDashboardId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class DashboardsImpl implements DashboardsService {
     String path = String.format("/api/2.0/preview/sql/dashboards/%s", request.getDashboardId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Dashboard.class, headers);
+    return apiClient.execute("GET", path, request, Dashboard.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class DashboardsImpl implements DashboardsService {
     String path = "/api/2.0/preview/sql/dashboards";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListResponse.class, headers);
   }
 
   @Override
@@ -54,7 +54,7 @@ class DashboardsImpl implements DashboardsService {
         String.format("/api/2.0/preview/sql/dashboards/trash/%s", request.getDashboardId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.POST(path, null, RestoreResponse.class, headers);
+    apiClient.execute("POST", path, null, RestoreResponse.class, headers);
   }
 
   @Override
@@ -63,6 +63,6 @@ class DashboardsImpl implements DashboardsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Dashboard.class, headers);
+    return apiClient.execute("POST", path, request, Dashboard.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DbsqlPermissionsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DbsqlPermissionsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of DbsqlPermissions */
 @Generated
@@ -21,9 +22,14 @@ class DbsqlPermissionsImpl implements DbsqlPermissionsService {
         String.format(
             "/api/2.0/preview/sql/permissions/%s/%s",
             request.getObjectType(), request.getObjectId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -32,10 +38,15 @@ class DbsqlPermissionsImpl implements DbsqlPermissionsService {
         String.format(
             "/api/2.0/preview/sql/permissions/%s/%s",
             request.getObjectType(), request.getObjectId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, SetResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, SetResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -44,9 +55,14 @@ class DbsqlPermissionsImpl implements DbsqlPermissionsService {
         String.format(
             "/api/2.0/preview/sql/permissions/%s/%s/transfer",
             request.getObjectType(), request.getObjectId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Success.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Success.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DbsqlPermissionsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/DbsqlPermissionsImpl.java
@@ -23,7 +23,7 @@ class DbsqlPermissionsImpl implements DbsqlPermissionsService {
             request.getObjectType(), request.getObjectId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetResponse.class, headers);
   }
 
   @Override
@@ -35,7 +35,7 @@ class DbsqlPermissionsImpl implements DbsqlPermissionsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, SetResponse.class, headers);
+    return apiClient.execute("POST", path, request, SetResponse.class, headers);
   }
 
   @Override
@@ -47,6 +47,6 @@ class DbsqlPermissionsImpl implements DbsqlPermissionsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Success.class, headers);
+    return apiClient.execute("POST", path, request, Success.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Queries */
 @Generated
@@ -18,52 +19,81 @@ class QueriesImpl implements QueriesService {
   @Override
   public Query create(CreateQueryRequest request) {
     String path = "/api/2.0/sql/queries";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Query.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Query.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(TrashQueryRequest request) {
     String path = String.format("/api/2.0/sql/queries/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, Empty.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, Empty.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Query get(GetQueryRequest request) {
     String path = String.format("/api/2.0/sql/queries/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, Query.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, Query.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListQueryObjectsResponse list(ListQueriesRequest request) {
     String path = "/api/2.0/sql/queries";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListQueryObjectsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListQueryObjectsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListVisualizationsForQueryResponse listVisualizations(
       ListVisualizationsForQueryRequest request) {
     String path = String.format("/api/2.0/sql/queries/%s/visualizations", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, ListVisualizationsForQueryResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListVisualizationsForQueryResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Query update(UpdateQueryRequest request) {
     String path = String.format("/api/2.0/sql/queries/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, Query.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Query.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesImpl.java
@@ -21,7 +21,7 @@ class QueriesImpl implements QueriesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Query.class, headers);
+    return apiClient.execute("POST", path, request, Query.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class QueriesImpl implements QueriesService {
     String path = String.format("/api/2.0/sql/queries/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, Empty.class, headers);
+    apiClient.execute("DELETE", path, request, Empty.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class QueriesImpl implements QueriesService {
     String path = String.format("/api/2.0/sql/queries/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, Query.class, headers);
+    return apiClient.execute("GET", path, request, Query.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class QueriesImpl implements QueriesService {
     String path = "/api/2.0/sql/queries";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListQueryObjectsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListQueryObjectsResponse.class, headers);
   }
 
   @Override
@@ -54,7 +54,8 @@ class QueriesImpl implements QueriesService {
     String path = String.format("/api/2.0/sql/queries/%s/visualizations", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListVisualizationsForQueryResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, ListVisualizationsForQueryResponse.class, headers);
   }
 
   @Override
@@ -63,6 +64,6 @@ class QueriesImpl implements QueriesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, Query.class, headers);
+    return apiClient.execute("PATCH", path, request, Query.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesLegacyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesLegacyImpl.java
@@ -21,7 +21,7 @@ class QueriesLegacyImpl implements QueriesLegacyService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, LegacyQuery.class, headers);
+    return apiClient.execute("POST", path, request, LegacyQuery.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class QueriesLegacyImpl implements QueriesLegacyService {
     String path = String.format("/api/2.0/preview/sql/queries/%s", request.getQueryId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class QueriesLegacyImpl implements QueriesLegacyService {
     String path = String.format("/api/2.0/preview/sql/queries/%s", request.getQueryId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, LegacyQuery.class, headers);
+    return apiClient.execute("GET", path, request, LegacyQuery.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class QueriesLegacyImpl implements QueriesLegacyService {
     String path = "/api/2.0/preview/sql/queries";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, QueryList.class, headers);
+    return apiClient.execute("GET", path, request, QueryList.class, headers);
   }
 
   @Override
@@ -53,7 +53,7 @@ class QueriesLegacyImpl implements QueriesLegacyService {
     String path = String.format("/api/2.0/preview/sql/queries/trash/%s", request.getQueryId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.POST(path, null, RestoreResponse.class, headers);
+    apiClient.execute("POST", path, null, RestoreResponse.class, headers);
   }
 
   @Override
@@ -62,6 +62,6 @@ class QueriesLegacyImpl implements QueriesLegacyService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, LegacyQuery.class, headers);
+    return apiClient.execute("POST", path, request, LegacyQuery.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesLegacyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueriesLegacyImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of QueriesLegacy */
 @Generated
@@ -18,50 +19,80 @@ class QueriesLegacyImpl implements QueriesLegacyService {
   @Override
   public LegacyQuery create(QueryPostContent request) {
     String path = "/api/2.0/preview/sql/queries";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, LegacyQuery.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, LegacyQuery.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteQueriesLegacyRequest request) {
     String path = String.format("/api/2.0/preview/sql/queries/%s", request.getQueryId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public LegacyQuery get(GetQueriesLegacyRequest request) {
     String path = String.format("/api/2.0/preview/sql/queries/%s", request.getQueryId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, LegacyQuery.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, LegacyQuery.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public QueryList list(ListQueriesLegacyRequest request) {
     String path = "/api/2.0/preview/sql/queries";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, QueryList.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, QueryList.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void restore(RestoreQueriesLegacyRequest request) {
     String path = String.format("/api/2.0/preview/sql/queries/trash/%s", request.getQueryId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("POST", path, null, RestoreResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, RestoreResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public LegacyQuery update(QueryEditContent request) {
     String path = String.format("/api/2.0/preview/sql/queries/%s", request.getQueryId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, LegacyQuery.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, LegacyQuery.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryHistoryImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryHistoryImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of QueryHistory */
 @Generated
@@ -18,8 +19,13 @@ class QueryHistoryImpl implements QueryHistoryService {
   @Override
   public ListQueriesResponse list(ListQueryHistoryRequest request) {
     String path = "/api/2.0/sql/history/queries";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListQueriesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListQueriesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryHistoryImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryHistoryImpl.java
@@ -20,6 +20,6 @@ class QueryHistoryImpl implements QueryHistoryService {
     String path = "/api/2.0/sql/history/queries";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListQueriesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListQueriesResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryVisualizationsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryVisualizationsImpl.java
@@ -21,7 +21,7 @@ class QueryVisualizationsImpl implements QueryVisualizationsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, Visualization.class, headers);
+    return apiClient.execute("POST", path, request, Visualization.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class QueryVisualizationsImpl implements QueryVisualizationsService {
     String path = String.format("/api/2.0/sql/visualizations/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, Empty.class, headers);
+    apiClient.execute("DELETE", path, request, Empty.class, headers);
   }
 
   @Override
@@ -38,6 +38,6 @@ class QueryVisualizationsImpl implements QueryVisualizationsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, Visualization.class, headers);
+    return apiClient.execute("PATCH", path, request, Visualization.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryVisualizationsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryVisualizationsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of QueryVisualizations */
 @Generated
@@ -18,26 +19,41 @@ class QueryVisualizationsImpl implements QueryVisualizationsService {
   @Override
   public Visualization create(CreateVisualizationRequest request) {
     String path = "/api/2.0/sql/visualizations";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, Visualization.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Visualization.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteVisualizationRequest request) {
     String path = String.format("/api/2.0/sql/visualizations/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, Empty.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, Empty.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public Visualization update(UpdateVisualizationRequest request) {
     String path = String.format("/api/2.0/sql/visualizations/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, Visualization.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, Visualization.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryVisualizationsLegacyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryVisualizationsLegacyImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of QueryVisualizationsLegacy */
 @Generated
@@ -18,26 +19,41 @@ class QueryVisualizationsLegacyImpl implements QueryVisualizationsLegacyService 
   @Override
   public LegacyVisualization create(CreateQueryVisualizationsLegacyRequest request) {
     String path = "/api/2.0/preview/sql/visualizations";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, LegacyVisualization.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, LegacyVisualization.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteQueryVisualizationsLegacyRequest request) {
     String path = String.format("/api/2.0/preview/sql/visualizations/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public LegacyVisualization update(LegacyVisualization request) {
     String path = String.format("/api/2.0/preview/sql/visualizations/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, LegacyVisualization.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, LegacyVisualization.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryVisualizationsLegacyImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/QueryVisualizationsLegacyImpl.java
@@ -21,7 +21,7 @@ class QueryVisualizationsLegacyImpl implements QueryVisualizationsLegacyService 
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, LegacyVisualization.class, headers);
+    return apiClient.execute("POST", path, request, LegacyVisualization.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class QueryVisualizationsLegacyImpl implements QueryVisualizationsLegacyService 
     String path = String.format("/api/2.0/preview/sql/visualizations/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -38,6 +38,6 @@ class QueryVisualizationsLegacyImpl implements QueryVisualizationsLegacyService 
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, LegacyVisualization.class, headers);
+    return apiClient.execute("POST", path, request, LegacyVisualization.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/StatementExecutionImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/StatementExecutionImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of StatementExecution */
 @Generated
@@ -18,25 +19,40 @@ class StatementExecutionImpl implements StatementExecutionService {
   @Override
   public void cancelExecution(CancelExecutionRequest request) {
     String path = String.format("/api/2.0/sql/statements/%s/cancel", request.getStatementId());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("POST", path, null, CancelExecutionResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, CancelExecutionResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public StatementResponse executeStatement(ExecuteStatementRequest request) {
     String path = "/api/2.0/sql/statements/";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, StatementResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, StatementResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public StatementResponse getStatement(GetStatementRequest request) {
     String path = String.format("/api/2.0/sql/statements/%s", request.getStatementId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, StatementResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, StatementResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -45,8 +61,13 @@ class StatementExecutionImpl implements StatementExecutionService {
         String.format(
             "/api/2.0/sql/statements/%s/result/chunks/%s",
             request.getStatementId(), request.getChunkIndex());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ResultData.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ResultData.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/StatementExecutionImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/StatementExecutionImpl.java
@@ -19,7 +19,7 @@ class StatementExecutionImpl implements StatementExecutionService {
   public void cancelExecution(CancelExecutionRequest request) {
     String path = String.format("/api/2.0/sql/statements/%s/cancel", request.getStatementId());
     Map<String, String> headers = new HashMap<>();
-    apiClient.POST(path, null, CancelExecutionResponse.class, headers);
+    apiClient.execute("POST", path, null, CancelExecutionResponse.class, headers);
   }
 
   @Override
@@ -28,7 +28,7 @@ class StatementExecutionImpl implements StatementExecutionService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, StatementResponse.class, headers);
+    return apiClient.execute("POST", path, request, StatementResponse.class, headers);
   }
 
   @Override
@@ -36,7 +36,7 @@ class StatementExecutionImpl implements StatementExecutionService {
     String path = String.format("/api/2.0/sql/statements/%s", request.getStatementId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, StatementResponse.class, headers);
+    return apiClient.execute("GET", path, request, StatementResponse.class, headers);
   }
 
   @Override
@@ -47,6 +47,6 @@ class StatementExecutionImpl implements StatementExecutionService {
             request.getStatementId(), request.getChunkIndex());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ResultData.class, headers);
+    return apiClient.execute("GET", path, request, ResultData.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesImpl.java
@@ -21,7 +21,7 @@ class WarehousesImpl implements WarehousesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateWarehouseResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateWarehouseResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class WarehousesImpl implements WarehousesService {
     String path = String.format("/api/2.0/sql/warehouses/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteWarehouseResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteWarehouseResponse.class, headers);
   }
 
   @Override
@@ -38,7 +38,7 @@ class WarehousesImpl implements WarehousesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, EditWarehouseResponse.class, headers);
+    apiClient.execute("POST", path, request, EditWarehouseResponse.class, headers);
   }
 
   @Override
@@ -46,7 +46,7 @@ class WarehousesImpl implements WarehousesService {
     String path = String.format("/api/2.0/sql/warehouses/%s", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetWarehouseResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetWarehouseResponse.class, headers);
   }
 
   @Override
@@ -57,7 +57,8 @@ class WarehousesImpl implements WarehousesService {
             "/api/2.0/permissions/warehouses/%s/permissionLevels", request.getWarehouseId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetWarehousePermissionLevelsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetWarehousePermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -65,7 +66,7 @@ class WarehousesImpl implements WarehousesService {
     String path = String.format("/api/2.0/permissions/warehouses/%s", request.getWarehouseId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, WarehousePermissions.class, headers);
+    return apiClient.execute("GET", path, request, WarehousePermissions.class, headers);
   }
 
   @Override
@@ -73,7 +74,7 @@ class WarehousesImpl implements WarehousesService {
     String path = "/api/2.0/sql/config/warehouses";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, GetWorkspaceWarehouseConfigResponse.class, headers);
+    return apiClient.execute("GET", path, null, GetWorkspaceWarehouseConfigResponse.class, headers);
   }
 
   @Override
@@ -81,7 +82,7 @@ class WarehousesImpl implements WarehousesService {
     String path = "/api/2.0/sql/warehouses";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListWarehousesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListWarehousesResponse.class, headers);
   }
 
   @Override
@@ -90,7 +91,7 @@ class WarehousesImpl implements WarehousesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, WarehousePermissions.class, headers);
+    return apiClient.execute("PUT", path, request, WarehousePermissions.class, headers);
   }
 
   @Override
@@ -99,7 +100,7 @@ class WarehousesImpl implements WarehousesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PUT(path, request, SetWorkspaceWarehouseConfigResponse.class, headers);
+    apiClient.execute("PUT", path, request, SetWorkspaceWarehouseConfigResponse.class, headers);
   }
 
   @Override
@@ -107,7 +108,7 @@ class WarehousesImpl implements WarehousesService {
     String path = String.format("/api/2.0/sql/warehouses/%s/start", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.POST(path, null, StartWarehouseResponse.class, headers);
+    apiClient.execute("POST", path, null, StartWarehouseResponse.class, headers);
   }
 
   @Override
@@ -115,7 +116,7 @@ class WarehousesImpl implements WarehousesService {
     String path = String.format("/api/2.0/sql/warehouses/%s/stop", request.getId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.POST(path, null, StopWarehouseResponse.class, headers);
+    apiClient.execute("POST", path, null, StopWarehouseResponse.class, headers);
   }
 
   @Override
@@ -124,6 +125,6 @@ class WarehousesImpl implements WarehousesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, WarehousePermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, WarehousePermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sql/WarehousesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.sql;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Warehouses */
 @Generated
@@ -18,35 +19,55 @@ class WarehousesImpl implements WarehousesService {
   @Override
   public CreateWarehouseResponse create(CreateWarehouseRequest request) {
     String path = "/api/2.0/sql/warehouses";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateWarehouseResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateWarehouseResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteWarehouseRequest request) {
     String path = String.format("/api/2.0/sql/warehouses/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteWarehouseResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteWarehouseResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void edit(EditWarehouseRequest request) {
     String path = String.format("/api/2.0/sql/warehouses/%s/edit", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, EditWarehouseResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, EditWarehouseResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetWarehouseResponse get(GetWarehouseRequest request) {
     String path = String.format("/api/2.0/sql/warehouses/%s", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetWarehouseResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetWarehouseResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -55,76 +76,120 @@ class WarehousesImpl implements WarehousesService {
     String path =
         String.format(
             "/api/2.0/permissions/warehouses/%s/permissionLevels", request.getWarehouseId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetWarehousePermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetWarehousePermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public WarehousePermissions getPermissions(GetWarehousePermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/warehouses/%s", request.getWarehouseId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, WarehousePermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, WarehousePermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetWorkspaceWarehouseConfigResponse getWorkspaceWarehouseConfig() {
     String path = "/api/2.0/sql/config/warehouses";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, GetWorkspaceWarehouseConfigResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetWorkspaceWarehouseConfigResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListWarehousesResponse list(ListWarehousesRequest request) {
     String path = "/api/2.0/sql/warehouses";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListWarehousesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListWarehousesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public WarehousePermissions setPermissions(WarehousePermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/warehouses/%s", request.getWarehouseId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, WarehousePermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, WarehousePermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void setWorkspaceWarehouseConfig(SetWorkspaceWarehouseConfigRequest request) {
     String path = "/api/2.0/sql/config/warehouses";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PUT", path, request, SetWorkspaceWarehouseConfigResponse.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, SetWorkspaceWarehouseConfigResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void start(StartRequest request) {
     String path = String.format("/api/2.0/sql/warehouses/%s/start", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("POST", path, null, StartWarehouseResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, StartWarehouseResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void stop(StopRequest request) {
     String path = String.format("/api/2.0/sql/warehouses/%s/stop", request.getId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("POST", path, null, StopWarehouseResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, StopWarehouseResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public WarehousePermissions updatePermissions(WarehousePermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/warehouses/%s", request.getWarehouseId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, WarehousePermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, WarehousePermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/vectorsearch/VectorSearchEndpointsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/vectorsearch/VectorSearchEndpointsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.vectorsearch;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of VectorSearchEndpoints */
 @Generated
@@ -18,32 +19,52 @@ class VectorSearchEndpointsImpl implements VectorSearchEndpointsService {
   @Override
   public EndpointInfo createEndpoint(CreateEndpoint request) {
     String path = "/api/2.0/vector-search/endpoints";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, EndpointInfo.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, EndpointInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteEndpoint(DeleteEndpointRequest request) {
     String path = String.format("/api/2.0/vector-search/endpoints/%s", request.getEndpointName());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteEndpointResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteEndpointResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public EndpointInfo getEndpoint(GetEndpointRequest request) {
     String path = String.format("/api/2.0/vector-search/endpoints/%s", request.getEndpointName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, EndpointInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, EndpointInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListEndpointResponse listEndpoints(ListEndpointsRequest request) {
     String path = "/api/2.0/vector-search/endpoints";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListEndpointResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListEndpointResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/vectorsearch/VectorSearchEndpointsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/vectorsearch/VectorSearchEndpointsImpl.java
@@ -21,14 +21,14 @@ class VectorSearchEndpointsImpl implements VectorSearchEndpointsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, EndpointInfo.class, headers);
+    return apiClient.execute("POST", path, request, EndpointInfo.class, headers);
   }
 
   @Override
   public void deleteEndpoint(DeleteEndpointRequest request) {
     String path = String.format("/api/2.0/vector-search/endpoints/%s", request.getEndpointName());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteEndpointResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteEndpointResponse.class, headers);
   }
 
   @Override
@@ -36,7 +36,7 @@ class VectorSearchEndpointsImpl implements VectorSearchEndpointsService {
     String path = String.format("/api/2.0/vector-search/endpoints/%s", request.getEndpointName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, EndpointInfo.class, headers);
+    return apiClient.execute("GET", path, request, EndpointInfo.class, headers);
   }
 
   @Override
@@ -44,6 +44,6 @@ class VectorSearchEndpointsImpl implements VectorSearchEndpointsService {
     String path = "/api/2.0/vector-search/endpoints";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListEndpointResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListEndpointResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/vectorsearch/VectorSearchIndexesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/vectorsearch/VectorSearchIndexesImpl.java
@@ -21,7 +21,7 @@ class VectorSearchIndexesImpl implements VectorSearchIndexesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateVectorIndexResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateVectorIndexResponse.class, headers);
   }
 
   @Override
@@ -31,14 +31,14 @@ class VectorSearchIndexesImpl implements VectorSearchIndexesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, DeleteDataVectorIndexResponse.class, headers);
+    return apiClient.execute("POST", path, request, DeleteDataVectorIndexResponse.class, headers);
   }
 
   @Override
   public void deleteIndex(DeleteIndexRequest request) {
     String path = String.format("/api/2.0/vector-search/indexes/%s", request.getIndexName());
     Map<String, String> headers = new HashMap<>();
-    apiClient.DELETE(path, request, DeleteIndexResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteIndexResponse.class, headers);
   }
 
   @Override
@@ -46,7 +46,7 @@ class VectorSearchIndexesImpl implements VectorSearchIndexesService {
     String path = String.format("/api/2.0/vector-search/indexes/%s", request.getIndexName());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, VectorIndex.class, headers);
+    return apiClient.execute("GET", path, request, VectorIndex.class, headers);
   }
 
   @Override
@@ -54,7 +54,7 @@ class VectorSearchIndexesImpl implements VectorSearchIndexesService {
     String path = "/api/2.0/vector-search/indexes";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListVectorIndexesResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListVectorIndexesResponse.class, headers);
   }
 
   @Override
@@ -63,7 +63,7 @@ class VectorSearchIndexesImpl implements VectorSearchIndexesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, QueryVectorIndexResponse.class, headers);
+    return apiClient.execute("POST", path, request, QueryVectorIndexResponse.class, headers);
   }
 
   @Override
@@ -73,7 +73,7 @@ class VectorSearchIndexesImpl implements VectorSearchIndexesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, QueryVectorIndexResponse.class, headers);
+    return apiClient.execute("POST", path, request, QueryVectorIndexResponse.class, headers);
   }
 
   @Override
@@ -82,14 +82,14 @@ class VectorSearchIndexesImpl implements VectorSearchIndexesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, ScanVectorIndexResponse.class, headers);
+    return apiClient.execute("POST", path, request, ScanVectorIndexResponse.class, headers);
   }
 
   @Override
   public void syncIndex(SyncIndexRequest request) {
     String path = String.format("/api/2.0/vector-search/indexes/%s/sync", request.getIndexName());
     Map<String, String> headers = new HashMap<>();
-    apiClient.POST(path, null, SyncIndexResponse.class, headers);
+    apiClient.execute("POST", path, null, SyncIndexResponse.class, headers);
   }
 
   @Override
@@ -99,6 +99,6 @@ class VectorSearchIndexesImpl implements VectorSearchIndexesService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, UpsertDataVectorIndexResponse.class, headers);
+    return apiClient.execute("POST", path, request, UpsertDataVectorIndexResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/vectorsearch/VectorSearchIndexesImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/vectorsearch/VectorSearchIndexesImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.vectorsearch;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of VectorSearchIndexes */
 @Generated
@@ -18,87 +19,137 @@ class VectorSearchIndexesImpl implements VectorSearchIndexesService {
   @Override
   public CreateVectorIndexResponse createIndex(CreateVectorIndexRequest request) {
     String path = "/api/2.0/vector-search/indexes";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateVectorIndexResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateVectorIndexResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public DeleteDataVectorIndexResponse deleteDataVectorIndex(DeleteDataVectorIndexRequest request) {
     String path =
         String.format("/api/2.0/vector-search/indexes/%s/delete-data", request.getIndexName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, DeleteDataVectorIndexResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, DeleteDataVectorIndexResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteIndex(DeleteIndexRequest request) {
     String path = String.format("/api/2.0/vector-search/indexes/%s", request.getIndexName());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("DELETE", path, request, DeleteIndexResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, DeleteIndexResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public VectorIndex getIndex(GetIndexRequest request) {
     String path = String.format("/api/2.0/vector-search/indexes/%s", request.getIndexName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, VectorIndex.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, VectorIndex.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListVectorIndexesResponse listIndexes(ListIndexesRequest request) {
     String path = "/api/2.0/vector-search/indexes";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListVectorIndexesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListVectorIndexesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public QueryVectorIndexResponse queryIndex(QueryVectorIndexRequest request) {
     String path = String.format("/api/2.0/vector-search/indexes/%s/query", request.getIndexName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, QueryVectorIndexResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, QueryVectorIndexResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public QueryVectorIndexResponse queryNextPage(QueryVectorIndexNextPageRequest request) {
     String path =
         String.format("/api/2.0/vector-search/indexes/%s/query-next-page", request.getIndexName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, QueryVectorIndexResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, QueryVectorIndexResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ScanVectorIndexResponse scanIndex(ScanVectorIndexRequest request) {
     String path = String.format("/api/2.0/vector-search/indexes/%s/scan", request.getIndexName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, ScanVectorIndexResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, ScanVectorIndexResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void syncIndex(SyncIndexRequest request) {
     String path = String.format("/api/2.0/vector-search/indexes/%s/sync", request.getIndexName());
-    Map<String, String> headers = new HashMap<>();
-    apiClient.execute("POST", path, null, SyncIndexResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      apiClient.execute(req, SyncIndexResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public UpsertDataVectorIndexResponse upsertDataVectorIndex(UpsertDataVectorIndexRequest request) {
     String path =
         String.format("/api/2.0/vector-search/indexes/%s/upsert-data", request.getIndexName());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, UpsertDataVectorIndexResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, UpsertDataVectorIndexResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/GitCredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/GitCredentialsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.workspace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of GitCredentials */
 @Generated
@@ -18,42 +19,67 @@ class GitCredentialsImpl implements GitCredentialsService {
   @Override
   public CreateCredentialsResponse create(CreateCredentialsRequest request) {
     String path = "/api/2.0/git-credentials";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateCredentialsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateCredentialsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteCredentialsRequest request) {
     String path = String.format("/api/2.0/git-credentials/%s", request.getCredentialId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteCredentialsResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteCredentialsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetCredentialsResponse get(GetCredentialsRequest request) {
     String path = String.format("/api/2.0/git-credentials/%s", request.getCredentialId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetCredentialsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetCredentialsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListCredentialsResponse list() {
     String path = "/api/2.0/git-credentials";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListCredentialsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListCredentialsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(UpdateCredentialsRequest request) {
     String path = String.format("/api/2.0/git-credentials/%s", request.getCredentialId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateCredentialsResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateCredentialsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/GitCredentialsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/GitCredentialsImpl.java
@@ -21,7 +21,7 @@ class GitCredentialsImpl implements GitCredentialsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateCredentialsResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateCredentialsResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class GitCredentialsImpl implements GitCredentialsService {
     String path = String.format("/api/2.0/git-credentials/%s", request.getCredentialId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteCredentialsResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteCredentialsResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class GitCredentialsImpl implements GitCredentialsService {
     String path = String.format("/api/2.0/git-credentials/%s", request.getCredentialId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetCredentialsResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetCredentialsResponse.class, headers);
   }
 
   @Override
@@ -45,7 +45,7 @@ class GitCredentialsImpl implements GitCredentialsService {
     String path = "/api/2.0/git-credentials";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListCredentialsResponse.class, headers);
+    return apiClient.execute("GET", path, null, ListCredentialsResponse.class, headers);
   }
 
   @Override
@@ -54,6 +54,6 @@ class GitCredentialsImpl implements GitCredentialsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateCredentialsResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateCredentialsResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/ReposImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/ReposImpl.java
@@ -21,7 +21,7 @@ class ReposImpl implements ReposService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.POST(path, request, CreateRepoResponse.class, headers);
+    return apiClient.execute("POST", path, request, CreateRepoResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class ReposImpl implements ReposService {
     String path = String.format("/api/2.0/repos/%s", request.getRepoId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    apiClient.DELETE(path, request, DeleteRepoResponse.class, headers);
+    apiClient.execute("DELETE", path, request, DeleteRepoResponse.class, headers);
   }
 
   @Override
@@ -37,7 +37,7 @@ class ReposImpl implements ReposService {
     String path = String.format("/api/2.0/repos/%s", request.getRepoId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetRepoResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetRepoResponse.class, headers);
   }
 
   @Override
@@ -47,7 +47,7 @@ class ReposImpl implements ReposService {
         String.format("/api/2.0/permissions/repos/%s/permissionLevels", request.getRepoId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetRepoPermissionLevelsResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetRepoPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -55,7 +55,7 @@ class ReposImpl implements ReposService {
     String path = String.format("/api/2.0/permissions/repos/%s", request.getRepoId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, RepoPermissions.class, headers);
+    return apiClient.execute("GET", path, request, RepoPermissions.class, headers);
   }
 
   @Override
@@ -63,7 +63,7 @@ class ReposImpl implements ReposService {
     String path = "/api/2.0/repos";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListReposResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListReposResponse.class, headers);
   }
 
   @Override
@@ -72,7 +72,7 @@ class ReposImpl implements ReposService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, RepoPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, RepoPermissions.class, headers);
   }
 
   @Override
@@ -81,7 +81,7 @@ class ReposImpl implements ReposService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.PATCH(path, request, UpdateRepoResponse.class, headers);
+    apiClient.execute("PATCH", path, request, UpdateRepoResponse.class, headers);
   }
 
   @Override
@@ -90,6 +90,6 @@ class ReposImpl implements ReposService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, RepoPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, RepoPermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/ReposImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/ReposImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.workspace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Repos */
 @Generated
@@ -18,26 +19,41 @@ class ReposImpl implements ReposService {
   @Override
   public CreateRepoResponse create(CreateRepoRequest request) {
     String path = "/api/2.0/repos";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("POST", path, request, CreateRepoResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, CreateRepoResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void delete(DeleteRepoRequest request) {
     String path = String.format("/api/2.0/repos/%s", request.getRepoId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    apiClient.execute("DELETE", path, request, DeleteRepoResponse.class, headers);
+    try {
+      Request req = new Request("DELETE", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      apiClient.execute(req, DeleteRepoResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetRepoResponse get(GetRepoRequest request) {
     String path = String.format("/api/2.0/repos/%s", request.getRepoId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetRepoResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetRepoResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -45,51 +61,81 @@ class ReposImpl implements ReposService {
       GetRepoPermissionLevelsRequest request) {
     String path =
         String.format("/api/2.0/permissions/repos/%s/permissionLevels", request.getRepoId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetRepoPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetRepoPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RepoPermissions getPermissions(GetRepoPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/repos/%s", request.getRepoId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, RepoPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, RepoPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListReposResponse list(ListReposRequest request) {
     String path = "/api/2.0/repos";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListReposResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListReposResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RepoPermissions setPermissions(RepoPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/repos/%s", request.getRepoId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, RepoPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RepoPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void update(UpdateRepoRequest request) {
     String path = String.format("/api/2.0/repos/%s", request.getRepoId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("PATCH", path, request, UpdateRepoResponse.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, UpdateRepoResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public RepoPermissions updatePermissions(RepoPermissionsRequest request) {
     String path = String.format("/api/2.0/permissions/repos/%s", request.getRepoId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, RepoPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, RepoPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/SecretsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/SecretsImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.workspace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Secrets */
 @Generated
@@ -18,94 +19,149 @@ class SecretsImpl implements SecretsService {
   @Override
   public void createScope(CreateScope request) {
     String path = "/api/2.0/secrets/scopes/create";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, CreateScopeResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, CreateScopeResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteAcl(DeleteAcl request) {
     String path = "/api/2.0/secrets/acls/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteAclResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteAclResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteScope(DeleteScope request) {
     String path = "/api/2.0/secrets/scopes/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteScopeResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteScopeResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void deleteSecret(DeleteSecret request) {
     String path = "/api/2.0/secrets/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteSecretResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteSecretResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public AclItem getAcl(GetAclRequest request) {
     String path = "/api/2.0/secrets/acls/get";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, AclItem.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, AclItem.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public GetSecretResponse getSecret(GetSecretRequest request) {
     String path = "/api/2.0/secrets/get";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, GetSecretResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetSecretResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListAclsResponse listAcls(ListAclsRequest request) {
     String path = "/api/2.0/secrets/acls/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListAclsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListAclsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListScopesResponse listScopes() {
     String path = "/api/2.0/secrets/scopes/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, null, ListScopesResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListScopesResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListSecretsResponse listSecrets(ListSecretsRequest request) {
     String path = "/api/2.0/secrets/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListSecretsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListSecretsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void putAcl(PutAcl request) {
     String path = "/api/2.0/secrets/acls/put";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, PutAclResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PutAclResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void putSecret(PutSecret request) {
     String path = "/api/2.0/secrets/put";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, PutSecretResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, PutSecretResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/SecretsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/SecretsImpl.java
@@ -21,7 +21,7 @@ class SecretsImpl implements SecretsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, CreateScopeResponse.class, headers);
+    apiClient.execute("POST", path, request, CreateScopeResponse.class, headers);
   }
 
   @Override
@@ -30,7 +30,7 @@ class SecretsImpl implements SecretsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteAclResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteAclResponse.class, headers);
   }
 
   @Override
@@ -39,7 +39,7 @@ class SecretsImpl implements SecretsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteScopeResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteScopeResponse.class, headers);
   }
 
   @Override
@@ -48,7 +48,7 @@ class SecretsImpl implements SecretsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteSecretResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteSecretResponse.class, headers);
   }
 
   @Override
@@ -56,7 +56,7 @@ class SecretsImpl implements SecretsService {
     String path = "/api/2.0/secrets/acls/get";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, AclItem.class, headers);
+    return apiClient.execute("GET", path, request, AclItem.class, headers);
   }
 
   @Override
@@ -64,7 +64,7 @@ class SecretsImpl implements SecretsService {
     String path = "/api/2.0/secrets/get";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetSecretResponse.class, headers);
+    return apiClient.execute("GET", path, request, GetSecretResponse.class, headers);
   }
 
   @Override
@@ -72,7 +72,7 @@ class SecretsImpl implements SecretsService {
     String path = "/api/2.0/secrets/acls/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListAclsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListAclsResponse.class, headers);
   }
 
   @Override
@@ -80,7 +80,7 @@ class SecretsImpl implements SecretsService {
     String path = "/api/2.0/secrets/scopes/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, ListScopesResponse.class, headers);
+    return apiClient.execute("GET", path, null, ListScopesResponse.class, headers);
   }
 
   @Override
@@ -88,7 +88,7 @@ class SecretsImpl implements SecretsService {
     String path = "/api/2.0/secrets/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListSecretsResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListSecretsResponse.class, headers);
   }
 
   @Override
@@ -97,7 +97,7 @@ class SecretsImpl implements SecretsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, PutAclResponse.class, headers);
+    apiClient.execute("POST", path, request, PutAclResponse.class, headers);
   }
 
   @Override
@@ -106,6 +106,6 @@ class SecretsImpl implements SecretsService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, PutSecretResponse.class, headers);
+    apiClient.execute("POST", path, request, PutSecretResponse.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/WorkspaceImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/WorkspaceImpl.java
@@ -21,7 +21,7 @@ class WorkspaceImpl implements WorkspaceService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, DeleteResponse.class, headers);
+    apiClient.execute("POST", path, request, DeleteResponse.class, headers);
   }
 
   @Override
@@ -29,7 +29,7 @@ class WorkspaceImpl implements WorkspaceService {
     String path = "/api/2.0/workspace/export";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ExportResponse.class, headers);
+    return apiClient.execute("GET", path, request, ExportResponse.class, headers);
   }
 
   @Override
@@ -41,7 +41,8 @@ class WorkspaceImpl implements WorkspaceService {
             request.getWorkspaceObjectType(), request.getWorkspaceObjectId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, GetWorkspaceObjectPermissionLevelsResponse.class, headers);
+    return apiClient.execute(
+        "GET", path, request, GetWorkspaceObjectPermissionLevelsResponse.class, headers);
   }
 
   @Override
@@ -52,7 +53,7 @@ class WorkspaceImpl implements WorkspaceService {
             request.getWorkspaceObjectType(), request.getWorkspaceObjectId());
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, WorkspaceObjectPermissions.class, headers);
+    return apiClient.execute("GET", path, request, WorkspaceObjectPermissions.class, headers);
   }
 
   @Override
@@ -60,7 +61,7 @@ class WorkspaceImpl implements WorkspaceService {
     String path = "/api/2.0/workspace/get-status";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ObjectInfo.class, headers);
+    return apiClient.execute("GET", path, request, ObjectInfo.class, headers);
   }
 
   @Override
@@ -69,7 +70,7 @@ class WorkspaceImpl implements WorkspaceService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, ImportResponse.class, headers);
+    apiClient.execute("POST", path, request, ImportResponse.class, headers);
   }
 
   @Override
@@ -77,7 +78,7 @@ class WorkspaceImpl implements WorkspaceService {
     String path = "/api/2.0/workspace/list";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
-    return apiClient.GET(path, request, ListResponse.class, headers);
+    return apiClient.execute("GET", path, request, ListResponse.class, headers);
   }
 
   @Override
@@ -86,7 +87,7 @@ class WorkspaceImpl implements WorkspaceService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    apiClient.POST(path, request, MkdirsResponse.class, headers);
+    apiClient.execute("POST", path, request, MkdirsResponse.class, headers);
   }
 
   @Override
@@ -98,7 +99,7 @@ class WorkspaceImpl implements WorkspaceService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PUT(path, request, WorkspaceObjectPermissions.class, headers);
+    return apiClient.execute("PUT", path, request, WorkspaceObjectPermissions.class, headers);
   }
 
   @Override
@@ -110,6 +111,6 @@ class WorkspaceImpl implements WorkspaceService {
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    return apiClient.PATCH(path, request, WorkspaceObjectPermissions.class, headers);
+    return apiClient.execute("PATCH", path, request, WorkspaceObjectPermissions.class, headers);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/WorkspaceImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/workspace/WorkspaceImpl.java
@@ -2,9 +2,10 @@
 package com.databricks.sdk.service.workspace;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.support.Generated;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 /** Package-local implementation of Workspace */
 @Generated
@@ -18,18 +19,28 @@ class WorkspaceImpl implements WorkspaceService {
   @Override
   public void delete(Delete request) {
     String path = "/api/2.0/workspace/delete";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, DeleteResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, DeleteResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ExportResponse export(ExportRequest request) {
     String path = "/api/2.0/workspace/export";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ExportResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ExportResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -39,10 +50,14 @@ class WorkspaceImpl implements WorkspaceService {
         String.format(
             "/api/2.0/permissions/%s/%s/permissionLevels",
             request.getWorkspaceObjectType(), request.getWorkspaceObjectId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute(
-        "GET", path, request, GetWorkspaceObjectPermissionLevelsResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, GetWorkspaceObjectPermissionLevelsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -51,43 +66,68 @@ class WorkspaceImpl implements WorkspaceService {
         String.format(
             "/api/2.0/permissions/%s/%s",
             request.getWorkspaceObjectType(), request.getWorkspaceObjectId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, WorkspaceObjectPermissions.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, WorkspaceObjectPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ObjectInfo getStatus(GetStatusRequest request) {
     String path = "/api/2.0/workspace/get-status";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ObjectInfo.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ObjectInfo.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void importContent(Import request) {
     String path = "/api/2.0/workspace/import";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, ImportResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, ImportResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public ListResponse list(ListWorkspaceRequest request) {
     String path = "/api/2.0/workspace/list";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    return apiClient.execute("GET", path, request, ListResponse.class, headers);
+    try {
+      Request req = new Request("GET", path);
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      return apiClient.execute(req, ListResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
   public void mkdirs(Mkdirs request) {
     String path = "/api/2.0/workspace/mkdirs";
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    apiClient.execute("POST", path, request, MkdirsResponse.class, headers);
+    try {
+      Request req = new Request("POST", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      apiClient.execute(req, MkdirsResponse.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -96,10 +136,15 @@ class WorkspaceImpl implements WorkspaceService {
         String.format(
             "/api/2.0/permissions/%s/%s",
             request.getWorkspaceObjectType(), request.getWorkspaceObjectId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PUT", path, request, WorkspaceObjectPermissions.class, headers);
+    try {
+      Request req = new Request("PUT", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, WorkspaceObjectPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -108,9 +153,14 @@ class WorkspaceImpl implements WorkspaceService {
         String.format(
             "/api/2.0/permissions/%s/%s",
             request.getWorkspaceObjectType(), request.getWorkspaceObjectId());
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "application/json");
-    headers.put("Content-Type", "application/json");
-    return apiClient.execute("PATCH", path, request, WorkspaceObjectPermissions.class, headers);
+    try {
+      Request req = new Request("PATCH", path, apiClient.serialize(request));
+      ApiClient.setQuery(req, request);
+      req.withHeader("Accept", "application/json");
+      req.withHeader("Content-Type", "application/json");
+      return apiClient.execute(req, WorkspaceObjectPermissions.class);
+    } catch (IOException e) {
+      throw new DatabricksException("IO error: " + e.getMessage(), e);
+    }
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/ApiClientTest.java
@@ -65,9 +65,12 @@ public class ApiClientTest {
       ApiClient client, Request request, Class<? extends T> clazz, T expectedResponse) {
     T response;
     if (request.getMethod().equals(Request.GET)) {
-      response = client.GET(request.getUri().getPath(), clazz, Collections.emptyMap());
+      response =
+          client.execute("GET", request.getUri().getPath(), null, clazz, Collections.emptyMap());
     } else if (request.getMethod().equals(Request.POST)) {
-      response = client.POST(request.getUri().getPath(), request, clazz, Collections.emptyMap());
+      response =
+          client.execute(
+              "POST", request.getUri().getPath(), request, clazz, Collections.emptyMap());
     } else {
       throw new IllegalArgumentException("Unsupported method: " + request.getMethod());
     }
@@ -96,11 +99,15 @@ public class ApiClientTest {
     if (request.getMethod().equals(Request.GET)) {
       return assertThrows(
           exceptionClass,
-          () -> client.GET(request.getUri().getPath(), clazz, Collections.emptyMap()));
+          () ->
+              client.execute(
+                  "GET", request.getUri().getPath(), null, clazz, Collections.emptyMap()));
     } else if (request.getMethod().equals(Request.POST)) {
       return assertThrows(
           exceptionClass,
-          () -> client.POST(request.getUri().getPath(), request, clazz, Collections.emptyMap()));
+          () ->
+              client.execute(
+                  "POST", request.getUri().getPath(), request, clazz, Collections.emptyMap()));
     } else {
       throw new IllegalArgumentException("Unsupported method: " + request.getMethod());
     }
@@ -413,8 +420,12 @@ public class ApiClientTest {
         assertThrows(
             PrivateLinkValidationError.class,
             () ->
-                client.GET(
-                    req.getUri().getPath(), MyEndpointResponse.class, Collections.emptyMap()));
+                client.execute(
+                    "GET",
+                    req.getUri().getPath(),
+                    null,
+                    MyEndpointResponse.class,
+                    Collections.emptyMap()));
     assertTrue(e.getMessage().contains("AWS PrivateLink"));
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/service/apps/AppsImplTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/service/apps/AppsImplTest.java
@@ -1,0 +1,46 @@
+package com.databricks.sdk.service.apps;
+
+import com.databricks.sdk.core.ApiClient;
+import static org.mockito.ArgumentMatchers.*;
+import com.databricks.sdk.core.http.Request;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AppsImplTest {
+  @Test
+  public void testCreateAppIncludesNoComputeParameter() throws IOException {
+    ApiClient apiClient = Mockito.mock(ApiClient.class);
+    String expectedPath = "/api/2.0/apps";
+    when(apiClient.execute(any(), any())).thenReturn(null);
+    when(apiClient.serialize(any())).thenReturn("");
+
+    AppsService apps = new AppsImpl(apiClient);
+    apps.create(new CreateAppRequest().setNoCompute(true));
+
+    verify(apiClient)
+        .execute(
+            argThat(
+                (Request req) -> {
+                  if (!req.getMethod().equals("POST")) {
+                    return false;
+                  }
+                  if (!req.getUrl().equals(expectedPath)) {
+                    return false;
+                  }
+                  if (!req.getQuery().containsKey("no_compute")) {
+                    return false;
+                  }
+                  if (!req.getQuery().get("no_compute").get(0).equals("true")) {
+                    return false;
+                  }
+                  return true;
+                }),
+            eq(App.class));
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/service/jobs/JobsImplTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/service/jobs/JobsImplTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.databricks.sdk.core.ApiClient;
+import com.databricks.sdk.core.http.Request;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -16,74 +18,148 @@ public class JobsImplTest {
    */
 
   @Test
-  public void testJobsCreateUsesApi2_1() {
+  public void testJobsCreateUsesApi2_1() throws IOException {
     ApiClient apiClient = Mockito.mock(ApiClient.class);
     String expectedPath = "/api/2.1/jobs/create";
-    when(apiClient.POST(eq(expectedPath), any(), any(), any())).thenReturn(null);
+    when(apiClient.execute(any(), any())).thenReturn(null);
+    when(apiClient.serialize(any())).thenReturn("");
 
     JobsService jobs = new JobsImpl(apiClient);
     jobs.create(new CreateJob());
 
-    verify(apiClient).POST(eq(expectedPath), any(), any(), any());
+    verify(apiClient)
+        .execute(
+            argThat(
+                (Request req) -> {
+                  if (!req.getMethod().equals("POST")) {
+                    return false;
+                  }
+                  if (!req.getUrl().equals(expectedPath)) {
+                    return false;
+                  }
+                  return true;
+                }),
+            eq(CreateResponse.class));
   }
 
   @Test
-  public void testJobsGetUsesApi2_1() {
+  public void testJobsGetUsesApi2_1() throws IOException {
     ApiClient apiClient = Mockito.mock(ApiClient.class);
     String expectedPath = "/api/2.1/jobs/get";
-    when(apiClient.GET(eq(expectedPath), any(), any(), any())).thenReturn(null);
+    when(apiClient.execute(any(), any())).thenReturn(null);
 
     JobsService jobs = new JobsImpl(apiClient);
     jobs.get(new GetJobRequest());
 
-    verify(apiClient).GET(eq(expectedPath), any(), any(), any());
+    verify(apiClient)
+        .execute(
+            argThat(
+                (Request req) -> {
+                  if (!req.getMethod().equals("GET")) {
+                    return false;
+                  }
+                  if (!req.getUrl().equals(expectedPath)) {
+                    return false;
+                  }
+                  return true;
+                }),
+            eq(Job.class));
   }
 
   @Test
-  public void testJobsListUsesApi2_1() {
+  public void testJobsListUsesApi2_1() throws IOException {
     ApiClient apiClient = Mockito.mock(ApiClient.class);
     String expectedPath = "/api/2.1/jobs/list";
-    when(apiClient.GET(eq(expectedPath), any(), any(), any())).thenReturn(null);
+    when(apiClient.execute(any(), any())).thenReturn(null);
 
     JobsService jobs = new JobsImpl(apiClient);
     jobs.list(new ListJobsRequest());
 
-    verify(apiClient).GET(eq(expectedPath), any(), any(), any());
+    verify(apiClient)
+        .execute(
+            argThat(
+                (Request req) -> {
+                  if (!req.getMethod().equals("GET")) {
+                    return false;
+                  }
+                  if (!req.getUrl().equals(expectedPath)) {
+                    return false;
+                  }
+                  return true;
+                }),
+            eq(ListJobsResponse.class));
   }
 
   @Test
-  public void testJobsUpdateUsesApi2_1() {
+  public void testJobsUpdateUsesApi2_1() throws IOException {
     ApiClient apiClient = Mockito.mock(ApiClient.class);
     String expectedPath = "/api/2.1/jobs/update";
-    when(apiClient.POST(eq(expectedPath), any(), any(), any())).thenReturn(null);
+    when(apiClient.execute(any(), any())).thenReturn(null);
 
     JobsService jobs = new JobsImpl(apiClient);
     jobs.update(new UpdateJob());
 
-    verify(apiClient).POST(eq(expectedPath), any(), any(), any());
+    verify(apiClient)
+        .execute(
+            argThat(
+                (Request req) -> {
+                  if (!req.getMethod().equals("POST")) {
+                    return false;
+                  }
+                  if (!req.getUrl().equals(expectedPath)) {
+                    return false;
+                  }
+                  return true;
+                }),
+            eq(UpdateResponse.class));
   }
 
   @Test
-  public void testJobsResetUsesApi2_1() {
+  public void testJobsResetUsesApi2_1() throws IOException {
     ApiClient apiClient = Mockito.mock(ApiClient.class);
     String expectedPath = "/api/2.1/jobs/reset";
-    when(apiClient.POST(eq(expectedPath), any(), any(), any())).thenReturn(null);
+    when(apiClient.execute(any(), any())).thenReturn(null);
+    when(apiClient.serialize(any())).thenReturn("");
 
     JobsService jobs = new JobsImpl(apiClient);
     jobs.reset(new ResetJob());
 
-    verify(apiClient).POST(eq(expectedPath), any(), any(), any());
+    verify(apiClient)
+        .execute(
+            argThat(
+                (Request req) -> {
+                  if (!req.getMethod().equals("POST")) {
+                    return false;
+                  }
+                  if (!req.getUrl().equals(expectedPath)) {
+                    return false;
+                  }
+                  return true;
+                }),
+            eq(ResetResponse.class));
   }
 
   @Test
-  public void testJobsListRunsUsesApi2_1() {
+  public void testJobsListRunsUsesApi2_1() throws IOException {
     ApiClient apiClient = Mockito.mock(ApiClient.class);
     String expectedPath = "/api/2.1/jobs/runs/list";
-    when(apiClient.GET(eq(expectedPath), any(), any(), any())).thenReturn(null);
+    when(apiClient.execute(any(), any())).thenReturn(null);
 
     JobsService jobs = new JobsImpl(apiClient);
     jobs.listRuns(new ListRunsRequest());
 
-    verify(apiClient).GET(eq(expectedPath), any(), any(), any());
+    verify(apiClient)
+        .execute(
+            argThat(
+                (Request req) -> {
+                  if (!req.getMethod().equals("GET")) {
+                    return false;
+                  }
+                  if (!req.getUrl().equals(expectedPath)) {
+                    return false;
+                  }
+                  return true;
+                }),
+            eq(ListRunsResponse.class));
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
The Databricks API spec has two different styles of APIs, those where the request body is a field in the `Request` structure, and those where the request body is said structure (not counting the parameters passed via the URI path and query string). The former style of APIs was incorrectly implemented, preventing such APIs from using any query parameters.

Generally, the approach taken here is to move the construction of the request object into the autogenerated `Impl` classes and providing a fully materialized `Request` object to the `ApiClient`. To do so, we expose the `<T> T execute(Request in, Target Class<T>)` method as public.

Separately, I've removed the per-HTTP-method methods from `ApiClient`, opting instead to use the singular `execute`, as they purely create more maintenance burden for us and decrease the surface area we need to maintain.

## How is this tested?
Added `AppsImplTest` to verify that the no_compute flag is included in the request passed to the `ApiClient`.