### PR TITLE
[Internal] Add CICD environment to User Agent

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -166,7 +166,7 @@ public class UserAgent {
   // The 'volatile' keyword ensures that changes to these variables
   // are immediately visible to all threads. It prevents instruction
   // reordering by the compiler.
-  private static volatile String cicdProvider = null;
+  protected static volatile String cicdProvider = null;
 
   protected static Environment env = null;
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -160,12 +160,13 @@ public class UserAgent {
     );
   }
 
-  // Volatile fields to ensure thread-safe lazy initialization
+  // Volatile field to ensure thread-safe lazy initialization
   // The 'volatile' keyword ensures that changes to these variables
   // are immediately visible to all threads. It prevents instruction
   // reordering by the compiler.
-  protected static volatile String cicdProvider = null;
-  protected static volatile Environment env = null;
+  private static volatile String cicdProvider = null;
+
+  protected static Environment env = null;
 
   // Represents an environment variable with its name and expected value
   private static class EnvVar {
@@ -228,7 +229,7 @@ public class UserAgent {
     return cicdProvider;
   }
 
-  protected static Environment env() {
+  private static Environment env() {
     if (env == null) {
       env = new Environment(System.getenv(), System.getenv("PATH").split(File.pathSeparator), System.getProperty("os.name"));
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -142,22 +142,24 @@ public class UserAgent {
   // List of CI/CD providers and their environment variables for detection
   private static List<CicdProvider> listCiCdProviders() {
     return Arrays.asList(
-            new CicdProvider("github", Collections.singletonList(new EnvVar("GITHUB_ACTIONS", "true"))),
-            new CicdProvider("gitlab", Collections.singletonList(new EnvVar("GITLAB_CI", "true"))),
-            new CicdProvider("jenkins", Collections.singletonList(new EnvVar("JENKINS_URL", ""))),
-            new CicdProvider("azure-devops", Collections.singletonList(new EnvVar("TF_BUILD", "True"))),
-            new CicdProvider("circle", Collections.singletonList(new EnvVar("CIRCLECI", "true"))),
-            new CicdProvider("travis", Collections.singletonList(new EnvVar("TRAVIS", "true"))),
-            new CicdProvider("bitbucket", Collections.singletonList(new EnvVar("BITBUCKET_BUILD_NUMBER", ""))),
-            new CicdProvider("google-cloud-build", Arrays.asList(
-                    new EnvVar("PROJECT_ID", ""),
-                    new EnvVar("BUILD_ID", ""),
-                    new EnvVar("PROJECT_NUMBER", ""),
-                    new EnvVar("LOCATION", "")
-            )),
-            new CicdProvider("aws-code-build", Collections.singletonList(new EnvVar("CODEBUILD_BUILD_ARN", ""))),
-            new CicdProvider("tf-cloud", Collections.singletonList(new EnvVar("TFC_RUN_ID", "")))
-    );
+        new CicdProvider("github", Collections.singletonList(new EnvVar("GITHUB_ACTIONS", "true"))),
+        new CicdProvider("gitlab", Collections.singletonList(new EnvVar("GITLAB_CI", "true"))),
+        new CicdProvider("jenkins", Collections.singletonList(new EnvVar("JENKINS_URL", ""))),
+        new CicdProvider("azure-devops", Collections.singletonList(new EnvVar("TF_BUILD", "True"))),
+        new CicdProvider("circle", Collections.singletonList(new EnvVar("CIRCLECI", "true"))),
+        new CicdProvider("travis", Collections.singletonList(new EnvVar("TRAVIS", "true"))),
+        new CicdProvider(
+            "bitbucket", Collections.singletonList(new EnvVar("BITBUCKET_BUILD_NUMBER", ""))),
+        new CicdProvider(
+            "google-cloud-build",
+            Arrays.asList(
+                new EnvVar("PROJECT_ID", ""),
+                new EnvVar("BUILD_ID", ""),
+                new EnvVar("PROJECT_NUMBER", ""),
+                new EnvVar("LOCATION", ""))),
+        new CicdProvider(
+            "aws-code-build", Collections.singletonList(new EnvVar("CODEBUILD_BUILD_ARN", ""))),
+        new CicdProvider("tf-cloud", Collections.singletonList(new EnvVar("TFC_RUN_ID", ""))));
   }
 
   // Volatile field to ensure thread-safe lazy initialization
@@ -231,7 +233,11 @@ public class UserAgent {
 
   private static Environment env() {
     if (env == null) {
-      env = new Environment(System.getenv(), System.getenv("PATH").split(File.pathSeparator), System.getProperty("os.name"));
+      env =
+          new Environment(
+              System.getenv(),
+              System.getenv("PATH").split(File.pathSeparator),
+              System.getProperty("os.name"));
     }
     return env;
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -180,7 +180,7 @@ public class UserAgent {
     }
 
     public boolean detect() {
-      String value = System.getProperty(name);
+      String value = System.getenv(name);
       return value != null && (expectedValue.isEmpty() || value.equals(expectedValue));
     }
   }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -1,8 +1,8 @@
 package com.databricks.sdk.core;
 
+import com.databricks.sdk.core.utils.Environment;
 import java.util.ArrayList;
 import java.util.HashMap;
-import com.databricks.sdk.core.utils.Environment;
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,26 +65,39 @@ public class UserAgentTest {
 
   @Test
   public void testUserAgentCicdNoProvider() {
-    UserAgent.env = new Environment(new HashMap<>(), new ArrayList<>(), System.getProperty("os.name"));
+    UserAgent.env =
+        new Environment(new HashMap<>(), new ArrayList<>(), System.getProperty("os.name"));
     Assertions.assertFalse(UserAgent.asString().contains("cicd"));
     UserAgent.env = null;
   }
 
   @Test
   public void testUserAgentCicdOneProvider() {
-    UserAgent.env = new Environment(new HashMap<String, String>() {{
-      put("GITHUB_ACTIONS", "true");
-    }}, new ArrayList<>(), System.getProperty("os.name"));
+    UserAgent.env =
+        new Environment(
+            new HashMap<String, String>() {
+              {
+                put("GITHUB_ACTIONS", "true");
+              }
+            },
+            new ArrayList<>(),
+            System.getProperty("os.name"));
     Assertions.assertTrue(UserAgent.asString().contains("cicd/github"));
     UserAgent.env = null;
   }
 
   @Test
   public void testUserAgentCicdTwoProvider() {
-    UserAgent.env = new Environment(new HashMap<String, String>() {{
-      put("GITLAB_CI", "true");
-      put("JENKINS_URL", "");
-    }}, new ArrayList<>(), System.getProperty("os.name"));
+    UserAgent.env =
+        new Environment(
+            new HashMap<String, String>() {
+              {
+                put("GITLAB_CI", "true");
+                put("JENKINS_URL", "");
+              }
+            },
+            new ArrayList<>(),
+            System.getProperty("os.name"));
     Assertions.assertTrue(UserAgent.asString().contains("cicd/gitlab"));
     UserAgent.env = null;
   }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -1,9 +1,13 @@
 package com.databricks.sdk.core;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import java.util.Properties;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UserAgentTest {
+  private static final Logger log = LoggerFactory.getLogger(UserAgentTest.class);
+
   @Test
   public void testUserAgent() {
     UserAgent.withProduct("product", "productVersion");
@@ -55,5 +59,40 @@ public class UserAgentTest {
     UserAgent.withOtherInfo("key1", "1.0.0-dev+metadata");
     String userAgent = UserAgent.asString();
     Assertions.assertTrue(userAgent.contains("key1/1.0.0-dev+metadata"));
+  }
+
+  private Properties originalProperties;
+
+  @BeforeEach
+  public void clearCICD() {
+    // Save original system properties
+    originalProperties = (Properties) System.getProperties().clone();
+
+    // Clear all system properties
+    System.getProperties().clear();
+  }
+
+  @AfterEach
+  public void restoreProperties() {
+    // Restore original system properties
+    System.setProperties(originalProperties);
+  }
+
+  @Test
+  public void testUserAgentCicdNoProvider() {
+    Assertions.assertEquals("", UserAgent.cicdProvider());
+  }
+
+  @Test
+  public void testUserAgentCicdOneProvider() {
+    System.setProperty("GITHUB_ACTIONS", "true");
+    Assertions.assertEquals("github", UserAgent.cicdProvider());
+  }
+
+  @Test
+  public void testUserAgentCicdMultipleProviders() {
+    System.setProperty("GITHUB_ACTIONS", "true");
+    System.setProperty("GITLAB_CI", "true");
+    Assertions.assertEquals("github", UserAgent.cicdProvider());
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -64,12 +64,9 @@ public class UserAgentTest {
   private Properties originalProperties;
 
   @BeforeEach
-  public void clearCICD() {
+  public void saveProperties() {
     // Save original system properties
     originalProperties = (Properties) System.getProperties().clone();
-
-    // Clear all system properties
-    System.getProperties().clear();
   }
 
   @AfterEach

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -65,6 +65,7 @@ public class UserAgentTest {
 
   @Test
   public void testUserAgentCicdNoProvider() {
+    UserAgent.cicdProvider = null;
     UserAgent.env =
         new Environment(new HashMap<>(), new ArrayList<>(), System.getProperty("os.name"));
     Assertions.assertFalse(UserAgent.asString().contains("cicd"));
@@ -73,6 +74,7 @@ public class UserAgentTest {
 
   @Test
   public void testUserAgentCicdOneProvider() {
+    UserAgent.cicdProvider = null;
     UserAgent.env =
         new Environment(
             new HashMap<String, String>() {
@@ -88,6 +90,7 @@ public class UserAgentTest {
 
   @Test
   public void testUserAgentCicdTwoProvider() {
+    UserAgent.cicdProvider = null;
     UserAgent.env =
         new Environment(
             new HashMap<String, String>() {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -3,13 +3,10 @@ package com.databricks.sdk.core;
 import com.databricks.sdk.core.utils.Environment;
 import java.util.ArrayList;
 import java.util.HashMap;
-import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class UserAgentTest {
-  private static final Logger log = LoggerFactory.getLogger(UserAgentTest.class);
-
   @Test
   public void testUserAgent() {
     UserAgent.withProduct("product", "productVersion");


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds CI/CD environment to the User Agent of each SDK outbound request. The implementation is similar to the one used in the Go SDK. This is useful to track how often and from which CI/CD platforms our tools are being run.

## How is this tested?

Added unit tests.
