### PR TITLE
[Internal] Update Jobs `list` function to support paginated responses

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Documentation
 
 ### Internal Changes
+* Update Jobs ListJobs API to support paginated responses ([#411](https://github.com/databricks/databricks-sdk-java/pull/411))
 * Introduce automated tagging ([#409](https://github.com/databricks/databricks-sdk-java/pull/409)).
 * Update Jobs GetJob API to support paginated responses  ([#403](https://github.com/databricks/databricks-sdk-java/pull/403)).
 * Update Jobs GetRun API to support paginated responses  ([#402](https://github.com/databricks/databricks-sdk-java/pull/402)).

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
@@ -40,14 +40,22 @@ public class JobsExt extends JobsAPI {
           @Override
           public BaseJob next() {
             BaseJob job = iterator.next();
-            // fully fetch all top level arrays for the job
-            GetJobRequest getJobRequest = new GetJobRequest().setJobId(job.getJobId());
-            Job fullJob = get(getJobRequest);
-            job.getSettings().setTasks(fullJob.getSettings().getTasks());
-            job.getSettings().setJobClusters(fullJob.getSettings().getJobClusters());
-            job.getSettings().setParameters(fullJob.getSettings().getParameters());
-            job.getSettings().setEnvironments(fullJob.getSettings().getEnvironments());
-            job.setHasMore(false);
+
+            // The has_more field is only present in jobs with 100+ tasks, that is served from Jobs
+            // API 2.2.
+            // Extra tasks and other fields need to be fetched only when has_more is true.
+            if (job.getHasMore() != null && job.getHasMore()) {
+              // fully fetch all top level arrays for the job
+              GetJobRequest getJobRequest = new GetJobRequest().setJobId(job.getJobId());
+              Job fullJob = get(getJobRequest);
+              job.getSettings().setTasks(fullJob.getSettings().getTasks());
+              job.getSettings().setJobClusters(fullJob.getSettings().getJobClusters());
+              job.getSettings().setParameters(fullJob.getSettings().getParameters());
+              job.getSettings().setEnvironments(fullJob.getSettings().getEnvironments());
+            }
+            // Set the has_more field to false to indicate that there are no more tasks and other
+            // fields to fetch.
+            job.setHasMore(null);
             return job;
           }
         };

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
@@ -15,7 +15,14 @@ public class JobsExt extends JobsAPI {
     super(mock);
   }
 
+  /**
+   * List jobs.
+   *
+   * <p>Retrieves a list of jobs. If the job has multiple pages of tasks, job_clusters, parameters or environments,
+   *         it will paginate through all pages and aggregate the results.
+   */
   public Iterable<BaseJob> list(ListJobsRequest request) {
+    // fetch jobs with limited elements in top level arrays
     Iterable<BaseJob> jobsList =  super.list(request);
 
     if (!request.getExpandTasks()) {
@@ -32,6 +39,7 @@ public class JobsExt extends JobsAPI {
       @Override
       public BaseJob next() {
         BaseJob job = iterator.next();
+        // fully fetch all top level arrays for the job
         GetJobRequest getJobRequest = new GetJobRequest().setJobId(job.getJobId());
         Job fullJob = get(getJobRequest);
         job.getSettings().setTasks(fullJob.getSettings().getTasks());

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
@@ -18,37 +18,38 @@ public class JobsExt extends JobsAPI {
   /**
    * List jobs.
    *
-   * <p>Retrieves a list of jobs. If the job has multiple pages of tasks, job_clusters, parameters or environments,
-   *         it will paginate through all pages and aggregate the results.
+   * <p>Retrieves a list of jobs. If the job has multiple pages of tasks, job_clusters, parameters
+   * or environments, it will paginate through all pages and aggregate the results.
    */
   public Iterable<BaseJob> list(ListJobsRequest request) {
     // fetch jobs with limited elements in top level arrays
-    Iterable<BaseJob> jobsList =  super.list(request);
+    Iterable<BaseJob> jobsList = super.list(request);
 
     if (!request.getExpandTasks()) {
       return jobsList;
     }
 
     Iterator<BaseJob> iterator = jobsList.iterator();
-    return () -> new Iterator<BaseJob>() {
-      @Override
-      public boolean hasNext() {
-        return iterator.hasNext();
-      }
+    return () ->
+        new Iterator<BaseJob>() {
+          @Override
+          public boolean hasNext() {
+            return iterator.hasNext();
+          }
 
-      @Override
-      public BaseJob next() {
-        BaseJob job = iterator.next();
-        // fully fetch all top level arrays for the job
-        GetJobRequest getJobRequest = new GetJobRequest().setJobId(job.getJobId());
-        Job fullJob = get(getJobRequest);
-        job.getSettings().setTasks(fullJob.getSettings().getTasks());
-        job.getSettings().setJobClusters(fullJob.getSettings().getJobClusters());
-        job.getSettings().setParameters(fullJob.getSettings().getParameters());
-        job.getSettings().setEnvironments(fullJob.getSettings().getEnvironments());
-        return job;
-      }
-    };
+          @Override
+          public BaseJob next() {
+            BaseJob job = iterator.next();
+            // fully fetch all top level arrays for the job
+            GetJobRequest getJobRequest = new GetJobRequest().setJobId(job.getJobId());
+            Job fullJob = get(getJobRequest);
+            job.getSettings().setTasks(fullJob.getSettings().getTasks());
+            job.getSettings().setJobClusters(fullJob.getSettings().getJobClusters());
+            job.getSettings().setParameters(fullJob.getSettings().getParameters());
+            job.getSettings().setEnvironments(fullJob.getSettings().getEnvironments());
+            return job;
+          }
+        };
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
@@ -47,6 +47,7 @@ public class JobsExt extends JobsAPI {
             job.getSettings().setJobClusters(fullJob.getSettings().getJobClusters());
             job.getSettings().setParameters(fullJob.getSettings().getParameters());
             job.getSettings().setEnvironments(fullJob.getSettings().getEnvironments());
+            job.setHasMore(false);
             return job;
           }
         };

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/JobsExtTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/JobsExtTest.java
@@ -244,9 +244,17 @@ public class JobsExtTest {
   @Test
   public void testListJobs() {
     JobsService service = Mockito.mock(JobsService.class);
-    BaseJob job1 = new BaseJob().setJobId(100L).setSettings(new JobSettings().setName("job1"));
+    BaseJob job1 =
+        new BaseJob()
+            .setJobId(100L)
+            .setSettings(new JobSettings().setName("job1"))
+            .setHasMore(true);
     addTasks(job1, "job1_taskKey1", "job1_taskKey2");
-    BaseJob job2 = new BaseJob().setJobId(200L).setSettings(new JobSettings().setName("job2"));
+    BaseJob job2 =
+        new BaseJob()
+            .setJobId(200L)
+            .setSettings(new JobSettings().setName("job2"))
+            .setHasMore(true);
     addTasks(job2, "job2_taskKey1", "job2_taskKey2");
 
     Job getJob1_page1 =
@@ -311,10 +319,16 @@ public class JobsExtTest {
     Iterable<BaseJob> jobsList = jobsExt.list(request);
 
     BaseJob expectedJob1 =
-        new BaseJob().setJobId(100L).setSettings(new JobSettings().setName("job1"));
+        new BaseJob()
+            .setJobId(100L)
+            .setSettings(new JobSettings().setName("job1"))
+            .setHasMore(false);
     addTasks(expectedJob1, "job1_taskKey1", "job1_taskKey2", "job1_taskKey3", "job1_taskKey4");
     BaseJob expectedJob2 =
-        new BaseJob().setJobId(200L).setSettings(new JobSettings().setName("job2"));
+        new BaseJob()
+            .setJobId(200L)
+            .setSettings(new JobSettings().setName("job2"))
+            .setHasMore(false);
     addTasks(expectedJob2, "job2_taskKey1", "job2_taskKey2", "job2_taskKey3", "job2_taskKey4");
     List<BaseJob> expectedJobsList = new ArrayList<>();
     expectedJobsList.add(expectedJob1);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/JobsExtTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/JobsExtTest.java
@@ -218,8 +218,8 @@ public class JobsExtTest {
     jobsOnSecondPage.add(job3);
     jobsOnSecondPage.add(job4);
     when(service.list(any()))
-            .thenReturn(new ListJobsResponse().setJobs(jobsOnFirstPage))
-            .thenReturn(new ListJobsResponse().setJobs(jobsOnSecondPage));
+        .thenReturn(new ListJobsResponse().setJobs(jobsOnFirstPage))
+        .thenReturn(new ListJobsResponse().setJobs(jobsOnSecondPage));
     JobsExt jobsExt = new JobsExt(service);
 
     ListJobsRequest request = new ListJobsRequest().setExpandTasks(false);
@@ -231,7 +231,8 @@ public class JobsExtTest {
     expectedJobsList.add(job3);
     expectedJobsList.add(job4);
     for (BaseJob job : jobsList) {
-      BaseJob expectedJob = expectedJobsList.stream()
+      BaseJob expectedJob =
+          expectedJobsList.stream()
               .filter(e -> e.getJobId().equals(job.getJobId()))
               .findFirst()
               .orElse(null);
@@ -248,30 +249,56 @@ public class JobsExtTest {
     BaseJob job2 = new BaseJob().setJobId(200L).setSettings(new JobSettings().setName("job2"));
     addTasks(job2, "job2_taskKey1", "job2_taskKey2");
 
-    Job getJob1_page1 = new Job()
+    Job getJob1_page1 =
+        new Job()
             .setJobId(100L)
             .setNextPageToken("job1_page2token")
             .setSettings(new JobSettings().setName("job1"));
     addTasks(getJob1_page1, "job1_taskKey1", "job1_taskKey2");
-    Job getJob1_page2 = new Job()
-            .setJobId(100L)
-            .setSettings(new JobSettings().setName("job1"));
+    Job getJob1_page2 = new Job().setJobId(100L).setSettings(new JobSettings().setName("job1"));
     addTasks(getJob1_page2, "job1_taskKey3", "job1_taskKey4");
 
-    Job getJob2_page1 = new Job()
+    Job getJob2_page1 =
+        new Job()
             .setJobId(200L)
             .setNextPageToken("job2_page2token")
             .setSettings(new JobSettings().setName("job2"));
     addTasks(getJob2_page1, "job2_taskKey1", "job2_taskKey2");
-    Job getJob2_page2 = new Job()
-            .setJobId(200L)
-            .setSettings(new JobSettings().setName("job2"));
+    Job getJob2_page2 = new Job().setJobId(200L).setSettings(new JobSettings().setName("job2"));
     addTasks(getJob2_page2, "job2_taskKey3", "job2_taskKey4");
 
-    doReturn(getJob1_page1).when(service).get(argThat(request -> request != null && request.getJobId() == 100L && request.getPageToken() == null));
-    doReturn(getJob1_page2).when(service).get(argThat(request -> request != null && request.getJobId() == 100L && "job1_page2token".equals(request.getPageToken())));
-    doReturn(getJob2_page1).when(service).get(argThat(request -> request != null && request.getJobId() == 200L && request.getPageToken() == null));
-    doReturn(getJob2_page2).when(service).get(argThat(request -> request != null && request.getJobId() == 200L && "job2_page2token".equals(request.getPageToken())));
+    doReturn(getJob1_page1)
+        .when(service)
+        .get(
+            argThat(
+                request ->
+                    request != null
+                        && request.getJobId() == 100L
+                        && request.getPageToken() == null));
+    doReturn(getJob1_page2)
+        .when(service)
+        .get(
+            argThat(
+                request ->
+                    request != null
+                        && request.getJobId() == 100L
+                        && "job1_page2token".equals(request.getPageToken())));
+    doReturn(getJob2_page1)
+        .when(service)
+        .get(
+            argThat(
+                request ->
+                    request != null
+                        && request.getJobId() == 200L
+                        && request.getPageToken() == null));
+    doReturn(getJob2_page2)
+        .when(service)
+        .get(
+            argThat(
+                request ->
+                    request != null
+                        && request.getJobId() == 200L
+                        && "job2_page2token".equals(request.getPageToken())));
 
     List<BaseJob> jobsOnFirstPage = new ArrayList<>();
     jobsOnFirstPage.add(job1);
@@ -283,15 +310,18 @@ public class JobsExtTest {
     ListJobsRequest request = new ListJobsRequest().setExpandTasks(true);
     Iterable<BaseJob> jobsList = jobsExt.list(request);
 
-    BaseJob expectedJob1 = new BaseJob().setJobId(100L).setSettings(new JobSettings().setName("job1"));
+    BaseJob expectedJob1 =
+        new BaseJob().setJobId(100L).setSettings(new JobSettings().setName("job1"));
     addTasks(expectedJob1, "job1_taskKey1", "job1_taskKey2", "job1_taskKey3", "job1_taskKey4");
-    BaseJob expectedJob2 = new BaseJob().setJobId(200L).setSettings(new JobSettings().setName("job2"));
+    BaseJob expectedJob2 =
+        new BaseJob().setJobId(200L).setSettings(new JobSettings().setName("job2"));
     addTasks(expectedJob2, "job2_taskKey1", "job2_taskKey2", "job2_taskKey3", "job2_taskKey4");
     List<BaseJob> expectedJobsList = new ArrayList<>();
     expectedJobsList.add(expectedJob1);
     expectedJobsList.add(expectedJob2);
     for (BaseJob job : jobsList) {
-      BaseJob expectedJob = expectedJobsList.stream()
+      BaseJob expectedJob =
+          expectedJobsList.stream()
               .filter(e -> e.getJobId().equals(job.getJobId()))
               .findFirst()
               .orElse(null);


### PR DESCRIPTION
## What changes are proposed in this pull request?
Introduces logic in the extension for jobs ListJobs call. The extended logic accounts for the new response format of API 2.2. API 2.1 format returns all tasks and job_cluster for each job in the jobs list. API 2.2 format truncates tasks and job_cluster to 100 elements. The extended ListJobs logic calls GetJob for each job in the list to populate the full list of tasks and job_clusters.

The code consumes iterator from `super.list` and produces iterator that contains already paginated jobs.

## How is this tested?
Unit tests. I can't do manual tests because I haven't figured out how to run the code locally.