### PR TITLE
[Internal] Update Jobs `listRuns` function to support paginated responses

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Documentation
 
 ### Internal Changes
+* Update Jobs ListRuns API to support paginated responses ([#410](https://github.com/databricks/databricks-sdk-java/pull/410))
 * Introduce automated tagging ([#409](https://github.com/databricks/databricks-sdk-java/pull/409)).
 * Update Jobs GetJob API to support paginated responses  ([#403](https://github.com/databricks/databricks-sdk-java/pull/403)).
 * Update Jobs GetRun API to support paginated responses  ([#402](https://github.com/databricks/databricks-sdk-java/pull/402)).

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
@@ -40,13 +40,19 @@ public class JobsExt extends JobsAPI {
           @Override
           public BaseRun next() {
             BaseRun run = iterator.next();
-            // fully fetch all top level arrays for the run
-            GetRunRequest getRunRequest = new GetRunRequest().setRunId(run.getRunId());
-            Run fullRun = getRun(getRunRequest);
-            run.setTasks(fullRun.getTasks());
-            run.setJobClusters(fullRun.getJobClusters());
-            run.setJobParameters(fullRun.getJobParameters());
-            run.setRepairHistory(fullRun.getRepairHistory());
+
+            // The has_more field is only present in run with 100+ tasks, that is served from Jobs API 2.2.
+            // Extra tasks and other fields need to be fetched only when has_more is true.
+            if (run.getHasMore() != null && run.getHasMore()) {
+              // fully fetch all top level arrays for the run
+              GetRunRequest getRunRequest = new GetRunRequest().setRunId(run.getRunId());
+              Run fullRun = getRun(getRunRequest);
+              run.setTasks(fullRun.getTasks());
+              run.setJobClusters(fullRun.getJobClusters());
+              run.setJobParameters(fullRun.getJobParameters());
+              run.setRepairHistory(fullRun.getRepairHistory());
+            }
+            // Set the has_more field to false to indicate that there are no more tasks and other fields to fetch.
             run.setHasMore(false);
             return run;
           }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
@@ -41,7 +41,8 @@ public class JobsExt extends JobsAPI {
           public BaseRun next() {
             BaseRun run = iterator.next();
 
-            // The has_more field is only present in run with 100+ tasks, that is served from Jobs API 2.2.
+            // The has_more field is only present in run with 100+ tasks, that is served from Jobs
+            // API 2.2.
             // Extra tasks and other fields need to be fetched only when has_more is true.
             if (run.getHasMore() != null && run.getHasMore()) {
               // fully fetch all top level arrays for the run
@@ -53,8 +54,10 @@ public class JobsExt extends JobsAPI {
               run.setRepairHistory(fullRun.getRepairHistory());
             }
             // Set the has_more fields to null.
-            // This field in Jobs API 2.2 is useful for pagination. It indicates if there are more than 100 tasks or job_clusters in the run.
-            // This function hides pagination details from the user. So the field does not play useful role here.
+            // This field in Jobs API 2.2 is useful for pagination. It indicates if there are more
+            // than 100 tasks or job_clusters in the run.
+            // This function hides pagination details from the user. So the field does not play
+            // useful role here.
             run.setHasMore(null);
             return run;
           }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/JobsExt.java
@@ -52,8 +52,10 @@ public class JobsExt extends JobsAPI {
               run.setJobParameters(fullRun.getJobParameters());
               run.setRepairHistory(fullRun.getRepairHistory());
             }
-            // Set the has_more field to false to indicate that there are no more tasks and other fields to fetch.
-            run.setHasMore(false);
+            // Set the has_more fields to null.
+            // This field in Jobs API 2.2 is useful for pagination. It indicates if there are more than 100 tasks or job_clusters in the run.
+            // This function hides pagination details from the user. So the field does not play useful role here.
+            run.setHasMore(null);
             return run;
           }
         };

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/JobsExtTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/JobsExtTest.java
@@ -358,13 +358,13 @@ public class JobsExtTest {
     ListRunsRequest request = new ListRunsRequest().setExpandTasks(true);
     Iterable<BaseRun> runsList = jobsExt.listRuns(request);
 
-    BaseRun expectedRun1 = new BaseRun().setRunId(100L).setJobId(1L).setHasMore(false);
+    BaseRun expectedRun1 = new BaseRun().setRunId(100L).setJobId(1L);
     addTasks(expectedRun1, 101L, 102L, 103L, 104L, 105L);
-    BaseRun expectedRun2 = new BaseRun().setRunId(200L).setJobId(2L).setHasMore(false);
+    BaseRun expectedRun2 = new BaseRun().setRunId(200L).setJobId(2L);
     addTasks(expectedRun2, 201L, 202L, 203L);
-    BaseRun expectedRun3 = new BaseRun().setRunId(300L).setJobId(3L).setHasMore(false);
+    BaseRun expectedRun3 = new BaseRun().setRunId(300L).setJobId(3L);
     addTasks(expectedRun3, 301L);
-    BaseRun expectedRun4 = new BaseRun().setRunId(400L).setJobId(4L).setHasMore(false);
+    BaseRun expectedRun4 = new BaseRun().setRunId(400L).setJobId(4L);
     addTasks(expectedRun4, 401L, 402L, 403L, 404L);
     List<BaseRun> expectedRunsList = new ArrayList<>();
     expectedRunsList.add(expectedRun1);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/JobsExtTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/JobsExtTest.java
@@ -379,9 +379,9 @@ public class JobsExtTest {
               .orElse(null);
       assertEquals(expectedRun, run);
     }
-    // 3 getRun calls for run 100, 2 getRun calls for run 200, 1 getRun call for run 300, 2 getRun
+    // 3 getRun calls for run 100, 2 getRun calls for run 200, 0 getRun call for run 300, 2 getRun
     // calls for run 400
-    verify(service, times(8)).getRun(any());
+    verify(service, times(7)).getRun(any());
   }
 
   private void addTasks(BaseRun run, long... taskRunIds) {


### PR DESCRIPTION
## What changes are proposed in this pull request?
Introduces logic in the extension for jobs ListRuns call. The extended logic accounts for the new response format of API 2.2. API 2.1 format returns all tasks and job_cluster for each run in the jobs list. API 2.2 format truncates tasks and job_cluster to 100 elements. The extended ListRuns logic calls GetRun for each job in the list to populate the full list of tasks and job_clusters.

The code consumes iterator from `super.listRuns` and produces iterator that contains already paginated jobs.

## How is this tested?
Unit tests. I can't do manual tests because I haven't figured out how to run the code locally.