### PR TITLE
Add IDTokenSource Interface

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
@@ -1,22 +1,23 @@
 package com.databricks.sdk.core.oauth;
 
 /**
- * Represents an ID Token provided by an identity provider from an OAuth flow.
- * This token can later be exchanged for an access token.
+ * Represents an ID Token provided by an identity provider from an OAuth flow. This token can later
+ * be exchanged for an access token.
  */
 public class IDToken {
-    // The string value of the ID Token
-    private final String value;
+  // The string value of the ID Token
+  private final String value;
 
-    /**
-     * Constructs an IDToken with a value.
-     * @param value The ID Token string.
-     */
-    public IDToken(String value) {
-        this.value = value;
-    }
+  /**
+   * Constructs an IDToken with a value.
+   *
+   * @param value The ID Token string.
+   */
+  public IDToken(String value) {
+    this.value = value;
+  }
 
-    public String getValue() {
-        return value;
-    }
+  public String getValue() {
+    return value;
+  }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
@@ -1,0 +1,22 @@
+package com.databricks.sdk.core.oauth;
+
+/**
+ * Represents an ID Token provided by an identity provider from an OAuth flow.
+ * IDToken is a token that can be exchanged for an access token.
+ */
+public class IDToken {
+    // The string value of the ID Token
+    private final String value;
+
+    /**
+     * Constructs an IDToken with a value.
+     * @param value The ID Token string.
+     */
+    public IDToken(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
@@ -14,6 +14,9 @@ public class IDToken {
    * @param value The ID Token string.
    */
   public IDToken(String value) {
+    if (value == null || value.isEmpty()) {
+        throw new IllegalArgumentException("ID Token value cannot be null or empty");
+    }
     this.value = value;
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
@@ -15,11 +15,16 @@ public class IDToken {
    */
   public IDToken(String value) {
     if (value == null || value.isEmpty()) {
-        throw new IllegalArgumentException("ID Token value cannot be null or empty");
+      throw new IllegalArgumentException("ID Token value cannot be null or empty");
     }
     this.value = value;
   }
 
+  /**
+   * Returns the value of the ID Token.
+   *
+   * @return The string representation of the ID Token.
+   */
   public String getValue() {
     return value;
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
@@ -2,7 +2,7 @@ package com.databricks.sdk.core.oauth;
 
 /**
  * Represents an ID Token provided by an identity provider from an OAuth flow.
- * IDToken is a token that can be exchanged for an access token.
+ * This token can later be exchanged for an access token.
  */
 public class IDToken {
     // The string value of the ID Token

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDTokenSource.java
@@ -1,0 +1,14 @@
+package com.databricks.sdk.core.oauth;
+
+/**
+ * IDTokenSource is anything that returns an IDToken given an audience.
+ */
+public interface IDTokenSource {
+    /**
+     * Retrieves an ID Token for the specified audience.
+     *
+     * @param audience The intended recipient of the ID Token.
+     * @return An {@link IDToken} containing the token value.
+     */
+    IDToken getIDToken(String audience);
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDTokenSource.java
@@ -1,14 +1,12 @@
 package com.databricks.sdk.core.oauth;
 
-/**
- * IDTokenSource is anything that returns an IDToken given an audience.
- */
+/** IDTokenSource is anything that returns an IDToken given an audience. */
 public interface IDTokenSource {
-    /**
-     * Retrieves an ID Token for the specified audience.
-     *
-     * @param audience The intended recipient of the ID Token.
-     * @return An {@link IDToken} containing the token value.
-     */
-    IDToken getIDToken(String audience);
+  /**
+   * Retrieves an ID Token for the specified audience.
+   *
+   * @param audience The intended recipient of the ID Token.
+   * @return An {@link IDToken} containing the token value.
+   */
+  IDToken getIDToken(String audience);
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/IDTokenTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/IDTokenTest.java
@@ -1,0 +1,15 @@
+package com.databricks.sdk.core.oauth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+public class IDTokenTest {
+
+    private static final String accessToken = "testIdToken";
+
+    @Test
+    void createIDToken() {
+        IDToken idToken = new IDToken(accessToken);
+        assertEquals(accessToken, idToken.getValue());
+    }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/IDTokenTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/IDTokenTest.java
@@ -1,15 +1,16 @@
 package com.databricks.sdk.core.oauth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 
 public class IDTokenTest {
 
-    private static final String accessToken = "testIdToken";
+  private static final String accessToken = "testIdToken";
 
-    @Test
-    void createIDToken() {
-        IDToken idToken = new IDToken(accessToken);
-        assertEquals(accessToken, idToken.getValue());
-    }
+  @Test
+  void createIDToken() {
+    IDToken idToken = new IDToken(accessToken);
+    assertEquals(accessToken, idToken.getValue());
+  }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/IDTokenTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/IDTokenTest.java
@@ -1,6 +1,7 @@
 package com.databricks.sdk.core.oauth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,8 +10,13 @@ public class IDTokenTest {
   private static final String accessToken = "testIdToken";
 
   @Test
-  void createIDToken() {
+  void testIDTokenWithValue() {
     IDToken idToken = new IDToken(accessToken);
     assertEquals(accessToken, idToken.getValue());
+  }
+
+  @Test
+  void testIDTokenWithNullValue() {
+    assertThrows(IllegalArgumentException.class, () -> new IDToken(null));
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR adds the foundational components for OIDC support in the Databricks Java SDK:

**IDToken Class:** Encapsulates ID tokens from identity providers for OAuth flows.
**IDTokenSource** Interface: Defines a standard for retrieving ID tokens.

## How is this tested?
- Unit tests added for the IDToken class.
- IDTokenSource is not tested, as no implementation exists yet.

NO_CHANGELOG=true