### PR TITLE
[Fix] Fix parsing issue in ErrorDetail (#328)

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ErrorDetail.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ErrorDetail.java
@@ -26,7 +26,7 @@ public class ErrorDetail {
     this.type = type;
     this.reason = reason;
     this.domain = domain;
-    this.metadata = Collections.unmodifiableMap(metadata);
+    this.metadata = metadata != null ? Collections.unmodifiableMap(metadata) : null;
   }
 
   public String getType() {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/error/ApiErrorBodyDeserializationSuite.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/error/ApiErrorBodyDeserializationSuite.java
@@ -51,4 +51,15 @@ public class ApiErrorBodyDeserializationSuite {
     assertEquals(error.getErrorCode(), "theerrorcode");
     assertEquals(error.getMessage(), "themessage");
   }
+
+  @Test
+  void handleNullMetadataFieldInErrorResponse() throws JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    String rawResponse =
+        "{\"error_code\":\"METASTORE_DOES_NOT_EXIST\",\"message\":\"No metastore assigned for the current workspace.\",\"details\":[{\"@type\":\"type.googleapis.com/google.rpc.RequestInfo\",\"request_id\":\"1888e822-f1b5-4996-85eb-0d2b5cc402e6\",\"serving_data\":\"\"}]}";
+    ApiErrorBody error = mapper.readValue(rawResponse, ApiErrorBody.class);
+
+    assertEquals(error.getErrorCode(), "METASTORE_DOES_NOT_EXIST");
+    assertEquals(error.getMessage(), "No metastore assigned for the current workspace.");
+  }
 }


### PR DESCRIPTION
## This is a cherry picked change from the mainline fork 
commit - https://github.com/databricks/databricks-sdk-java/commit/841b34645d111f436dd5e75cde799630daf9f9d0
original PR - https://github.com/databricks/databricks-sdk-java/pull/328/commits/f40ec0fa237887f84f86a4af33eb44259e49642a

We need to pull this change into our fork because we are hitting this same issue now.

## Issue Description
Exceptions are not deserialized correctly, the message field contains the response JSON and the string 'Cannot construct instance of com.databricks.sdk.core.error.ErrorDetail, problem: Cannot invoke "Object.getClass()" because "m" is null'

## Changes
In ErrorDetails class, i added a null check before the unmodifiableMap is created.

## Tests
Created an unit test in ApiErrorBodyDeserializationSuite.java

## What changes are proposed in this pull request?

Provide the readers and reviewers with the information they need to understand
this PR in a comprehensive manner. 

Specifically, try to answer the two following questions:

- **WHAT** changes are being made in the PR? This should be a summary of the 
  major changes to allow the reader to quickly understand the PR without having
  to look at the code. 
- **WHY** are these changes needed? This should provide the context that the 
  reader might be missing. For example, were there any decisions behind the 
  change that are not reflected in the code itself? 

The “why part” is the most important of the two as it usually cannot be 
inferred from the code itself. A well-written PR description will help future
developers (including your future self) to know how to interact and update your
code.

## How is this tested?

Describe any tests you have done; especially if test tests are not part of
the unit tests (e.g. local tests).

**ALWAYS ANSWER THIS QUESTION:** Answer with "N/A" if tests are not applicable
to your PR (e.g. if the PR only modifies comments). Do not be afraid of 
answering "Not tested" if the PR has not been tested. Being clear about what 
has been done and not done provides important context to the reviewers. 