### PR TITLE
Add GitHub OIDC authentication support

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
@@ -100,9 +100,9 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
    * @param config The Databricks configuration containing OIDC settings
    */
   private void addOIDCCredentialsProviders(DatabricksConfig config) {
-    // TODO: refactor the code so that the IdTokenSources are created within the 
+    // TODO: refactor the code so that the IdTokenSources are created within the
     // configure call of their corresponding CredentialsProvider. This will allow
-    // us to simplify the code by validating IdTokenSources when they are created. 
+    // us to simplify the code by validating IdTokenSources when they are created.
     OpenIDConnectEndpoints endpoints = null;
     try {
       endpoints = config.getOidcEndpoints();

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
@@ -100,6 +100,9 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
    * @param config The Databricks configuration containing OIDC settings
    */
   private void addOIDCCredentialsProviders(DatabricksConfig config) {
+    // TODO: refactor the code so that the IdTokenSources are created within the 
+    // configure call of their corresponding CredentialsProvider. This will allow
+    // us to simplify the code by validating IdTokenSources when they are created. 
     OpenIDConnectEndpoints endpoints = null;
     try {
       endpoints = config.getOidcEndpoints();

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
@@ -2,7 +2,6 @@ package com.databricks.sdk.core;
 
 import com.databricks.sdk.core.oauth.*;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,48 +9,37 @@ import org.slf4j.LoggerFactory;
 public class DefaultCredentialsProvider implements CredentialsProvider {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultCredentialsProvider.class);
 
-  private static final List<Class<?>> providerClasses =
-      Arrays.asList(
-          PatCredentialsProvider.class,
-          BasicCredentialsProvider.class,
-          OAuthM2MServicePrincipalCredentialsProvider.class,
-          GithubOidcCredentialsProvider.class,
-          AzureGithubOidcCredentialsProvider.class,
-          AzureServicePrincipalCredentialsProvider.class,
-          AzureCliCredentialsProvider.class,
-          ExternalBrowserCredentialsProvider.class,
-          DatabricksCliCredentialsProvider.class,
-          NotebookNativeCredentialsProvider.class,
-          GoogleCredentialsCredentialsProvider.class,
-          GoogleIdCredentialsProvider.class);
-
-  private final List<CredentialsProvider> providers;
+  private List<CredentialsProvider> providers = new ArrayList<>();
 
   private String authType = "default";
+
+  private static class NamedIDTokenSource {
+    private final String name;
+    private final IDTokenSource idTokenSource;
+
+    public NamedIDTokenSource(String name, IDTokenSource idTokenSource) {
+      this.name = name;
+      this.idTokenSource = idTokenSource;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public IDTokenSource getIdTokenSource() {
+      return idTokenSource;
+    }
+  }
+
+  public DefaultCredentialsProvider() {}
 
   public String authType() {
     return authType;
   }
 
-  public DefaultCredentialsProvider() {
-    providers = new ArrayList<>();
-    for (Class<?> clazz : providerClasses) {
-      try {
-        providers.add((CredentialsProvider) clazz.newInstance());
-      } catch (NoClassDefFoundError | InstantiationException | IllegalAccessException e) {
-        LOG.warn(
-            "Failed to instantiate credentials provider: "
-                + clazz.getName()
-                + ", skipping. Cause: "
-                + e.getClass().getCanonicalName()
-                + ": "
-                + e.getMessage());
-      }
-    }
-  }
-
   @Override
   public synchronized HeaderFactory configure(DatabricksConfig config) {
+    addDefaultCredentialsProviders(config);
     for (CredentialsProvider provider : providers) {
       if (config.getAuthType() != null
           && !config.getAuthType().isEmpty()
@@ -79,5 +67,58 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
         "cannot configure default credentials, please check "
             + authFlowUrl
             + " to configure credentials for your preferred authentication method");
+  }
+
+  private void addOIDCCredentialsProviders(DatabricksConfig config) {
+    OpenIDConnectEndpoints endpoints = null;
+    try {
+      endpoints = config.getOidcEndpoints();
+    } catch (Exception e) {
+      LOG.warn("Failed to get OpenID Connect endpoints", e);
+    }
+
+    List<NamedIDTokenSource> namedIdTokenSources = new ArrayList<>();
+    namedIdTokenSources.add(
+        new NamedIDTokenSource(
+            "github-oidc",
+            new GithubIDTokenSource(
+                config.getActionsIdTokenRequestUrl(),
+                config.getActionsIdTokenRequestToken(),
+                config.getHttpClient())));
+    // Add new IDTokenSources and ID providers here. Example:
+    // namedIdTokenSources.add(new NamedIDTokenSource("custom-oidc", new CustomIDTokenSource(...)));
+
+    for (NamedIDTokenSource namedIdTokenSource : namedIdTokenSources) {
+      DatabricksOAuthTokenSource oauthTokenSource =
+          new DatabricksOAuthTokenSource.Builder(
+                  config.getClientId(),
+                  config.getHost(),
+                  endpoints,
+                  namedIdTokenSource.getIdTokenSource(),
+                  config.getHttpClient())
+              .audience(config.getTokenAudience())
+              .accountId(config.isAccountClient() ? config.getAccountId() : null)
+              .build();
+
+      providers.add(
+          new TokenSourceCredentialsProvider(oauthTokenSource, namedIdTokenSource.getName()));
+    }
+  }
+
+  private void addDefaultCredentialsProviders(DatabricksConfig config) {
+    providers.add(new PatCredentialsProvider());
+    providers.add(new BasicCredentialsProvider());
+    providers.add(new OAuthM2MServicePrincipalCredentialsProvider());
+
+    addOIDCCredentialsProviders(config);
+
+    providers.add(new AzureGithubOidcCredentialsProvider());
+    providers.add(new AzureServicePrincipalCredentialsProvider());
+    providers.add(new AzureCliCredentialsProvider());
+    providers.add(new ExternalBrowserCredentialsProvider());
+    providers.add(new DatabricksCliCredentialsProvider());
+    providers.add(new NotebookNativeCredentialsProvider());
+    providers.add(new GoogleCredentialsCredentialsProvider());
+    providers.add(new GoogleIdCredentialsProvider());
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
@@ -16,7 +16,7 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultCredentialsProvider.class);
 
   /* List of credential providers that will be tried in sequence */
-  private List<CredentialsProvider> providers;
+  private List<CredentialsProvider> providers = new ArrayList<>();
 
   /* The currently selected authentication type */
   private String authType = "default";
@@ -145,8 +145,11 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
    *
    * @param config The Databricks configuration to use for provider initialization
    */
-  private void addDefaultCredentialsProviders(DatabricksConfig config) {
-    providers = new ArrayList<>();
+  private synchronized void addDefaultCredentialsProviders(DatabricksConfig config) {
+    if (!providers.isEmpty()) {
+      return;
+    }
+
     providers.add(new PatCredentialsProvider());
     providers.add(new BasicCredentialsProvider());
     providers.add(new OAuthM2MServicePrincipalCredentialsProvider());

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
@@ -6,13 +6,25 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The DefaultCredentialsProvider is the primary authentication handler for the Databricks SDK. It
+ * implements a chain of responsibility pattern to manage multiple authentication methods, including
+ * Personal Access Tokens (PAT), OAuth, Azure, Google, and OpenID Connect (OIDC). The provider
+ * attempts each authentication method in sequence until a valid credential is obtained.
+ */
 public class DefaultCredentialsProvider implements CredentialsProvider {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultCredentialsProvider.class);
 
+  // List of credential providers that will be tried in sequence
   private List<CredentialsProvider> providers = new ArrayList<>();
 
+  // The currently selected authentication type
   private String authType = "default";
 
+  /**
+   * Internal class to associate an ID token source with a name for identification purposes. Used
+   * primarily for OIDC (OpenID Connect) authentication flows.
+   */
   private static class NamedIDTokenSource {
     private final String name;
     private final IDTokenSource idTokenSource;
@@ -33,10 +45,23 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
 
   public DefaultCredentialsProvider() {}
 
+  /**
+   * Returns the current authentication type being used
+   *
+   * @return String representing the authentication type
+   */
   public String authType() {
     return authType;
   }
 
+  /**
+   * Configures the credentials provider with the given Databricks configuration. This method tries
+   * each available credential provider in sequence until one succeeds.
+   *
+   * @param config The Databricks configuration containing authentication details
+   * @return HeaderFactory for making authenticated requests
+   * @throws DatabricksException if no valid credentials can be configured
+   */
   @Override
   public synchronized HeaderFactory configure(DatabricksConfig config) {
     addDefaultCredentialsProviders(config);
@@ -69,6 +94,11 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
             + " to configure credentials for your preferred authentication method");
   }
 
+  /**
+   * Adds OpenID Connect (OIDC) based credential providers to the list of available providers.
+   *
+   * @param config The Databricks configuration containing OIDC settings
+   */
   private void addOIDCCredentialsProviders(DatabricksConfig config) {
     OpenIDConnectEndpoints endpoints = null;
     try {
@@ -88,6 +118,7 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
     // Add new IDTokenSources and ID providers here. Example:
     // namedIdTokenSources.add(new NamedIDTokenSource("custom-oidc", new CustomIDTokenSource(...)));
 
+    // Configure OAuth token sources for each ID token source
     for (NamedIDTokenSource namedIdTokenSource : namedIdTokenSources) {
       DatabricksOAuthTokenSource oauthTokenSource =
           new DatabricksOAuthTokenSource.Builder(
@@ -105,11 +136,18 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
     }
   }
 
+  /**
+   * Initializes all available credential providers in the preferred order. The order of providers
+   * determines the authentication fallback sequence.
+   *
+   * @param config The Databricks configuration to use for provider initialization
+   */
   private void addDefaultCredentialsProviders(DatabricksConfig config) {
     providers.add(new PatCredentialsProvider());
     providers.add(new BasicCredentialsProvider());
     providers.add(new OAuthM2MServicePrincipalCredentialsProvider());
 
+    // Add OIDC-based providers
     addOIDCCredentialsProviders(config);
 
     providers.add(new AzureGithubOidcCredentialsProvider());

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
@@ -15,10 +15,10 @@ import org.slf4j.LoggerFactory;
 public class DefaultCredentialsProvider implements CredentialsProvider {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultCredentialsProvider.class);
 
-  // List of credential providers that will be tried in sequence
-  private List<CredentialsProvider> providers = new ArrayList<>();
+  /* List of credential providers that will be tried in sequence */
+  private List<CredentialsProvider> providers;
 
-  // The currently selected authentication type
+  /* The currently selected authentication type */
   private String authType = "default";
 
   /**
@@ -143,6 +143,7 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
    * @param config The Databricks configuration to use for provider initialization
    */
   private void addDefaultCredentialsProviders(DatabricksConfig config) {
+    providers = new ArrayList<>();
     providers.add(new PatCredentialsProvider());
     providers.add(new BasicCredentialsProvider());
     providers.add(new OAuthM2MServicePrincipalCredentialsProvider());

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/GithubIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/GithubIDTokenSource.java
@@ -1,0 +1,89 @@
+package com.databricks.sdk.core.oauth;
+
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.HttpClient;
+import com.databricks.sdk.core.http.Request;
+import com.databricks.sdk.core.http.Response;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Strings;
+import java.io.IOException;
+
+/** GithubIDTokenSource retrieves JWT Tokens from GitHub Actions. */
+public class GithubIDTokenSource implements IDTokenSource {
+  private final String actionsIDTokenRequestURL;
+  private final String actionsIDTokenRequestToken;
+  private final HttpClient httpClient;
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  /**
+   * Constructs a new GithubIDTokenSource.
+   *
+   * @param actionsIDTokenRequestURL The URL to request the ID token from GitHub Actions.
+   * @param actionsIDTokenRequestToken The token used to authenticate the request.
+   * @param httpClient The HTTP client to use for making requests.
+   */
+  public GithubIDTokenSource(
+      String actionsIDTokenRequestURL, String actionsIDTokenRequestToken, HttpClient httpClient) {
+    this.actionsIDTokenRequestURL = actionsIDTokenRequestURL;
+    this.actionsIDTokenRequestToken = actionsIDTokenRequestToken;
+    this.httpClient = httpClient;
+  }
+
+  @Override
+  public IDToken getIDToken(String audience) {
+    if (Strings.isNullOrEmpty(actionsIDTokenRequestURL)) {
+      throw new DatabricksException("Missing ActionsIDTokenRequestURL");
+    }
+    if (Strings.isNullOrEmpty(actionsIDTokenRequestToken)) {
+      throw new DatabricksException("Missing ActionsIDTokenRequestToken");
+    }
+    if (httpClient == null) {
+      throw new DatabricksException("HttpClient cannot be null");
+    }
+
+    String requestUrl = actionsIDTokenRequestURL;
+    if (!Strings.isNullOrEmpty(audience)) {
+      requestUrl = String.format("%s&audience=%s", requestUrl, audience);
+    }
+
+    Request req =
+        new Request("GET", requestUrl)
+            .withHeader("Authorization", "Bearer " + actionsIDTokenRequestToken);
+
+    Response resp;
+    try {
+      resp = httpClient.execute(req);
+    } catch (IOException e) {
+      throw new DatabricksException(
+          "Failed to request ID token from " + requestUrl + ": " + e.getMessage(), e);
+    }
+
+    if (resp.getStatusCode() != 200) {
+      throw new DatabricksException(
+          "Failed to request ID token: status code "
+              + resp.getStatusCode()
+              + ", response body: "
+              + resp.getBody().toString());
+    }
+
+    ObjectNode jsonResp;
+    try {
+      jsonResp = mapper.readValue(resp.getBody(), ObjectNode.class);
+    } catch (IOException e) {
+      throw new DatabricksException(
+          "Failed to request ID token: corrupted token: " + e.getMessage());
+    }
+
+    if (!jsonResp.has("value")) {
+      throw new DatabricksException("ID token response missing 'value' field");
+    }
+
+    String tokenValue = jsonResp.get("value").textValue();
+    if (Strings.isNullOrEmpty(tokenValue)) {
+      throw new DatabricksException("Received empty ID token from GitHub Actions");
+    }
+
+    return new IDToken(tokenValue);
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/GithubIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/GithubIDTokenSource.java
@@ -15,14 +15,14 @@ import java.io.IOException;
  * Actions environment.
  */
 public class GithubIDTokenSource implements IDTokenSource {
-  // URL endpoint for requesting ID tokens from GitHub Actions
+  /* URL endpoint for requesting ID tokens from GitHub Actions */
   private final String actionsIDTokenRequestURL;
-  // Authentication token required to request ID tokens from GitHub Actions
+  /* Authentication token required to request ID tokens from GitHub Actions */
   private final String actionsIDTokenRequestToken;
-  // HTTP client for making requests to GitHub Actions
+  /* HTTP client for making requests to GitHub Actions */
   private final HttpClient httpClient;
-  // JSON mapper for parsing response data
-  private final ObjectMapper mapper = new ObjectMapper();
+  /* JSON mapper for parsing response data */
+  private static final ObjectMapper mapper = new ObjectMapper();
 
   /**
    * Constructs a new GithubIDTokenSource.
@@ -100,11 +100,11 @@ public class GithubIDTokenSource implements IDTokenSource {
       throw new DatabricksException("ID token response missing 'value' field");
     }
 
-    String tokenValue = jsonResp.get("value").textValue();
-    if (Strings.isNullOrEmpty(tokenValue)) {
+    try {
+      String tokenValue = jsonResp.get("value").textValue();
+      return new IDToken(tokenValue);
+    } catch (IllegalArgumentException e) {
       throw new DatabricksException("Received empty ID token from GitHub Actions");
     }
-
-    return new IDToken(tokenValue);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/TokenSourceCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/TokenSourceCredentialsProvider.java
@@ -6,7 +6,14 @@ import com.databricks.sdk.core.HeaderFactory;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Base class for token-based credentials providers. */
+/**
+ * A credentials provider that uses a TokenSource to obtain and manage authentication tokens. This
+ * class serves as a base implementation for token-based authentication, handling the conversion of
+ * tokens into HTTP authorization headers.
+ *
+ * <p>The provider validates token availability during configuration and creates. appropriate
+ * authorization headers for API requests.
+ */
 public class TokenSourceCredentialsProvider implements CredentialsProvider {
   private final TokenSource tokenSource;
   private final String authType;
@@ -14,14 +21,23 @@ public class TokenSourceCredentialsProvider implements CredentialsProvider {
   /**
    * Creates a new TokenSourceCredentialsProvider with the specified token source and auth type.
    *
-   * @param tokenSource The token source to use for token exchange
-   * @param authType The authentication type string
+   * @param tokenSource The token source responsible for token acquisition and management.
+   * @param authType The authentication type identifier.
    */
   public TokenSourceCredentialsProvider(TokenSource tokenSource, String authType) {
     this.tokenSource = tokenSource;
     this.authType = authType;
   }
 
+  /**
+   * Configures the credentials provider and creates a HeaderFactory for generating authentication
+   * headers. This method validates token availability by attempting to obtain an access token
+   * before returning the HeaderFactory.
+   *
+   * @param config The Databricks configuration object.
+   * @return A HeaderFactory that generates "Bearer" token authorization headers, or null if token
+   *     acquisition fails.
+   */
   @Override
   public HeaderFactory configure(DatabricksConfig config) {
     try {
@@ -38,6 +54,12 @@ public class TokenSourceCredentialsProvider implements CredentialsProvider {
     }
   }
 
+  /**
+   * Returns the authentication type identifier for this credentials provider. This is used to
+   * identify the authentication method being used.
+   *
+   * @return The authentication type string
+   */
   @Override
   public String authType() {
     return authType;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/TokenSourceCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/TokenSourceCredentialsProvider.java
@@ -1,0 +1,45 @@
+package com.databricks.sdk.core.oauth;
+
+import com.databricks.sdk.core.CredentialsProvider;
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.HeaderFactory;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Base class for token-based credentials providers. */
+public class TokenSourceCredentialsProvider implements CredentialsProvider {
+  private final TokenSource tokenSource;
+  private final String authType;
+
+  /**
+   * Creates a new TokenSourceCredentialsProvider with the specified token source and auth type.
+   *
+   * @param tokenSource The token source to use for token exchange
+   * @param authType The authentication type string
+   */
+  public TokenSourceCredentialsProvider(TokenSource tokenSource, String authType) {
+    this.tokenSource = tokenSource;
+    this.authType = authType;
+  }
+
+  @Override
+  public HeaderFactory configure(DatabricksConfig config) {
+    try {
+      // Validate that we can get a token before returning the HeaderFactory
+      String accessToken = tokenSource.getToken().getAccessToken();
+
+      return () -> {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer " + accessToken);
+        return headers;
+      };
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  @Override
+  public String authType() {
+    return authType;
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
@@ -34,8 +34,7 @@ public class DatabricksAuthManualTest implements ConfigResolving {
             .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
     resolveConfig(config, env);
     Map<String, String> headers = config.authenticate();
-    assertEquals(
-        azureWorkspaceResourceId, headers.get("X-Databricks-Azure-Workspace-Resource-Id"));
+    assertEquals(azureWorkspaceResourceId, headers.get("X-Databricks-Azure-Workspace-Resource-Id"));
   }
 
   @Test

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
@@ -2,12 +2,17 @@ package com.databricks.sdk;
 
 import com.databricks.sdk.core.ConfigResolving;
 import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.DummyHttpClient;
 import com.databricks.sdk.core.utils.TestOSUtils;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DatabricksAuthManualTest implements ConfigResolving {
+  private DatabricksConfig createConfigWithMockClient() {
+    return new DatabricksConfig().setHttpClient(new DummyHttpClient());
+  }
+
   @Test
   void azureCliWorkspaceHeaderPresent() {
     StaticEnv env =
@@ -18,7 +23,7 @@ public class DatabricksAuthManualTest implements ConfigResolving {
     String azureWorkspaceResourceId =
         "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
     DatabricksConfig config =
-        new DatabricksConfig()
+        createConfigWithMockClient()
             .setAuthType("azure-cli")
             .setHost("https://x")
             .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
@@ -38,7 +43,7 @@ public class DatabricksAuthManualTest implements ConfigResolving {
     String azureWorkspaceResourceId =
         "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
     DatabricksConfig config =
-        new DatabricksConfig()
+        createConfigWithMockClient()
             .setAuthType("azure-cli")
             .setHost("https://x")
             .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
@@ -58,7 +63,7 @@ public class DatabricksAuthManualTest implements ConfigResolving {
     String azureWorkspaceResourceId =
         "/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123";
     DatabricksConfig config =
-        new DatabricksConfig()
+        createConfigWithMockClient()
             .setAuthType("azure-cli")
             .setHost("https://x")
             .setAzureWorkspaceResourceId(azureWorkspaceResourceId);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthManualTest.java
@@ -1,16 +1,21 @@
 package com.databricks.sdk;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
 import com.databricks.sdk.core.ConfigResolving;
 import com.databricks.sdk.core.DatabricksConfig;
-import com.databricks.sdk.core.DummyHttpClient;
+import com.databricks.sdk.core.http.HttpClient;
 import com.databricks.sdk.core.utils.TestOSUtils;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DatabricksAuthManualTest implements ConfigResolving {
+
   private DatabricksConfig createConfigWithMockClient() {
-    return new DatabricksConfig().setHttpClient(new DummyHttpClient());
+    HttpClient mockClient = mock(HttpClient.class);
+    return new DatabricksConfig().setHttpClient(mockClient);
   }
 
   @Test
@@ -29,7 +34,7 @@ public class DatabricksAuthManualTest implements ConfigResolving {
             .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
     resolveConfig(config, env);
     Map<String, String> headers = config.authenticate();
-    Assertions.assertEquals(
+    assertEquals(
         azureWorkspaceResourceId, headers.get("X-Databricks-Azure-Workspace-Resource-Id"));
   }
 
@@ -49,7 +54,7 @@ public class DatabricksAuthManualTest implements ConfigResolving {
             .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
     resolveConfig(config, env);
     Map<String, String> headers = config.authenticate();
-    Assertions.assertEquals("...", headers.get("X-Databricks-Azure-SP-Management-Token"));
+    assertEquals("...", headers.get("X-Databricks-Azure-SP-Management-Token"));
   }
 
   @Test
@@ -69,6 +74,6 @@ public class DatabricksAuthManualTest implements ConfigResolving {
             .setAzureWorkspaceResourceId(azureWorkspaceResourceId);
     resolveConfig(config, env);
     Map<String, String> headers = config.authenticate();
-    Assertions.assertNull(headers.get("X-Databricks-Azure-SP-Management-Token"));
+    assertNull(headers.get("X-Databricks-Azure-SP-Management-Token"));
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
@@ -4,22 +4,26 @@
 package com.databricks.sdk;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 import com.databricks.sdk.core.ConfigResolving;
 import com.databricks.sdk.core.DatabricksConfig;
-import com.databricks.sdk.core.DummyHttpClient;
+import com.databricks.sdk.core.http.HttpClient;
 import com.databricks.sdk.core.utils.GitHubUtils;
 import com.databricks.sdk.core.utils.TestOSUtils;
 import java.io.File;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
 
   private String errorMessageBase =
       "default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred authentication method";
 
   private DatabricksConfig createConfigWithMockClient() {
-    return new DatabricksConfig().setHttpClient(new DummyHttpClient());
+    return new DatabricksConfig().setHttpClient(mock(HttpClient.class));
   }
 
   public DatabricksAuthTest() {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
@@ -3,7 +3,9 @@
 
 package com.databricks.sdk;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.databricks.sdk.core.ConfigResolving;
@@ -13,17 +15,15 @@ import com.databricks.sdk.core.utils.GitHubUtils;
 import com.databricks.sdk.core.utils.TestOSUtils;
 import java.io.File;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
 
   private String errorMessageBase =
       "default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred authentication method";
 
   private DatabricksConfig createConfigWithMockClient() {
-    return new DatabricksConfig().setHttpClient(mock(HttpClient.class));
+    HttpClient mockClient = mock(HttpClient.class);
+    return new DatabricksConfig().setHttpClient(mockClient);
   }
 
   public DatabricksAuthTest() {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/DatabricksAuthTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.databricks.sdk.core.ConfigResolving;
 import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.DummyHttpClient;
 import com.databricks.sdk.core.utils.GitHubUtils;
 import com.databricks.sdk.core.utils.TestOSUtils;
 import java.io.File;
@@ -17,18 +18,20 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
   private String errorMessageBase =
       "default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred authentication method";
 
+  private DatabricksConfig createConfigWithMockClient() {
+    return new DatabricksConfig().setHttpClient(new DummyHttpClient());
+  }
+
   public DatabricksAuthTest() {
     setPermissionOnTestAz();
   }
 
   @Test
   public void testTestConfigNoParams() {
-
     raises(
         errorMessageBase,
         () -> {
-          DatabricksConfig config = new DatabricksConfig();
-
+          DatabricksConfig config = createConfigWithMockClient();
           config.authenticate();
         });
   }
@@ -40,7 +43,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
     raises(
         errorMessageBase + ". Config: host=https://x. Env: DATABRICKS_HOST",
         () -> {
-          DatabricksConfig config = new DatabricksConfig();
+          DatabricksConfig config = createConfigWithMockClient();
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -53,7 +56,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
     raises(
         errorMessageBase + ". Config: token=***. Env: DATABRICKS_TOKEN",
         () -> {
-          DatabricksConfig config = new DatabricksConfig();
+          DatabricksConfig config = createConfigWithMockClient();
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -63,7 +66,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
   public void testTestConfigHostTokenEnv() {
     // Set environment variables
     StaticEnv env = new StaticEnv().with("DATABRICKS_HOST", "x").with("DATABRICKS_TOKEN", "x");
-    DatabricksConfig config = new DatabricksConfig();
+    DatabricksConfig config = createConfigWithMockClient();
     resolveConfig(config, env);
     config.authenticate();
 
@@ -75,7 +78,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
   public void testTestConfigHostParamTokenEnv() {
     // Set environment variables
     StaticEnv env = new StaticEnv().with("DATABRICKS_TOKEN", "x");
-    DatabricksConfig config = new DatabricksConfig().setHost("https://x");
+    DatabricksConfig config = createConfigWithMockClient().setHost("https://x");
     resolveConfig(config, env);
     config.authenticate();
 
@@ -92,7 +95,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
         errorMessageBase
             + ". Config: username=x, password=***. Env: DATABRICKS_USERNAME, DATABRICKS_PASSWORD",
         () -> {
-          DatabricksConfig config = new DatabricksConfig();
+          DatabricksConfig config = createConfigWithMockClient();
           resolveConfig(config, env);
           config.authenticate();
 
@@ -108,7 +111,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("DATABRICKS_HOST", "x")
             .with("DATABRICKS_PASSWORD", "x")
             .with("DATABRICKS_USERNAME", "x");
-    DatabricksConfig config = new DatabricksConfig();
+    DatabricksConfig config = createConfigWithMockClient();
     resolveConfig(config, env);
     config.authenticate();
 
@@ -124,7 +127,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("DATABRICKS_HOST", "x")
             .with("DATABRICKS_PASSWORD", "x")
             .with("DATABRICKS_USERNAME", "x");
-    DatabricksConfig config = new DatabricksConfig().setHost("y");
+    DatabricksConfig config = createConfigWithMockClient().setHost("y");
     resolveConfig(config, env);
     config.authenticate();
 
@@ -136,7 +139,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
   public void testTestConfigBasicAuthMix() {
     // Set environment variables
     StaticEnv env = new StaticEnv().with("DATABRICKS_PASSWORD", "x");
-    DatabricksConfig config = new DatabricksConfig().setHost("y").setUsername("x");
+    DatabricksConfig config = createConfigWithMockClient().setHost("y").setUsername("x");
     resolveConfig(config, env);
     config.authenticate();
 
@@ -146,8 +149,8 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
 
   @Test
   public void testTestConfigBasicAuthAttrs() {
-
-    DatabricksConfig config = new DatabricksConfig().setHost("y").setUsername("x").setPassword("x");
+    DatabricksConfig config =
+        createConfigWithMockClient().setHost("y").setUsername("x").setPassword("x");
 
     config.authenticate();
 
@@ -167,7 +170,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
     raises(
         "validate: more than one authorization method configured: basic and pat. Config: host=x, token=***, username=x, password=***. Env: DATABRICKS_HOST, DATABRICKS_TOKEN, DATABRICKS_USERNAME, DATABRICKS_PASSWORD",
         () -> {
-          DatabricksConfig config = new DatabricksConfig();
+          DatabricksConfig config = createConfigWithMockClient();
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -182,7 +185,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("DATABRICKS_PASSWORD", "x")
             .with("DATABRICKS_TOKEN", "x")
             .with("DATABRICKS_USERNAME", "x");
-    DatabricksConfig config = new DatabricksConfig().setAuthType("basic");
+    DatabricksConfig config = createConfigWithMockClient().setAuthType("basic");
     resolveConfig(config, env);
     config.authenticate();
 
@@ -197,7 +200,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
     raises(
         errorMessageBase + ". Config: config_file=x. Env: DATABRICKS_CONFIG_FILE",
         () -> {
-          DatabricksConfig config = new DatabricksConfig();
+          DatabricksConfig config = createConfigWithMockClient();
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -210,7 +213,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
     raises(
         errorMessageBase + ". Config: host=https://x",
         () -> {
-          DatabricksConfig config = new DatabricksConfig().setHost("x");
+          DatabricksConfig config = createConfigWithMockClient().setHost("x");
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -223,7 +226,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
     raises(
         errorMessageBase,
         () -> {
-          DatabricksConfig config = new DatabricksConfig();
+          DatabricksConfig config = createConfigWithMockClient();
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -236,7 +239,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
         new StaticEnv()
             .with("DATABRICKS_CONFIG_PROFILE", "abc")
             .with("HOME", TestOSUtils.resource("/testdata/empty_default"));
-    DatabricksConfig config = new DatabricksConfig();
+    DatabricksConfig config = createConfigWithMockClient();
     resolveConfig(config, env);
     config.authenticate();
 
@@ -248,7 +251,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
   public void testTestConfigPatFromDatabricksCfg() {
     // Set environment variables
     StaticEnv env = new StaticEnv().with("HOME", TestOSUtils.resource("/testdata"));
-    DatabricksConfig config = new DatabricksConfig();
+    DatabricksConfig config = createConfigWithMockClient();
     resolveConfig(config, env);
     config.authenticate();
 
@@ -263,7 +266,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
         new StaticEnv()
             .with("DATABRICKS_CONFIG_PROFILE", "pat.with.dot")
             .with("HOME", TestOSUtils.resource("/testdata"));
-    DatabricksConfig config = new DatabricksConfig();
+    DatabricksConfig config = createConfigWithMockClient();
     resolveConfig(config, env);
     config.authenticate();
 
@@ -281,7 +284,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
     raises(
         errorMessageBase + ". Config: token=***, profile=nohost. Env: DATABRICKS_CONFIG_PROFILE",
         () -> {
-          DatabricksConfig config = new DatabricksConfig();
+          DatabricksConfig config = createConfigWithMockClient();
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -299,7 +302,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
         errorMessageBase
             + ". Config: token=***, profile=nohost. Env: DATABRICKS_TOKEN, DATABRICKS_CONFIG_PROFILE",
         () -> {
-          DatabricksConfig config = new DatabricksConfig();
+          DatabricksConfig config = createConfigWithMockClient();
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -316,7 +319,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
     raises(
         "validate: more than one authorization method configured: basic and pat. Config: token=***, username=x, profile=nohost. Env: DATABRICKS_USERNAME, DATABRICKS_CONFIG_PROFILE",
         () -> {
-          DatabricksConfig config = new DatabricksConfig();
+          DatabricksConfig config = createConfigWithMockClient();
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -324,9 +327,10 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
 
   @Test
   public void testTestConfigAzurePat() {
-
     DatabricksConfig config =
-        new DatabricksConfig().setHost("https://adb-xxx.y.azuredatabricks.net/").setToken("y");
+        createConfigWithMockClient()
+            .setHost("https://adb-xxx.y.azuredatabricks.net/")
+            .setToken("y");
 
     config.authenticate();
 
@@ -343,7 +347,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("HOME", TestOSUtils.resource("/testdata/azure"))
             .with("PATH", "testdata:/bin");
     DatabricksConfig config =
-        new DatabricksConfig()
+        createConfigWithMockClient()
             .setHost("https://adb-123.4.azuredatabricks.net")
             .setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
@@ -366,7 +370,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
         "default auth: azure-cli: cannot get access token: This is just a failing script.\n. Config: azure_workspace_resource_id=/sub/rg/ws",
         () -> {
           DatabricksConfig config =
-              new DatabricksConfig().setAzureWorkspaceResourceId("/sub/rg/ws");
+              createConfigWithMockClient().setAzureWorkspaceResourceId("/sub/rg/ws");
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -383,7 +387,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
         errorMessageBase + ". Config: azure_workspace_resource_id=/sub/rg/ws",
         () -> {
           DatabricksConfig config =
-              new DatabricksConfig().setAzureWorkspaceResourceId("/sub/rg/ws");
+              createConfigWithMockClient().setAzureWorkspaceResourceId("/sub/rg/ws");
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -400,7 +404,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
         "validate: more than one authorization method configured: azure and pat. Config: token=***, azure_workspace_resource_id=/sub/rg/ws",
         () -> {
           DatabricksConfig config =
-              new DatabricksConfig().setToken("x").setAzureWorkspaceResourceId("/sub/rg/ws");
+              createConfigWithMockClient().setToken("x").setAzureWorkspaceResourceId("/sub/rg/ws");
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -414,7 +418,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("HOME", TestOSUtils.resource("/testdata"))
             .with("PATH", "testdata:/bin");
     DatabricksConfig config =
-        new DatabricksConfig()
+        createConfigWithMockClient()
             .setHost("https://adb-123.4.azuredatabricks.net")
             .setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
@@ -434,7 +438,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("HOME", TestOSUtils.resource("/testdata/azure"))
             .with("PATH", "testdata:/bin");
     DatabricksConfig config =
-        new DatabricksConfig()
+        createConfigWithMockClient()
             .setHost("https://adb-123.4.azuredatabricks.net")
             .setAzureWorkspaceResourceId("/sub/rg/ws");
     resolveConfig(config, env);
@@ -457,7 +461,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
         "validate: more than one authorization method configured: azure and basic. Config: host=https://adb-123.4.azuredatabricks.net, username=x, azure_workspace_resource_id=/sub/rg/ws. Env: DATABRICKS_USERNAME",
         () -> {
           DatabricksConfig config =
-              new DatabricksConfig()
+              createConfigWithMockClient()
                   .setHost("https://adb-123.4.azuredatabricks.net")
                   .setAzureWorkspaceResourceId("/sub/rg/ws");
           resolveConfig(config, env);
@@ -475,7 +479,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
     raises(
         "resolve: testdata/corrupt/.databrickscfg has no DEFAULT profile configured. Config: profile=DEFAULT. Env: DATABRICKS_CONFIG_PROFILE",
         () -> {
-          DatabricksConfig config = new DatabricksConfig();
+          DatabricksConfig config = createConfigWithMockClient();
           resolveConfig(config, env);
           config.authenticate();
         });
@@ -490,7 +494,7 @@ public class DatabricksAuthTest implements GitHubUtils, ConfigResolving {
             .with("DATABRICKS_PASSWORD", "password")
             .with("DATABRICKS_TOKEN", "token")
             .with("DATABRICKS_USERNAME", "user");
-    DatabricksConfig config = new DatabricksConfig().setHost("x");
+    DatabricksConfig config = createConfigWithMockClient().setHost("x");
     resolveConfig(config, env);
     config.authenticate();
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/GithubIDTokenSourceTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/GithubIDTokenSourceTest.java
@@ -1,0 +1,154 @@
+package com.databricks.sdk.core.oauth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.HttpClient;
+import com.databricks.sdk.core.http.Request;
+import com.databricks.sdk.core.http.Response;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class GithubIDTokenSourceTest {
+  private static final String TEST_REQUEST_URL = "https://github.com/token";
+  private static final String TEST_REQUEST_TOKEN = "test-request-token";
+  private static final String TEST_ID_TOKEN = "test-id-token";
+  private static final String TEST_AUDIENCE = "test-audience";
+
+  @Mock private static HttpClient mockHttpClient;
+
+  private GithubIDTokenSource tokenSource;
+  private ObjectMapper mapper;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    MockitoAnnotations.openMocks(this);
+    mapper = new ObjectMapper();
+    tokenSource = new GithubIDTokenSource(TEST_REQUEST_URL, TEST_REQUEST_TOKEN, mockHttpClient);
+  }
+
+  @Test
+  void testSuccessfulTokenRetrieval() throws IOException {
+    // Prepare mock response
+    ObjectNode responseJson = mapper.createObjectNode();
+    responseJson.put("value", TEST_ID_TOKEN);
+    Response mockResponse = makeResponse(responseJson.toString(), 200);
+    when(mockHttpClient.execute(any(Request.class))).thenReturn(mockResponse);
+
+    // Test token retrieval
+    IDToken token = tokenSource.getIDToken(TEST_AUDIENCE);
+
+    assertNotNull(token);
+    assertEquals(TEST_ID_TOKEN, token.getValue());
+
+    // Verify the request was made with correct parameters
+    verify(mockHttpClient)
+        .execute(
+            argThat(
+                request -> {
+                  return request.getMethod().equals("GET")
+                      && request.getUrl().startsWith(TEST_REQUEST_URL)
+                      && request.getUrl().contains("audience=" + TEST_AUDIENCE)
+                      && request
+                          .getHeaders()
+                          .get("Authorization")
+                          .equals("Bearer " + TEST_REQUEST_TOKEN);
+                }));
+  }
+
+  @Test
+  void testSuccessfulTokenRetrievalWithoutAudience() throws IOException {
+    // Prepare mock response
+    ObjectNode responseJson = mapper.createObjectNode();
+    responseJson.put("value", TEST_ID_TOKEN);
+    Response mockResponse = makeResponse(responseJson.toString(), 200);
+    when(mockHttpClient.execute(any(Request.class))).thenReturn(mockResponse);
+
+    // Test token retrieval without audience
+    IDToken token = tokenSource.getIDToken("");
+
+    assertNotNull(token);
+    assertEquals(TEST_ID_TOKEN, token.getValue());
+
+    // Verify the request was made with correct parameters
+    verify(mockHttpClient)
+        .execute(
+            argThat(
+                request -> {
+                  return request.getMethod().equals("GET")
+                      && request.getUrl().equals(TEST_REQUEST_URL)
+                      && request
+                          .getHeaders()
+                          .get("Authorization")
+                          .equals("Bearer " + TEST_REQUEST_TOKEN);
+                }));
+  }
+
+  private static Stream<Arguments> provideInvalidConstructorParameters() {
+    return Stream.of(
+        Arguments.of("Missing Request URL", null, TEST_REQUEST_TOKEN, mockHttpClient),
+        Arguments.of("Missing Request Token", TEST_REQUEST_URL, null, mockHttpClient),
+        Arguments.of("Null HttpClient", TEST_REQUEST_URL, TEST_REQUEST_TOKEN, null));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("provideInvalidConstructorParameters")
+  void testInvalidConstructorParameters(
+      String testName, String requestUrl, String requestToken, HttpClient httpClient) {
+    GithubIDTokenSource invalidSource =
+        new GithubIDTokenSource(requestUrl, requestToken, httpClient);
+    assertThrows(DatabricksException.class, () -> invalidSource.getIDToken(TEST_AUDIENCE));
+  }
+
+  private static Stream<Arguments> provideHttpErrorScenarios() throws IOException {
+    HttpClient httpClientError = mock(HttpClient.class);
+    when(httpClientError.execute(any(Request.class))).thenThrow(new IOException("Network error"));
+
+    HttpClient nonSuccessClient = mock(HttpClient.class);
+    when(nonSuccessClient.execute(any(Request.class)))
+        .thenReturn(makeResponse("Error response", 400));
+
+    HttpClient invalidJsonClient = mock(HttpClient.class);
+    when(invalidJsonClient.execute(any(Request.class)))
+        .thenReturn(makeResponse("Invalid json", 200));
+
+    HttpClient missingTokenClient = mock(HttpClient.class);
+    when(missingTokenClient.execute(any(Request.class))).thenReturn(makeResponse("{}", 200));
+
+    HttpClient emptyTokenClient = mock(HttpClient.class);
+    when(emptyTokenClient.execute(any(Request.class)))
+        .thenReturn(makeResponse("{\"value\":\"\"}", 200));
+
+    return Stream.of(
+        Arguments.of("HTTP Client Error", httpClientError),
+        Arguments.of("Non-Success Status Code", nonSuccessClient),
+        Arguments.of("Invalid JSON Response", invalidJsonClient),
+        Arguments.of("Missing Token Value", missingTokenClient),
+        Arguments.of("Empty Token Value", emptyTokenClient));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("provideHttpErrorScenarios")
+  void testHttpErrorScenarios(String testName, HttpClient httpClient) {
+    GithubIDTokenSource source =
+        new GithubIDTokenSource(TEST_REQUEST_URL, TEST_REQUEST_TOKEN, httpClient);
+    assertThrows(DatabricksException.class, () -> source.getIDToken(TEST_AUDIENCE));
+  }
+
+  private static Response makeResponse(String body, int status) throws MalformedURLException {
+    return new Response(body, status, "status", new URL("https://databricks.com/"));
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/TokenSourceCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/TokenSourceCredentialsProviderTest.java
@@ -1,0 +1,72 @@
+package com.databricks.sdk.core.oauth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.HeaderFactory;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Tests for TokenSourceCredentialsProvider */
+class TokenSourceCredentialsProviderTest {
+  private TokenSourceCredentialsProvider provider;
+  private static final String TEST_AUTH_TYPE = "test-auth-type";
+  private static final String TEST_ACCESS_TOKEN_VALUE = "test-access-token";
+  private static final Token TEST_TOKEN =
+      new Token(TEST_ACCESS_TOKEN_VALUE, "Bearer", LocalDateTime.now().plusHours(1));
+
+  /** Tests token retrieval scenarios */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("provideTokenScenarios")
+  void testTokenScenarios(
+      String testName,
+      TokenSource mockTokenSource,
+      String expectedAuthHeader,
+      Exception expectedException) {
+    provider = new TokenSourceCredentialsProvider(mockTokenSource, TEST_AUTH_TYPE);
+    DatabricksConfig config = new DatabricksConfig();
+    HeaderFactory headerFactory = provider.configure(config);
+
+    if (expectedException != null) {
+      assertNull(headerFactory);
+    } else {
+      assertNotNull(headerFactory);
+      Map<String, String> headers = headerFactory.headers();
+      assertEquals(expectedAuthHeader, headers.get("Authorization"));
+    }
+    verify(mockTokenSource).getToken();
+    assertEquals(TEST_AUTH_TYPE, provider.authType());
+  }
+
+  /** Provides test scenarios */
+  private static Stream<Arguments> provideTokenScenarios() {
+    // Mock behaviour of successful token retrieval
+    TokenSource mockSuccessTokenSource = mock(TokenSource.class);
+    when(mockSuccessTokenSource.getToken()).thenReturn(TEST_TOKEN);
+
+    // Mock behaviour of failing token retrieval
+    TokenSource mockFailureTokenSource = mock(TokenSource.class);
+    when(mockFailureTokenSource.getToken())
+        .thenThrow(new DatabricksException("Token retrieval failed"));
+
+    return Stream.of(
+        // Success case
+        Arguments.of(
+            "Successful token retrieval",
+            mockSuccessTokenSource,
+            "Bearer " + TEST_ACCESS_TOKEN_VALUE,
+            null),
+        // Failure case
+        Arguments.of(
+            "Failed token retrieval",
+            mockFailureTokenSource,
+            null,
+            new DatabricksException("Token retrieval failed")));
+  }
+}

--- a/examples/docs/src/main/java/com/databricks/example/GithubOIDCAuthExample.java
+++ b/examples/docs/src/main/java/com/databricks/example/GithubOIDCAuthExample.java
@@ -8,20 +8,26 @@ import com.databricks.sdk.service.iam.Group;
 
 /**
  * Example demonstrating how to use GitHub OIDC authentication with Databricks.
+ * 
+ * IMPORTANT: This example only works when running within GitHub Actions.
  */
 public class GithubOIDCAuthExample {
 
     public static void main(String[] args) {
         // Create Databricks configuration with GitHub OIDC authentication
+        // Note: This configuration assumes the code is running in GitHub Actions
         DatabricksConfig config = new DatabricksConfig()
-        .setAuthType("github-oidc")
-        .setHost("https://accounts.cloud.databricks.com/")
-        .setAccountId("968367da-7edd-44f7-9dea-3e0b20b0ec97")
-        .setClientId("dd3b5d58-5a6e-45e3-a3ae-81d8f89fc6fd");
+            .setAuthType("github-oidc")  // Specifies GitHub OIDC as the authentication method
+            .setHost("<INSERT_HOST>")  // Databricks account URL
+            .setAccountId("<INSERT_ACCOUNT_ID>")  // Your Databricks account ID
+            .setClientId("<INSERT_CLIENT_ID>");  // Service Principal ID
 
+        // Initialize the Account client with the OIDC configuration
         AccountClient account = new AccountClient(config);
 
         try {
+            // Example: List all groups in the Databricks account
+            // This demonstrates that the OIDC authentication is working
             System.out.println("\nListing account groups:");
             Iterable<Group> groups = account.groups().list(new ListAccountGroupsRequest());
             for (Group group : groups) {

--- a/examples/docs/src/main/java/com/databricks/example/GithubOIDCAuthExample.java
+++ b/examples/docs/src/main/java/com/databricks/example/GithubOIDCAuthExample.java
@@ -2,6 +2,7 @@ package com.databricks.sdk.examples;
 
 import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.WorkspaceClient;
+import com.databricks.sdk.service.iam.User;
 
 /**
  * Example demonstrating how to use GitHub OIDC authentication with Databricks.
@@ -25,8 +26,8 @@ public class GithubOIDCAuthExample {
         WorkspaceClient workspace = new WorkspaceClient(config);
 
         try {
-            // Test the authentication by getting the current user
-            var currentUser = workspace.currentUser().me();
+            // Test the authentication by getting the current User
+            User currentUser = workspace.currentUser().me();
             System.out.println("Successfully authenticated as: " + currentUser.getUserName());
             
             // You can add more API calls here to test other functionality

--- a/examples/docs/src/main/java/com/databricks/example/GithubOIDCAuthExample.java
+++ b/examples/docs/src/main/java/com/databricks/example/GithubOIDCAuthExample.java
@@ -1,0 +1,42 @@
+package com.databricks.sdk.examples;
+
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.service.workspace.WorkspaceClient;
+
+/**
+ * Example demonstrating how to use GitHub OIDC authentication with Databricks.
+ * 
+ * This example assumes you have:
+ * 1. A Databricks workspace
+ * 2. A service principal configured with GitHub OIDC federation
+ * 3. The following environment variables set:
+ *    - DATABRICKS_HOST: Your Databricks workspace URL
+ *    - DATABRICKS_CLIENT_ID: Your service principal's client ID
+ *    - ACTIONS_ID_TOKEN_REQUEST_URL: GitHub Actions token request URL
+ *    - ACTIONS_ID_TOKEN_REQUEST_TOKEN: GitHub Actions token request token
+ */
+public class GithubOIDCAuthExample {
+    public static void main(String[] args) {
+        // Create Databricks configuration with GitHub OIDC authentication
+        DatabricksConfig config = new DatabricksConfig()
+            .setAuthType("github-oidc");
+
+        // Create a workspace client
+        WorkspaceClient workspace = new WorkspaceClient(config);
+
+        try {
+            // Test the authentication by getting the current user
+            var currentUser = workspace.currentUser().me();
+            System.out.println("Successfully authenticated as: " + currentUser.getUserName());
+            
+            // You can add more API calls here to test other functionality
+            // For example:
+            // var clusters = workspace.clusters().list();
+            // System.out.println("Available clusters: " + clusters);
+            
+        } catch (Exception e) {
+            System.err.println("Authentication failed: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+} 

--- a/examples/docs/src/main/java/com/databricks/example/GithubOIDCAuthExample.java
+++ b/examples/docs/src/main/java/com/databricks/example/GithubOIDCAuthExample.java
@@ -1,7 +1,7 @@
 package com.databricks.sdk.examples;
 
 import com.databricks.sdk.core.DatabricksConfig;
-import com.databricks.sdk.service.workspace.WorkspaceClient;
+import com.databricks.sdk.WorkspaceClient;
 
 /**
  * Example demonstrating how to use GitHub OIDC authentication with Databricks.

--- a/examples/docs/src/main/java/com/databricks/example/GithubOIDCAuthExample.java
+++ b/examples/docs/src/main/java/com/databricks/example/GithubOIDCAuthExample.java
@@ -1,43 +1,36 @@
-package com.databricks.sdk.examples;
+package com.databricks.example;
 
+import com.databricks.sdk.AccountClient;
 import com.databricks.sdk.core.DatabricksConfig;
-import com.databricks.sdk.WorkspaceClient;
 import com.databricks.sdk.service.iam.User;
+import com.databricks.sdk.service.iam.ListAccountGroupsRequest;
+import com.databricks.sdk.service.iam.Group;
 
 /**
  * Example demonstrating how to use GitHub OIDC authentication with Databricks.
- * 
- * This example assumes you have:
- * 1. A Databricks workspace
- * 2. A service principal configured with GitHub OIDC federation
- * 3. The following environment variables set:
- *    - DATABRICKS_HOST: Your Databricks workspace URL
- *    - DATABRICKS_CLIENT_ID: Your service principal's client ID
- *    - ACTIONS_ID_TOKEN_REQUEST_URL: GitHub Actions token request URL
- *    - ACTIONS_ID_TOKEN_REQUEST_TOKEN: GitHub Actions token request token
  */
 public class GithubOIDCAuthExample {
+
     public static void main(String[] args) {
         // Create Databricks configuration with GitHub OIDC authentication
         DatabricksConfig config = new DatabricksConfig()
-            .setAuthType("github-oidc");
+        .setAuthType("github-oidc")
+        .setHost("https://accounts.cloud.databricks.com/")
+        .setAccountId("968367da-7edd-44f7-9dea-3e0b20b0ec97")
+        .setClientId("dd3b5d58-5a6e-45e3-a3ae-81d8f89fc6fd");
 
-        // Create a workspace client
-        WorkspaceClient workspace = new WorkspaceClient(config);
+        AccountClient account = new AccountClient(config);
 
         try {
-            // Test the authentication by getting the current User
-            User currentUser = workspace.currentUser().me();
-            System.out.println("Successfully authenticated as: " + currentUser.getUserName());
-            
-            // You can add more API calls here to test other functionality
-            // For example:
-            // var clusters = workspace.clusters().list();
-            // System.out.println("Available clusters: " + clusters);
-            
+            System.out.println("\nListing account groups:");
+            Iterable<Group> groups = account.groups().list(new ListAccountGroupsRequest());
+            for (Group group : groups) {
+                System.out.println("- Group: " + group.getDisplayName() + " (ID: " + group.getId() + ")");
+            }
+
         } catch (Exception e) {
             System.err.println("Authentication failed: " + e.getMessage());
             e.printStackTrace();
         }
     }
-} 
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR adds support for GitHub OIDC (OpenID Connect) authentication in the Databricks SDK Java.

## Key Changes
- Added `GithubIDTokenSource` to retrieve JWT tokens from GitHub Actions environment
- Introduced new `TokenSourceCredentialsProvider` as a generic provider for token-based authentication flows
- Updated `DefaultCredentialsProvider` to support GitHub OIDC and restructured it to facilitate adding other identity providers
- Added an example demonstrating GitHub OIDC authentication with GitHub Actions

## How is this tested?
- Added unit tests for `GithubIDTokenSource` and `TokenSourceCredentialsProvider`
- Manually validated the authentication flow in a GitHub Actions workflow using the provided example

NO_CHANGELOG=true