### PR TITLE
Add support for OIDC ID token authentication using an environment variables and files

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -148,6 +148,14 @@ public class DatabricksConfig {
   @ConfigAttribute(env = "TOKEN_AUDIENCE")
   private String tokenAudience;
 
+  /** Path to the file containing an OIDC ID token. */
+  @ConfigAttribute(env = "DATABRICKS_OIDC_TOKEN_FILEPATH", auth = "file-oidc")
+  private String oidcTokenFilepath;
+
+  /** Environment variable name that contains an OIDC ID token. */
+  @ConfigAttribute(env = "DATABRICKS_OIDC_TOKEN_ENV", auth = "env-oidc")
+  private String oidcTokenEnv;
+
   public Environment getEnv() {
     return env;
   }
@@ -525,6 +533,24 @@ public class DatabricksConfig {
 
   public DatabricksConfig setTokenAudience(String tokenAudience) {
     this.tokenAudience = tokenAudience;
+    return this;
+  }
+
+  public String getOidcTokenFilepath() {
+    return oidcTokenFilepath;
+  }
+
+  public DatabricksConfig setOidcTokenFilepath(String oidcTokenFilepath) {
+    this.oidcTokenFilepath = oidcTokenFilepath;
+    return this;
+  }
+
+  public String getOidcTokenEnv() {
+    return oidcTokenEnv;
+  }
+
+  public DatabricksConfig setOidcTokenEnv(String oidcTokenEnv) {
+    this.oidcTokenEnv = oidcTokenEnv;
     return this;
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
@@ -1,6 +1,7 @@
 package com.databricks.sdk.core;
 
 import com.databricks.sdk.core.oauth.*;
+import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
@@ -111,6 +112,20 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
     }
 
     List<NamedIDTokenSource> namedIdTokenSources = new ArrayList<>();
+    namedIdTokenSources.add(
+        new NamedIDTokenSource(
+            "env-oidc",
+            new EnvVarIDTokenSource(
+                // Use configured environment variable name if set, otherwise default to
+                // DATABRICKS_OIDC_TOKEN
+                (Strings.isNullOrEmpty(config.getOidcTokenEnv()))
+                    ? "DATABRICKS_OIDC_TOKEN"
+                    : config.getOidcTokenEnv(),
+                config.getEnv())));
+
+    namedIdTokenSources.add(
+        new NamedIDTokenSource("file-oidc", new FileIDTokenSource(config.getOidcTokenFilepath())));
+
     namedIdTokenSources.add(
         new NamedIDTokenSource(
             "github-oidc",

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
@@ -118,7 +118,7 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
             new EnvVarIDTokenSource(
                 // Use configured environment variable name if set, otherwise default to
                 // DATABRICKS_OIDC_TOKEN
-                (Strings.isNullOrEmpty(config.getOidcTokenEnv()))
+                Strings.isNullOrEmpty(config.getOidcTokenEnv())
                     ? "DATABRICKS_OIDC_TOKEN"
                     : config.getOidcTokenEnv(),
                 config.getEnv())));

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
@@ -32,11 +32,8 @@ public class EnvVarIDTokenSource implements IDTokenSource {
    *
    * @param audience The intended recipient of the ID Token (unused in this implementation).
    * @return An {@link IDToken} containing the token value from the environment variable.
-   * @throws IllegalArgumentException if the environment variable name is null or empty, or the
-   *     environment is null.
+   * @throws IllegalArgumentException if the environment variable name is null or empty.
    * @throws DatabricksException if the environment variable is not set or is empty.
-   * @throws NullPointerException if the environment variable name is null.
-   * @throws ClassCastException if the environment variable name is not a String.
    */
   @Override
   public IDToken getIDToken(String audience) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
@@ -6,11 +6,6 @@ import com.google.common.base.Strings;
 
 /** Implementation of {@link IDTokenSource} that reads the ID token from an environment variable. */
 public class EnvVarIDTokenSource implements IDTokenSource {
-  private static final String ERROR_ENV_VAR_NULL_OR_EMPTY =
-      "Environment variable name cannot be null or empty";
-  private static final String ERROR_EMPTY_TOKEN =
-      "Received empty ID token from environment variable %s";
-
   /* The name of the environment variable to read the ID token from. */
   private final String envVarName;
   /* The environment to read variables from. */
@@ -38,14 +33,15 @@ public class EnvVarIDTokenSource implements IDTokenSource {
   @Override
   public IDToken getIDToken(String audience) {
     if (Strings.isNullOrEmpty(envVarName)) {
-      throw new IllegalArgumentException(ERROR_ENV_VAR_NULL_OR_EMPTY);
+      throw new IllegalArgumentException("Environment variable name cannot be null or empty");
     }
 
     try {
       String token = env.get(envVarName);
       return new IDToken(token);
     } catch (IllegalArgumentException e) {
-      throw new DatabricksException(String.format(ERROR_EMPTY_TOKEN, envVarName), e);
+      throw new DatabricksException(
+          String.format("Received empty ID token from environment variable %s", envVarName), e);
     }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
@@ -41,10 +41,12 @@ public class EnvVarIDTokenSource implements IDTokenSource {
       throw new IllegalArgumentException("Environment cannot be null");
     }
 
-    String token = env.get(envVarName);
-    if (Strings.isNullOrEmpty(token)) {
-      throw new DatabricksException("Missing environment variable: " + envVarName);
+    try {
+      String token = env.get(envVarName);
+      return new IDToken(token);
+    } catch (IllegalArgumentException e) {
+      throw new DatabricksException(
+          "Received empty ID token from environment variable " + envVarName);
     }
-    return new IDToken(token);
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
@@ -6,6 +6,11 @@ import com.google.common.base.Strings;
 
 /** Implementation of {@link IDTokenSource} that reads the ID token from an environment variable. */
 public class EnvVarIDTokenSource implements IDTokenSource {
+  private static final String ERROR_ENV_VAR_NULL_OR_EMPTY =
+      "Environment variable name cannot be null or empty";
+  private static final String ERROR_EMPTY_TOKEN =
+      "Received empty ID token from environment variable %s";
+
   /* The name of the environment variable to read the ID token from. */
   private final String envVarName;
   /* The environment to read variables from. */
@@ -30,23 +35,18 @@ public class EnvVarIDTokenSource implements IDTokenSource {
    * @throws IllegalArgumentException if the environment variable name is null or empty, or the
    *     environment is null.
    * @throws DatabricksException if the environment variable is not set or is empty.
-   * @throws ClassCastException if the environment variable is not valid type.
    */
   @Override
   public IDToken getIDToken(String audience) {
     if (Strings.isNullOrEmpty(envVarName)) {
-      throw new IllegalArgumentException("Environment variable name cannot be null or empty");
+      throw new IllegalArgumentException(ERROR_ENV_VAR_NULL_OR_EMPTY);
     }
 
     try {
       String token = env.get(envVarName);
       return new IDToken(token);
     } catch (IllegalArgumentException e) {
-      throw new DatabricksException(
-          "Received empty ID token from environment variable " + envVarName);
-    } catch (ClassCastException e) {
-      throw new DatabricksException(
-          "Environment variable " + envVarName + " has invalid type: " + e.getMessage(), e);
+      throw new DatabricksException(String.format(ERROR_EMPTY_TOKEN, envVarName), e);
     }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
@@ -30,6 +30,7 @@ public class EnvVarIDTokenSource implements IDTokenSource {
    * @throws IllegalArgumentException if the environment variable name is null or empty, or the
    *     environment is null.
    * @throws DatabricksException if the environment variable is not set or is empty.
+   * @throws ClassCastException if the environment variable is not valid type.
    */
   @Override
   public IDToken getIDToken(String audience) {
@@ -47,9 +48,9 @@ public class EnvVarIDTokenSource implements IDTokenSource {
     } catch (IllegalArgumentException e) {
       throw new DatabricksException(
           "Received empty ID token from environment variable " + envVarName);
-    } catch (RuntimeException e) {
+    } catch (ClassCastException e) {
       throw new DatabricksException(
-          "Failed to read environment variable " + envVarName + ": " + e.getMessage(), e);
+          "Environment variable " + envVarName + " has invalid type: " + e.getMessage(), e);
     }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
@@ -47,6 +47,9 @@ public class EnvVarIDTokenSource implements IDTokenSource {
     } catch (IllegalArgumentException e) {
       throw new DatabricksException(
           "Received empty ID token from environment variable " + envVarName);
+    } catch (RuntimeException e) {
+      throw new DatabricksException(
+          "Failed to read environment variable " + envVarName + ": " + e.getMessage(), e);
     }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
@@ -6,7 +6,9 @@ import com.google.common.base.Strings;
 
 /** Implementation of {@link IDTokenSource} that reads the ID token from an environment variable. */
 public class EnvVarIDTokenSource implements IDTokenSource {
+  /* The name of the environment variable to read the ID token from. */
   private final String envVarName;
+  /* The environment to read variables from. */
   private final Environment env;
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
@@ -35,6 +35,8 @@ public class EnvVarIDTokenSource implements IDTokenSource {
    * @throws IllegalArgumentException if the environment variable name is null or empty, or the
    *     environment is null.
    * @throws DatabricksException if the environment variable is not set or is empty.
+   * @throws NullPointerException if the environment variable name is null.
+   * @throws ClassCastException if the environment variable name is not a String.
    */
   @Override
   public IDToken getIDToken(String audience) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
@@ -38,10 +38,6 @@ public class EnvVarIDTokenSource implements IDTokenSource {
       throw new IllegalArgumentException("Environment variable name cannot be null or empty");
     }
 
-    if (env == null) {
-      throw new IllegalArgumentException("Environment cannot be null");
-    }
-
     try {
       String token = env.get(envVarName);
       return new IDToken(token);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSource.java
@@ -1,0 +1,48 @@
+package com.databricks.sdk.core.oauth;
+
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.utils.Environment;
+import com.google.common.base.Strings;
+
+/** Implementation of {@link IDTokenSource} that reads the ID token from an environment variable. */
+public class EnvVarIDTokenSource implements IDTokenSource {
+  private final String envVarName;
+  private final Environment env;
+
+  /**
+   * Creates a new EnvVarIDTokenSource that reads from the specified environment variable.
+   *
+   * @param envVarName The name of the environment variable to read the ID token from.
+   * @param env The environment to read variables from.
+   */
+  public EnvVarIDTokenSource(String envVarName, Environment env) {
+    this.envVarName = envVarName;
+    this.env = env;
+  }
+
+  /**
+   * Retrieves an ID Token from the environment variable.
+   *
+   * @param audience The intended recipient of the ID Token (unused in this implementation).
+   * @return An {@link IDToken} containing the token value from the environment variable.
+   * @throws IllegalArgumentException if the environment variable name is null or empty, or the
+   *     environment is null.
+   * @throws DatabricksException if the environment variable is not set or is empty.
+   */
+  @Override
+  public IDToken getIDToken(String audience) {
+    if (Strings.isNullOrEmpty(envVarName)) {
+      throw new IllegalArgumentException("Environment variable name cannot be null or empty");
+    }
+
+    if (env == null) {
+      throw new IllegalArgumentException("Environment cannot be null");
+    }
+
+    String token = env.get(envVarName);
+    if (Strings.isNullOrEmpty(token)) {
+      throw new DatabricksException("Missing environment variable: " + envVarName);
+    }
+    return new IDToken(token);
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/FileIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/FileIDTokenSource.java
@@ -16,6 +16,7 @@ import java.util.List;
  * @see IDTokenSource
  */
 public class FileIDTokenSource implements IDTokenSource {
+  /* The path to the file containing the ID token. */
   private final String filePath;
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/FileIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/FileIDTokenSource.java
@@ -56,12 +56,13 @@ public class FileIDTokenSource implements IDTokenSource {
         throw new DatabricksException("File " + filePath + " is empty");
       }
 
-      String token = lines.get(0).trim();
-      if (Strings.isNullOrEmpty(token)) {
-        throw new DatabricksException("File " + filePath + " is empty");
+      try {
+        String token = lines.get(0).trim();
+        return new IDToken(token);
+      } catch (IllegalArgumentException e) {
+        throw new DatabricksException("Received empty ID token from file " + filePath);
       }
 
-      return new IDToken(token);
     } catch (IOException e) {
       throw new DatabricksException(
           "Failed to read ID token from file " + filePath + ": " + e.getMessage(), e);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/FileIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/FileIDTokenSource.java
@@ -90,13 +90,14 @@ public class FileIDTokenSource implements IDTokenSource {
       throw new DatabricksException("File " + filePath + " is empty");
     }
 
+    String token;
     try {
-      String token;
-      try {
-        token = lines.get(0).trim();
-      } catch (IndexOutOfBoundsException e) {
-        throw new DatabricksException("Invalid token format in file " + filePath);
-      }
+      token = lines.get(0).trim();
+    } catch (IndexOutOfBoundsException e) {
+      throw new DatabricksException("Invalid token format in file " + filePath);
+    }
+
+    try {
       return new IDToken(token);
     } catch (IllegalArgumentException e) {
       throw new DatabricksException("Received empty ID token from file " + filePath);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/FileIDTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/FileIDTokenSource.java
@@ -76,13 +76,16 @@ public class FileIDTokenSource implements IDTokenSource {
       throw new DatabricksException("Invalid file path: " + filePath, e);
     }
 
+    boolean isFileExists;
     try {
-      if (!Files.exists(path)) {
-        throw new DatabricksException(String.format(ERROR_FILE_NOT_FOUND, filePath));
-      }
+      isFileExists = Files.exists(path);
     } catch (SecurityException e) {
       throw new DatabricksException(
           String.format(ERROR_SECURITY_CHECK, filePath, e.getMessage()), e);
+    }
+
+    if (!isFileExists) {
+      throw new DatabricksException(String.format(ERROR_FILE_NOT_FOUND, filePath));
     }
 
     List<String> rawLines;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/IDToken.java
@@ -12,6 +12,7 @@ public class IDToken {
    * Constructs an IDToken with a value.
    *
    * @param value The ID Token string.
+   * @throws IllegalArgumentException if the token value is null or empty.
    */
   public IDToken(String value) {
     if (value == null || value.isEmpty()) {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSourceTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSourceTest.java
@@ -1,0 +1,91 @@
+package com.databricks.sdk.core.oauth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.utils.Environment;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Tests for EnvVarIDTokenSource. */
+public class EnvVarIDTokenSourceTest {
+  private static final String TEST_ENV_VAR_NAME = "TEST_ID_TOKEN";
+  private static final String TEST_TOKEN = "test-id-token";
+  private static final String TEST_AUDIENCE = "test-audience";
+
+  private Environment createTestEnvironment(Map<String, String> envVars) {
+    return new Environment(envVars, new String[0], "test");
+  }
+
+  private static Stream<Arguments> provideTestCases() {
+    return Stream.of(
+        // Test case: Success case
+        Arguments.of(
+            "Success case",
+            TEST_ENV_VAR_NAME,
+            createEnvVars(TEST_ENV_VAR_NAME, TEST_TOKEN),
+            TEST_TOKEN,
+            null),
+        // Test case: Null environment variable name
+        Arguments.of(
+            "Null environment variable name",
+            null,
+            new HashMap<>(),
+            null,
+            IllegalArgumentException.class),
+        // Test case: Empty environment variable name
+        Arguments.of(
+            "Empty environment variable name",
+            "",
+            new HashMap<>(),
+            null,
+            IllegalArgumentException.class),
+        // Test case: Missing environment variable
+        Arguments.of(
+            "Missing environment variable",
+            TEST_ENV_VAR_NAME,
+            new HashMap<>(),
+            null,
+            DatabricksException.class),
+        // Test case: Empty token value
+        Arguments.of(
+            "Empty token value",
+            TEST_ENV_VAR_NAME,
+            createEnvVars(TEST_ENV_VAR_NAME, ""),
+            null,
+            DatabricksException.class),
+        // Test case: Null environment
+        Arguments.of(
+            "Null environment", TEST_ENV_VAR_NAME, null, null, IllegalArgumentException.class));
+  }
+
+  private static Map<String, String> createEnvVars(String key, String value) {
+    Map<String, String> envVars = new HashMap<>();
+    envVars.put(key, value);
+    return envVars;
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("provideTestCases")
+  void testGetIDToken(
+      String testName,
+      String envVarName,
+      Map<String, String> envVars,
+      String expectedToken,
+      Class<? extends Exception> expectedException) {
+    Environment env = envVars != null ? createTestEnvironment(envVars) : null;
+    EnvVarIDTokenSource source = new EnvVarIDTokenSource(envVarName, env);
+
+    if (expectedException != null) {
+      assertThrows(expectedException, () -> source.getIDToken(TEST_AUDIENCE));
+    } else {
+      IDToken token = source.getIDToken(TEST_AUDIENCE);
+      assertNotNull(token);
+      assertEquals(expectedToken, token.getValue());
+    }
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSourceTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/EnvVarIDTokenSourceTest.java
@@ -57,10 +57,7 @@ public class EnvVarIDTokenSourceTest {
             TEST_ENV_VAR_NAME,
             createEnvVars(TEST_ENV_VAR_NAME, ""),
             null,
-            DatabricksException.class),
-        // Test case: Null environment
-        Arguments.of(
-            "Null environment", TEST_ENV_VAR_NAME, null, null, IllegalArgumentException.class));
+            DatabricksException.class));
   }
 
   private static Map<String, String> createEnvVars(String key, String value) {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/FileIDTokenSourceTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/FileIDTokenSourceTest.java
@@ -48,7 +48,7 @@ public class FileIDTokenSourceTest {
     Path tokenFile = tempDir.resolve("token.txt");
     Files.write(tokenFile, fileContent.getBytes(StandardCharsets.UTF_8));
 
-    String filePathToRead = null;
+    String testPathToRead = null;
     // If fileToReadFrom is null, we want to simulate passing a null path to FileIDTokenSource (for
     // error cases).
     // If fileToReadFrom is an empty string, we want to simulate passing an empty path (also for
@@ -56,13 +56,13 @@ public class FileIDTokenSourceTest {
     // Otherwise, resolve the file name relative to the temp directory to get the full path.
     if (fileToReadFrom != null) {
       if (fileToReadFrom.equals("")) {
-        filePathToRead = "";
+        testPathToRead = "";
       } else {
-        filePathToRead = tempDir.resolve(fileToReadFrom).toString();
+        testPathToRead = tempDir.resolve(fileToReadFrom).toString();
       }
     }
 
-    FileIDTokenSource source = new FileIDTokenSource(filePathToRead);
+    FileIDTokenSource source = new FileIDTokenSource(testPathToRead);
 
     if (expectedException != null) {
       assertThrows(expectedException, () -> source.getIDToken(TEST_AUDIENCE));

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/FileIDTokenSourceTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/FileIDTokenSourceTest.java
@@ -1,0 +1,72 @@
+package com.databricks.sdk.core.oauth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.databricks.sdk.core.DatabricksException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Tests for FileIDTokenSource. */
+public class FileIDTokenSourceTest {
+  private static final String TEST_TOKEN = "test-id-token";
+  private static final String TEST_AUDIENCE = "test-audience";
+
+  @TempDir Path tempDir;
+
+  private Path createTestFile(String content) throws IOException {
+    Path file = tempDir.resolve("test-token.txt");
+    Files.write(file, content.getBytes(StandardCharsets.UTF_8));
+    return file;
+  }
+
+  private static Stream<Arguments> provideTestCases() {
+    return Stream.of(
+        // Test case name, file path (null means create temp file), file content, expected token,
+        // expected exception
+        Arguments.of("Valid token file", null, TEST_TOKEN, TEST_TOKEN, null),
+        Arguments.of("Token with whitespace", null, "  " + TEST_TOKEN + "  ", TEST_TOKEN, null),
+        Arguments.of("Empty file", null, "", null, DatabricksException.class),
+        Arguments.of("File with only whitespace", null, "   ", null, DatabricksException.class),
+        Arguments.of("Null file path", null, null, null, IllegalArgumentException.class),
+        Arguments.of("Empty file path", "", null, null, IllegalArgumentException.class),
+        Arguments.of(
+            "Non-existent file",
+            "/path/to/nonexistent/file.txt",
+            null,
+            null,
+            DatabricksException.class));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("provideTestCases")
+  void testGetIDToken(
+      String testName,
+      String filePath,
+      String fileContent,
+      String expectedToken,
+      Class<? extends Exception> expectedException)
+      throws IOException {
+    // If filePath is null, create a temporary test file
+    String actualFilePath = filePath;
+    if (filePath == null && fileContent != null) {
+      actualFilePath = createTestFile(fileContent).toString();
+    }
+
+    FileIDTokenSource source = new FileIDTokenSource(actualFilePath);
+
+    if (expectedException != null) {
+      assertThrows(expectedException, () -> source.getIDToken(TEST_AUDIENCE));
+    } else {
+      IDToken token = source.getIDToken(TEST_AUDIENCE);
+      assertNotNull(token);
+      assertEquals(expectedToken, token.getValue());
+    }
+  }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
Add Environment Variable and File-based ID Token Sources

## Key Changes
- Added `EnvVarIDTokenSource` to read ID tokens from environment variables
- Added `FileIDTokenSource` to read ID tokens from files
- Both implement the `IDTokenSource` interface for OIDC authentication
- Added envvar-oidc and file-oidc to the list of auth types

## How is this tested?
- Unit tests for both classes

NO_CHANGELOG=true