### PR TITLE
Add Support for Asynchronous Token Refresh

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,7 +3,12 @@
 ## Release v0.54.0
 
 ### New Features and Improvements
-
+* [Experimental] Add support for asynchronous token refresh ([#464](https://github.com/databricks/databricks-sdk-java/pull/465)).
+  Enable this feature by setting the environment variable:
+  ```bash
+  export DATABRICKS_ENABLE_EXPERIMENTAL_ASYNC_TOKEN_REFRESH=true
+  ```
+  Note: This feature and its configuration are experimental and may be removed in future releases.
 ### Bug Fixes
 
 ### Documentation

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/RefreshableTokenSource.java
@@ -45,7 +45,8 @@ public abstract class RefreshableTokenSource implements TokenSource {
   // The current OAuth token. May be null if not yet fetched.
   protected volatile Token token;
   // Whether asynchronous refresh is enabled.
-  private boolean asyncEnabled = false;
+  private boolean asyncEnabled =
+      Boolean.parseBoolean(System.getenv("DATABRICKS_ENABLE_EXPERIMENTAL_ASYNC_TOKEN_REFRESH"));
   // Duration before expiry to consider a token as 'stale'.
   private Duration staleDuration = DEFAULT_STALE_DURATION;
   // Additional buffer before expiry to consider a token as expired.


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR introduces a new environment variable `DATABRICKS_ENABLE_EXPERIMENTAL_ASYNC_TOKEN_REFRESH` to enable asynchronous token refresh in the Databricks SDK for Java. This feature improves performance by allowing token refresh operations to happen in the background, reducing latency for API calls.

This change activates the asynchronous refresh capability that was previously added in https://github.com/databricks/databricks-sdk-java/pull/455. When enabled, stale tokens will trigger a background refresh while expired tokens will still block until a new token is fetched.

### How to Enable Async Token Refresh
Set the environment variable:
```bash
export DATABRICKS_ENABLE_EXPERIMENTAL_ASYNC_TOKEN_REFRESH=true
```
This setting will be automatically picked up by the SDK and applied to all token refresh operations.

## How is this tested?
Manual verification that existing unit tests and integration tests pass with both async refresh disabled and enabled.