### PR TITLE
Fix U2M OAuth flows in Azure

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -725,8 +725,8 @@ public class DatabricksConfig {
 
   /**
    * Gets the default OAuth redirect URL. If one is not provided explicitly, uses
-   * http://localhost:8020, which is the default redirect URL for the default
-   * client ID (databricks-cli).
+   * http://localhost:8020, which is the default redirect URL for the default client ID
+   * (databricks-cli).
    *
    * @return The OAuth redirect URL to use
    */

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProvider.java
@@ -61,8 +61,7 @@ public class ExternalBrowserCredentialsProvider implements CredentialsProvider {
     try {
       if (tokenCache == null) {
         // Create a default FileTokenCache based on config
-        Path cachePath =
-            TokenCacheUtils.getCacheFilePath(config.getHost(), clientId, scopes);
+        Path cachePath = TokenCacheUtils.getCacheFilePath(config.getHost(), clientId, scopes);
         tokenCache = new FileTokenCache(cachePath);
       }
 
@@ -105,7 +104,11 @@ public class ExternalBrowserCredentialsProvider implements CredentialsProvider {
   }
 
   SessionCredentials performBrowserAuth(
-      DatabricksConfig config, String clientId, String clientSecret, List<String> scopes, TokenCache tokenCache)
+      DatabricksConfig config,
+      String clientId,
+      String clientSecret,
+      List<String> scopes,
+      TokenCache tokenCache)
       throws IOException {
     LOGGER.debug("Performing browser authentication");
     OAuthClient client =

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
@@ -165,15 +165,16 @@ public class OAuthClient {
   private static String urlEncode(String urlBase, Map<String, String> params) {
     String queryParams =
         params.entrySet().stream()
-            .map(entry -> {
-              try {
-                return URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.toString()) +
-                       "=" +
-                       URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.toString());
-              } catch (Exception e) {
-                throw new DatabricksException("Failed to URL encode parameters", e);
-              }
-            })
+            .map(
+                entry -> {
+                  try {
+                    return URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.toString())
+                        + "="
+                        + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.toString());
+                  } catch (Exception e) {
+                    throw new DatabricksException("Failed to URL encode parameters", e);
+                  }
+                })
             .collect(Collectors.joining("&"));
     return urlBase + "?" + queryParams;
   }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
@@ -436,7 +436,8 @@ public class ExternalBrowserCredentialsProviderTest {
         Mockito.spy(new ExternalBrowserCredentialsProvider(mockTokenCache));
     Mockito.doReturn(browserAuthCreds)
         .when(provider)
-        .performBrowserAuth(any(DatabricksConfig.class), any(), any(), any(List.class), any(TokenCache.class));
+        .performBrowserAuth(
+            any(DatabricksConfig.class), any(), any(), any(List.class), any(TokenCache.class));
 
     // Spy on the config to inject the endpoints
     DatabricksConfig spyConfig = Mockito.spy(config);
@@ -454,7 +455,8 @@ public class ExternalBrowserCredentialsProviderTest {
 
     // Verify performBrowserAuth was called since refresh failed
     Mockito.verify(provider, Mockito.times(1))
-        .performBrowserAuth(any(DatabricksConfig.class), any(), any(), any(List.class), any(TokenCache.class));
+        .performBrowserAuth(
+            any(DatabricksConfig.class), any(), any(), any(List.class), any(TokenCache.class));
 
     // Verify token was saved after browser auth (for the new token)
     Mockito.verify(mockTokenCache, Mockito.times(1)).save(any(Token.class));
@@ -497,7 +499,8 @@ public class ExternalBrowserCredentialsProviderTest {
         Mockito.spy(new ExternalBrowserCredentialsProvider(mockTokenCache));
     Mockito.doReturn(browserAuthCreds)
         .when(provider)
-        .performBrowserAuth(any(DatabricksConfig.class), any(), any(), any(List.class), any(TokenCache.class));
+        .performBrowserAuth(
+            any(DatabricksConfig.class), any(), any(), any(List.class), any(TokenCache.class));
 
     // Configure provider
     HeaderFactory headerFactory = provider.configure(config);
@@ -510,7 +513,8 @@ public class ExternalBrowserCredentialsProviderTest {
 
     // Verify performBrowserAuth was called since we had an invalid token
     Mockito.verify(provider, Mockito.times(1))
-        .performBrowserAuth(any(DatabricksConfig.class), any(), any(), any(List.class), any(TokenCache.class));
+        .performBrowserAuth(
+            any(DatabricksConfig.class), any(), any(), any(List.class), any(TokenCache.class));
 
     // Verify token was saved after browser auth (for the new token)
     Mockito.verify(mockTokenCache, Mockito.times(1)).save(any(Token.class));


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes some issues affecting the end-to-end workflow using External Browser auth in Azure. In addition to the base PR by @renaudhartert-db:
1. This corrects the default redirect URL for the Databricks CLI to http://localhost:8020, matching the Go SDK.
2. This fixes OAuth token caching to include the actual scopes requested in the hash (otherwise, if no scopes are requested, that is treated as `null` today, causing an NPE).
3. This removes legacy Azure-specific handling for U2M Auth, where we requested the 2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/user_impersonation permission. This is not needed anymore, since we login with the Databricks CLI App by default.
4. This fixes serialization of query parameters, using the standard UrlEncoder instead of the very approximate version replacing spaces with %20.
5. This changes the default scopes requested to be `offline_access` and `all-apis`, matching the defaults for the Go SDK & CLI.

## How is this tested?

I wrote a demo app using U2M OAuth to authenticate and make an API request:
```java
package com.databricks.sdk.demo;

import com.databricks.sdk.WorkspaceClient;
import com.databricks.sdk.core.DatabricksConfig;

public class App {
    public final static void main(String[] args) {
        DatabricksConfig config = new DatabricksConfig()
          .setHost("https://<azure workspace host>")
          .setAuthType("external-browser");
        WorkspaceClient client = new WorkspaceClient(config);

        System.out.println(client.currentUser().me());
    }
}
```
This succeeded.