### PR TITLE
Refactor SessionCredentials

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
@@ -159,7 +159,7 @@ public class Consent implements Serializable {
    * Launch a browser to collect an authorization code and exchange the code for an OAuth token.
    *
    * @return A {@code SessionCredentials} instance representing the retrieved OAuth token.
-   * @throws IOException if the webserver cannot be started, or if the browser cannot be opened
+   * @throws IOException if the webserver cannot be started, or if the browser cannot be opened.
    */
   public SessionCredentials launchExternalBrowser() throws IOException {
     Map<String, String> params = getOAuthCallbackParameters();
@@ -170,7 +170,7 @@ public class Consent implements Serializable {
    * Exchange callback parameters for OAuth credentials.
    *
    * @param query The callback parameters from the OAuth flow
-   * @return A {@code SessionCredentials} instance representing the retrieved OAuth token
+   * @return A {@code SessionCredentials} instance representing the retrieved OAuth token.
    */
   public SessionCredentials exchangeCallbackParameters(Map<String, String> query) {
     validateCallbackParameters(query);
@@ -208,8 +208,8 @@ public class Consent implements Serializable {
    * Handles the OAuth callback by setting up a local HTTP server, launching the browser, and
    * collecting the callback parameters.
    *
-   * @return A map containing the callback parameters from the OAuth flow
-   * @throws IOException if the webserver cannot be started, or if the browser cannot be opened
+   * @return A map containing the callback parameters from the OAuth flow.
+   * @throws IOException if the webserver cannot be started, or if the browser cannot be opened.
    */
   private Map<String, String> getOAuthCallbackParameters() throws IOException {
     URL redirect = new URL(getRedirectUrl());

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProvider.java
@@ -6,6 +6,7 @@ import com.databricks.sdk.core.DatabricksException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,15 +69,14 @@ public class ExternalBrowserCredentialsProvider implements CredentialsProvider {
         try {
           // Create SessionCredentialsTokenSource with the cached token and try to refresh if needed
           SessionCredentialsTokenSource tokenSource =
-              new SessionCredentialsTokenSource.Builder(
-                      cachedToken,
-                      config.getHttpClient(),
-                      config.getOidcEndpoints().getTokenEndpoint(),
-                      clientId,
-                      clientSecret)
-                  .withRedirectUrl(config.getEffectiveOAuthRedirectUrl())
-                  .withTokenCache(tokenCache)
-                  .build();
+              new SessionCredentialsTokenSource(
+                  cachedToken,
+                  config.getHttpClient(),
+                  config.getOidcEndpoints().getTokenEndpoint(),
+                  clientId,
+                  clientSecret,
+                  Optional.of(config.getEffectiveOAuthRedirectUrl()),
+                  Optional.of(tokenCache));
 
           LOGGER.debug("Using cached token, will immediately refresh");
           tokenSource.token = tokenSource.refresh();
@@ -117,14 +117,13 @@ public class ExternalBrowserCredentialsProvider implements CredentialsProvider {
     Token token = consent.getTokenFromExternalBrowser();
 
     // Create a SessionCredentialsTokenSource with the token from browser auth.
-    return new SessionCredentialsTokenSource.Builder(
-            token,
-            config.getHttpClient(),
-            config.getOidcEndpoints().getTokenEndpoint(),
-            config.getClientId(),
-            config.getClientSecret())
-        .withRedirectUrl(config.getEffectiveOAuthRedirectUrl())
-        .withTokenCache(tokenCache)
-        .build();
+    return new SessionCredentialsTokenSource(
+        token,
+        config.getHttpClient(),
+        config.getOidcEndpoints().getTokenEndpoint(),
+        config.getClientId(),
+        config.getClientSecret(),
+        Optional.ofNullable(config.getEffectiveOAuthRedirectUrl()),
+        Optional.ofNullable(tokenCache));
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/SessionCredentials.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/SessionCredentials.java
@@ -4,6 +4,7 @@ import com.databricks.sdk.core.CredentialsProvider;
 import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.core.http.HttpClient;
 import java.io.Serializable;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,11 +23,14 @@ public class SessionCredentials implements CredentialsProvider, Serializable {
 
   private SessionCredentials(Builder b) {
     this.tokenSource =
-        new SessionCredentialsTokenSource.Builder(
-                b.token, b.hc, b.tokenUrl, b.clientId, b.clientSecret)
-            .withRedirectUrl(b.redirectUrl)
-            .withTokenCache(b.tokenCache)
-            .build();
+        new SessionCredentialsTokenSource(
+            b.token,
+            b.hc,
+            b.tokenUrl,
+            b.clientId,
+            b.clientSecret,
+            Optional.ofNullable(b.redirectUrl),
+            Optional.ofNullable(b.tokenCache));
   }
 
   @Override

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/SessionCredentialsTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/SessionCredentialsTokenSource.java
@@ -4,6 +4,7 @@ import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.core.http.HttpClient;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,27 +21,40 @@ public class SessionCredentialsTokenSource extends RefreshableTokenSource {
   // OAuth token endpoint URL for refresh requests
   private final String tokenUrl;
   // OAuth redirect URL, used for Microsoft OAuth endpoints
-  private final String redirectUrl;
+  private final Optional<String> redirectUrl;
   // OAuth client ID for authentication
   private final String clientId;
   // OAuth client secret for authentication
   private final String clientSecret;
   // Optional token cache for persisting refreshed tokens
-  private final TokenCache tokenCache;
+  private final Optional<TokenCache> tokenCache;
 
   /**
-   * Constructs a new SessionCredentialsTokenSource with the given builder.
+   * Constructs a new SessionCredentialsTokenSource.
    *
-   * @param builder The builder containing all configuration parameters
+   * @param token The initial token to use
+   * @param hc The HTTP client for making token refresh requests
+   * @param tokenUrl The OAuth token endpoint URL
+   * @param clientId The OAuth client ID
+   * @param clientSecret The OAuth client secret
+   * @param redirectUrl The OAuth redirect URL (optional)
+   * @param tokenCache The token cache for persisting refreshed tokens (optional)
    */
-  private SessionCredentialsTokenSource(Builder builder) {
-    super(builder.token);
-    this.hc = builder.hc;
-    this.tokenUrl = builder.tokenUrl;
-    this.redirectUrl = builder.redirectUrl;
-    this.clientId = builder.clientId;
-    this.clientSecret = builder.clientSecret;
-    this.tokenCache = builder.tokenCache;
+  public SessionCredentialsTokenSource(
+      Token token,
+      HttpClient hc,
+      String tokenUrl,
+      String clientId,
+      String clientSecret,
+      Optional<String> redirectUrl,
+      Optional<TokenCache> tokenCache) {
+    super(token);
+    this.hc = hc;
+    this.tokenUrl = tokenUrl;
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.redirectUrl = redirectUrl;
+    this.tokenCache = tokenCache;
   }
 
   /**
@@ -50,9 +64,9 @@ public class SessionCredentialsTokenSource extends RefreshableTokenSource {
    * the new token is automatically saved to the token cache if one is configured. For Microsoft
    * OAuth endpoints, it includes the Origin header.
    *
-   * @return A new {@link Token} with updated access and refresh tokens
+   * @return A new {@link Token} with updated access and refresh tokens.
    * @throws DatabricksException if the token is not set, refresh token is missing, or the refresh
-   *     request fails
+   *     request fails.
    */
   @Override
   protected Token refresh() {
@@ -71,77 +85,18 @@ public class SessionCredentialsTokenSource extends RefreshableTokenSource {
     if (tokenUrl.contains("microsoft")) {
       // Tokens issued for the 'Single-Page Application' client-type may only be redeemed via
       // cross-origin requests
-      headers.put("Origin", redirectUrl);
+      redirectUrl.ifPresent(url -> headers.put("Origin", url));
     }
     Token newToken =
         retrieveToken(
             hc, clientId, clientSecret, tokenUrl, params, headers, AuthParameterPosition.BODY);
 
     // Save the refreshed token directly to cache
-    if (tokenCache != null) {
-      tokenCache.save(newToken);
-      LOGGER.debug("Saved refreshed token to cache");
-    }
+    tokenCache.ifPresent(
+        cache -> {
+          cache.save(newToken);
+          LOGGER.debug("Saved refreshed token to cache");
+        });
     return newToken;
-  }
-
-  /** Builder for creating SessionCredentialsTokenSource instances. */
-  public static class Builder {
-    private final Token token;
-    private final HttpClient hc;
-    private final String tokenUrl;
-    private final String clientId;
-    private final String clientSecret;
-    private String redirectUrl;
-    private TokenCache tokenCache;
-
-    /**
-     * Creates a new Builder for SessionCredentialsTokenSource with required parameters.
-     *
-     * @param token The initial token to use
-     * @param hc The HTTP client for making token refresh requests
-     * @param tokenUrl The OAuth token endpoint URL
-     * @param clientId The OAuth client ID
-     * @param clientSecret The OAuth client secret
-     */
-    public Builder(
-        Token token, HttpClient hc, String tokenUrl, String clientId, String clientSecret) {
-      this.token = token;
-      this.hc = hc;
-      this.tokenUrl = tokenUrl;
-      this.clientId = clientId;
-      this.clientSecret = clientSecret;
-    }
-
-    /**
-     * Sets the redirect URL (optional).
-     *
-     * @param redirectUrl The OAuth redirect URL
-     * @return This Builder instance for method chaining
-     */
-    public Builder withRedirectUrl(String redirectUrl) {
-      this.redirectUrl = redirectUrl;
-      return this;
-    }
-
-    /**
-     * Sets the token cache (optional).
-     *
-     * @param tokenCache The token cache for persisting refreshed tokens
-     * @return This Builder instance for method chaining
-     */
-    public Builder withTokenCache(TokenCache tokenCache) {
-      this.tokenCache = tokenCache;
-      return this;
-    }
-
-    /**
-     * Builds the SessionCredentialsTokenSource instance.
-     *
-     * @return A new SessionCredentialsTokenSource instance
-     */
-    public SessionCredentialsTokenSource build() {
-      return new SessionCredentialsTokenSource(this);
-    }
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -218,17 +219,15 @@ public class ExternalBrowserCredentialsProviderTest {
         .execute(any(Request.class));
 
     SessionCredentialsTokenSource sessionCredentialsTokenSource =
-        new SessionCredentialsTokenSource.Builder(
-                new Token(
-                    "originalAccessToken",
-                    "originalTokenType",
-                    "originalRefreshToken",
-                    Instant.MAX),
-                hc,
-                "https://tokenUrl",
-                "testClientId",
-                "abc")
-            .build();
+        new SessionCredentialsTokenSource(
+            new Token(
+                "originalAccessToken", "originalTokenType", "originalRefreshToken", Instant.MAX),
+            hc,
+            "https://tokenUrl",
+            "testClientId",
+            "abc",
+            Optional.empty(),
+            Optional.empty());
     Token token = sessionCredentialsTokenSource.refresh();
 
     // We check that we are actually getting the token from server response (that is defined
@@ -426,13 +425,14 @@ public class ExternalBrowserCredentialsProviderTest {
             Instant.now().plusSeconds(3600));
 
     SessionCredentialsTokenSource browserAuthTokenSource =
-        new SessionCredentialsTokenSource.Builder(
-                browserAuthToken,
-                mockHttpClient,
-                "https://test-token-url",
-                "test-client-id",
-                "test-client-secret")
-            .build();
+        new SessionCredentialsTokenSource(
+            browserAuthToken,
+            mockHttpClient,
+            "https://test-token-url",
+            "test-client-id",
+            "test-client-secret",
+            Optional.empty(),
+            Optional.empty());
 
     // Create config with failing HTTP client and mock token cache
     DatabricksConfig config =
@@ -498,13 +498,14 @@ public class ExternalBrowserCredentialsProviderTest {
             Instant.now().plusSeconds(3600));
 
     SessionCredentialsTokenSource browserAuthTokenSource =
-        new SessionCredentialsTokenSource.Builder(
-                browserAuthToken,
-                mockHttpClient,
-                "https://test-token-url",
-                "test-client-id",
-                "test-client-secret")
-            .build();
+        new SessionCredentialsTokenSource(
+            browserAuthToken,
+            mockHttpClient,
+            "https://test-token-url",
+            "test-client-id",
+            "test-client-secret",
+            Optional.empty(),
+            Optional.empty());
 
     // Create simple config
     DatabricksConfig config =


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR refactors the `SessionCredentials` class to achieve clearer separation of concerns by splitting its responsibilities into two distinct components: a `CredentialsProvider` implementation and a dedicated `TokenSource` implementation. This refactoring is necessary for introducing token cache wrappers in future PRs.

### Current Implementation
- `SessionCredentials` both implements `CredentialsProvider` and extends `RefreshableTokenSource`.
- Token refresh logic is tightly coupled with credential provider functionality, making it hard to isolate token source logic and introduce caching.
- A single class is responsible for both authentication configuration and token management.

## Proposed Changes
- `SessionCredentials` now implements only `CredentialsProvider` and delegates all token operations to a new `SessionCredentialsTokenSource` class.
- `SessionCredentialsTokenSource` extends `RefreshableTokenSource` and is solely responsible for token refresh logic.

## Benefits
- Token sources can now be easily wrapped with caching mechanisms in future updates.
- `SessionCredentials` remains a public `CredentialsProvider` as intended with no breaking changes to the public API.


## How is this tested?
Existing unit tests.

NO_CHANGELOG=true