### PR TITLE
Add a dependency on AutoValue to simplify handling of value classes.

### DIFF
--- a/databricks-sdk-java/pom.xml
+++ b/databricks-sdk-java/pom.xml
@@ -103,5 +103,18 @@
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>${jackson.version}</version>
     </dependency>
+    <!-- Google Auto Value -->
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <version>1.10.4</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+      <version>1.10.4</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DataPlaneTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DataPlaneTokenSource.java
@@ -6,14 +6,12 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Manages and provides Databricks data plane tokens. This class is responsible
- * for acquiring and caching OAuth tokens that are specific to a particular
- * Databricks data plane service endpoint and a set of authorization details.
- * It utilizes a {@link DatabricksOAuthTokenSource} for obtaining control plane
- * tokens, which may then be exchanged or used to authorize requests for data
- * plane tokens. Cached {@link EndpointTokenSource} instances are used to
- * efficiently reuse tokens for repeated requests to the same endpoint with the
- * same authorization context.
+ * Manages and provides Databricks data plane tokens. This class is responsible for acquiring and
+ * caching OAuth tokens that are specific to a particular Databricks data plane service endpoint and
+ * a set of authorization details. It utilizes a {@link DatabricksOAuthTokenSource} for obtaining
+ * control plane tokens, which may then be exchanged or used to authorize requests for data plane
+ * tokens. Cached {@link EndpointTokenSource} instances are used to efficiently reuse tokens for
+ * repeated requests to the same endpoint with the same authorization context.
  */
 public class DataPlaneTokenSource {
   private final HttpClient httpClient;
@@ -22,13 +20,13 @@ public class DataPlaneTokenSource {
   private final ConcurrentHashMap<TokenSourceKey, EndpointTokenSource> sourcesCache;
 
   /**
-   * Caching key for {@link EndpointTokenSource}, based on endpoint and 
-   * authorization details. This is a value object that uniquely identifies 
-   * a token source configuration.
+   * Caching key for {@link EndpointTokenSource}, based on endpoint and authorization details. This
+   * is a value object that uniquely identifies a token source configuration.
    */
   @AutoValue
-  static abstract class TokenSourceKey {
+  abstract static class TokenSourceKey {
     abstract String endpoint();
+
     abstract String authDetails();
 
     static TokenSourceKey create(String endpoint, String authDetails) {

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@
         <configuration>
           <source>8</source>
           <target>8</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>1.10.4</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a dependency on [Google's AutoValue library](https://chromium.googlesource.com/external/github.com/google/auto/+/refs/tags/auto-value-1.6.2/value/userguide/index.md) to simplify the development and maintenance of value classes. See [Why should I use AutoValue?](https://chromium.googlesource.com/external/github.com/google/auto/+/refs/tags/auto-value-1.6.2/value/userguide/why.md) for more details.

The decision to use AutoValue is motivated by the fact that the Databricks SDK must support Java 8 for the foreseeable future and does not have access to new language features such as records — which would obsolete AutoValue.

NO_CHANGELOG=true

## How is this tested?

Simplified one small internal class to use AutoValue and validated that the impacted unit and integration tests are fine with it.