### PR TITLE
Publish to the Central Repository. 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,19 @@
 name: Release
+
 on:
-  workflow_dispatch:
   push:
+    # Run a real release on pushes to tags like v1.0, v2.3.4, etc.
     tags:
       - "v*"
-  push:
+    # Run a dry-run on pushes to any branch
     branches:
-      - "renaud-hartert_data/maven-migration"
+      - "**"
 
 jobs:
   publish:
+    # Dynamically set the job name based on the trigger
+    name: ${{ startsWith(github.ref, 'refs/tags/') && 'Publish Release' || 'Run Release Dry-Run' }}
+
     runs-on:
       group: databricks-deco-testing-runner-group
       labels: ubuntu-latest-deco
@@ -29,10 +33,19 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Publish to the Maven Central Repository
+      # This step runs ONLY on branch pushes (dry-run)
+      - name: Run Release Dry-Run (Verify)
+        if: "!startsWith(github.ref, 'refs/tags/')"
         run: mvn -Prelease -DskipTests=true --batch-mode verify
 
+      # This step runs ONLY on tag pushes (real release)
+      - name: Publish to Maven Central Repository (Deploy)
+        if: "startsWith(github.ref, 'refs/tags/')"
+        run: mvn -Prelease -DskipTests=true --batch-mode deploy
+
+      # This step also runs ONLY on tag pushes (real release)
       - name: Create GitHub release
+        if: "startsWith(github.ref, 'refs/tags/')"
         uses: softprops/action-gh-release@v1
         with:
           files: target/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "v*"
+  push:
+    branches:
+      - "renaud-hartert_data/maven-migration"
+
 jobs:
   publish:
     runs-on:
@@ -26,7 +30,7 @@ jobs:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish to the Maven Central Repository
-        run: mvn -Prelease -DskipTests=true --batch-mode deploy
+        run: mvn -Prelease -DskipTests=true --batch-mode verify
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,15 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 8
-          server-id: ossrh
+          server-id: central
           distribution: "adopt"
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_PASSWORD
+          server-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          server-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish to the Maven Central Repository
         run: mvn -Prelease -DskipTests=true --batch-mode deploy
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1

--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,6 @@
     <system>GitHub Actions</system>
     <url>https://github.com/databricks/databricks-sdk-java/blob/main/.github/workflows/push.yml</url>
   </ciManagement>
-  <distributionManagement>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
   <properties>
     <jacoco.version>0.8.10</jacoco.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -263,35 +257,13 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <configuration>
-              <!-- Prevent gpg from using pinentry programs -->
-              <gpgArguments>
-                <arg>--pinentry-mode</arg>
-                <arg>loopback</arg>
-              </gpgArguments>
-            </configuration>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <phase>verify</phase>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.13</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.5.0</version> 
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.5.0</version> 
+            <version>0.5.0</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the release workflow to publish to the Sonatype Central Repository instead of OSSRH — which is [deprecated](https://central.sonatype.org/news/20250326_ossrh_sunset/). The PR also update the workflow to run a dry-run on pushes — which is used to validate this PR. 

## How is this tested?

See above, the workflow now does dry runs on pushes. 

NO_CHANGELOG=true