### PR TITLE
infer azure tenant id

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -14,10 +14,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.net.URL;
 import java.util.*;
 import org.apache.http.HttpMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DatabricksConfig {
+
+  private static final Logger logger = LoggerFactory.getLogger(DatabricksConfig.class);
   private CredentialsProvider credentialsProvider = new DefaultCredentialsProvider();
 
   @ConfigAttribute(env = "DATABRICKS_HOST")
@@ -414,13 +419,17 @@ public class DatabricksConfig {
     return this;
   }
 
-  /** @deprecated Use {@link #getAzureUseMsi()} instead. */
+  /**
+   * @deprecated Use {@link #getAzureUseMsi()} instead.
+   */
   @Deprecated()
   public boolean getAzureUseMSI() {
     return azureUseMsi;
   }
 
-  /** @deprecated Use {@link #setAzureUseMsi(boolean)} instead. */
+  /**
+   * @deprecated Use {@link #setAzureUseMsi(boolean)} instead.
+   */
   @Deprecated
   public DatabricksConfig setAzureUseMSI(boolean azureUseMsi) {
     this.azureUseMsi = azureUseMsi;
@@ -726,7 +735,7 @@ public class DatabricksConfig {
   }
 
   public DatabricksConfig clone() {
-    return clone(new HashSet<>());
+    return clone(new HashSet<>(Collections.singletonList("logger")));
   }
 
   public DatabricksConfig newWithWorkspaceHost(String host) {
@@ -736,6 +745,7 @@ public class DatabricksConfig {
                 // The config for WorkspaceClient has a different host and Azure Workspace resource
                 // ID, and also omits
                 // the account ID.
+                "logger",
                 "host",
                 "accountId",
                 "azureWorkspaceResourceId",
@@ -754,5 +764,83 @@ public class DatabricksConfig {
    */
   public String getEffectiveOAuthRedirectUrl() {
     return redirectUrl != null ? redirectUrl : "http://localhost:8080/callback";
+  }
+
+  private static final String AZURE_AUTH_ENDPOINT = "/aad/auth";
+
+  /**
+   * [Internal] Load the Azure tenant ID from the Azure Databricks login page. If the tenant ID is
+   * already set, this method does nothing.
+   */
+  public void loadAzureTenantId() {
+
+    if (!isAzure() || azureTenantId != null || host == null) {
+      return;
+    }
+
+    String loginUrl = host + AZURE_AUTH_ENDPOINT;
+    logger.debug("Loading tenant ID from {}", loginUrl);
+
+    try {
+      String redirectLocation = getRedirectLocation(loginUrl);
+      if (redirectLocation == null) {
+        return;
+      }
+
+      String extractedTenantId = extractTenantIdFromUrl(redirectLocation);
+      if (extractedTenantId == null) {
+        return;
+      }
+
+      this.azureTenantId = extractedTenantId;
+      logger.debug("Loaded tenant ID: {}", this.azureTenantId);
+
+    } catch (Exception e) {
+      logger.warn("Failed to load tenant ID: {}", e.getMessage());
+    }
+  }
+
+  private String getRedirectLocation(String loginUrl) throws IOException {
+
+    Request request = new Request("GET", loginUrl);
+    request.setRedirectionBehavior(false);
+    Response response = getHttpClient().execute(request);
+    int statusCode = response.getStatusCode();
+
+    if (statusCode / 100 != 3) {
+      logger.warn(
+          "Failed to get tenant ID from {}: expected status code 3xx, got {}",
+          loginUrl,
+          statusCode);
+      return null;
+    }
+
+    String location = response.getFirstHeader("Location");
+    if (location == null) {
+      logger.warn("No Location header in response from {}", loginUrl);
+    }
+
+    return location;
+  }
+
+  private String extractTenantIdFromUrl(String redirectUrl) {
+    try {
+      // The Location header has the following form:
+      // https://login.microsoftonline.com/<tenant-id>/oauth2/authorize?...
+      // The domain may change depending on the Azure cloud (e.g. login.microsoftonline.us for US
+      // Government cloud).
+      URL entraIdUrl = new URL(redirectUrl);
+      String[] pathSegments = entraIdUrl.getPath().split("/");
+
+      if (pathSegments.length < 2) {
+        logger.warn("Invalid path in Location header: {}", entraIdUrl.getPath());
+        return null;
+      }
+
+      return pathSegments[1];
+    } catch (Exception e) {
+      logger.warn("Failed to extract tenant ID from URL {}: {}", redirectUrl, e.getMessage());
+      return null;
+    }
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/AzureServicePrincipalCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/AzureServicePrincipalCredentialsProvider.java
@@ -22,12 +22,12 @@ public class AzureServicePrincipalCredentialsProvider implements CredentialsProv
   public OAuthHeaderFactory configure(DatabricksConfig config) {
     if (!config.isAzure()
         || config.getAzureClientId() == null
-        || config.getAzureClientSecret() == null
-        || config.getAzureTenantId() == null) {
+        || config.getAzureClientSecret() == null) {
       return null;
     }
     AzureUtils.ensureHostPresent(
         config, mapper, AzureServicePrincipalCredentialsProvider::tokenSourceFor);
+    config.loadAzureTenantId();
     CachedTokenSource inner = tokenSourceFor(config, config.getEffectiveAzureLoginAppId());
     CachedTokenSource cloud =
         tokenSourceFor(config, config.getAzureEnvironment().getServiceManagementEndpoint());

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -250,4 +250,91 @@ public class DatabricksConfigTest {
     assertFalse(tokenSource instanceof ErrorTokenSource);
     assertEquals(tokenSource.getToken().getAccessToken(), "test-token");
   }
+
+  @Test
+  public void testLoadAzureTenantId404() throws IOException {
+    try (FixtureServer server = new FixtureServer().with("GET", "/aad/auth", "", 404)) {
+      DatabricksConfig config = new DatabricksConfig();
+      config.setHost(server.getUrl());
+      config.setHttpClient(new CommonsHttpClient.Builder().withTimeoutSeconds(30).build());
+      config.loadAzureTenantId();
+      assertNull(config.getAzureTenantId());
+    }
+  }
+
+  @Test
+  public void testLoadAzureTenantIdNoLocationHeader() throws IOException {
+    try (FixtureServer server = new FixtureServer().with("GET", "/aad/auth", "", 302)) {
+      DatabricksConfig config = new DatabricksConfig();
+      config.setHost(server.getUrl());
+      config.setHttpClient(new CommonsHttpClient.Builder().withTimeoutSeconds(30).build());
+      config.loadAzureTenantId();
+      assertNull(config.getAzureTenantId());
+    }
+  }
+
+  @Test
+  public void testLoadAzureTenantIdUnparsableLocationHeader() throws IOException {
+    FixtureServer.FixtureMapping fixture =
+        new FixtureServer.FixtureMapping.Builder()
+            .validateMethod("GET")
+            .validatePath("/aad/auth")
+            .withRedirect("https://unexpected-location", 302)
+            .build();
+
+    try (FixtureServer server = new FixtureServer().with(fixture)) {
+      DatabricksConfig config = new DatabricksConfig();
+      config.setHost(server.getUrl());
+      config.setHttpClient(new CommonsHttpClient.Builder().withTimeoutSeconds(30).build());
+      config.loadAzureTenantId();
+      assertNull(config.getAzureTenantId());
+    }
+  }
+
+  @Test
+  public void testLoadAzureTenantIdHappyPath() throws IOException {
+    FixtureServer.FixtureMapping fixture =
+        new FixtureServer.FixtureMapping.Builder()
+            .validateMethod("GET")
+            .validatePath("/aad/auth")
+            .withRedirect("https://login.microsoftonline.com/test-tenant-id/oauth2/authorize", 302)
+            .build();
+
+    try (FixtureServer server = new FixtureServer().with(fixture)) {
+      DatabricksConfig config = new DatabricksConfig();
+      config.setHost(server.getUrl());
+      config.setAzureWorkspaceResourceId(
+          "/subscriptions/123/resourceGroups/rg/providers/Microsoft.Databricks/workspaces/ws");
+      config.setHttpClient(new CommonsHttpClient.Builder().withTimeoutSeconds(30).build());
+      config.loadAzureTenantId();
+      assertEquals("test-tenant-id", config.getAzureTenantId());
+    }
+  }
+
+  @Test
+  public void testLoadAzureTenantIdSkipsWhenNotAzure() throws IOException {
+    DatabricksConfig config = new DatabricksConfig();
+    config.setHost("https://my-workspace.cloud.databricks.com"); // non-azure host
+    config.setHttpClient(new CommonsHttpClient.Builder().withTimeoutSeconds(30).build());
+    config.loadAzureTenantId();
+    assertNull(config.getAzureTenantId());
+  }
+
+  @Test
+  public void testLoadAzureTenantIdSkipsWhenAlreadySet() throws IOException {
+    DatabricksConfig config = new DatabricksConfig();
+    config.setHost("https://adb-123.0.azuredatabricks.net");
+    config.setAzureTenantId("existing-tenant-id");
+    config.setHttpClient(new CommonsHttpClient.Builder().withTimeoutSeconds(30).build());
+    config.loadAzureTenantId();
+    assertEquals("existing-tenant-id", config.getAzureTenantId());
+  }
+
+  @Test
+  public void testLoadAzureTenantIdSkipsWhenNoHost() throws IOException {
+    DatabricksConfig config = new DatabricksConfig();
+    config.setHttpClient(new CommonsHttpClient.Builder().withTimeoutSeconds(30).build());
+    config.loadAzureTenantId();
+    assertNull(config.getAzureTenantId());
+  }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR modifies Azure CLI and Azure SP credential providers to attempt to load the tenant ID of the workspace if not provided before authenticating. Tenant ID is indirectly exposed via the redirect URL used when logging into a workspace. In this PR, we fetch the tenant ID from this endpoint and configure it if not already set.

Reference PR: https://github.com/databricks/databricks-sdk-py/pull/638

## How is this tested?
- Tested the changes using unit tests
