### PR TITLE
Fix Release Workflow to publish in Maven Central.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
           java-version: 8
           server-id: central
           distribution: "adopt"
-          server-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          server-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-passphrase: GPG_PASSPHRASE
 
       # This step runs ONLY on branch pushes (dry-run)
       - name: Run Release Dry-Run (Verify)

--- a/databricks-sdk-java/pom.xml
+++ b/databricks-sdk-java/pom.xml
@@ -8,6 +8,7 @@
     <version>0.55.0</version>
   </parent>
   <artifactId>databricks-sdk-java</artifactId>
+  <name>Databricks SDK for Java</name>
   <properties>
     <httpclient.version>4.5.14</httpclient.version>
     <jackson.version>2.15.2</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,27 @@
             </executions>
           </plugin>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <configuration>
+              <!-- Prevent gpg from using pinentry programs -->
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <phase>verify</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
             <version>0.5.0</version>


### PR DESCRIPTION
## What changes are proposed in this pull request?

This fixes three things in the release workflow:
- It fixes how we pass the secrets to setup-java. Previously, the secret was passed in the format of {env.Secret}.
- Added a block in the pom file that signs the binary.
- Added the name of the JAVA Library in the pom file.

## How is this tested?

Manually tested.