### PR TITLE
Add an option to set a timeout for browser confirmation in the U2M authentication flow. 

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+* Add option to add a timeout for browser confirmation in the U2M authentication flow.
+
 ### Bug Fixes
 
 * User provided scopes are now properly propagated in OAuth flows.

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigAttributeAccessor.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigAttributeAccessor.java
@@ -45,7 +45,7 @@ class ConfigAttributeAccessor {
       if (value == null || value.trim().isEmpty()) {
         return;
       }
-      
+
       if (field.getType() == String.class) {
         field.set(cfg, value);
       } else if (field.getType() == int.class) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigAttributeAccessor.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/ConfigAttributeAccessor.java
@@ -1,6 +1,7 @@
 package com.databricks.sdk.core;
 
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 
@@ -41,16 +42,25 @@ class ConfigAttributeAccessor {
     // workspace clients or config resolution) are safe
     synchronized (field) {
       field.setAccessible(true);
+      if (value == null || value.trim().isEmpty()) {
+        return;
+      }
+      
       if (field.getType() == String.class) {
         field.set(cfg, value);
       } else if (field.getType() == int.class) {
         field.set(cfg, Integer.parseInt(value));
+      } else if (field.getType() == Integer.class) {
+        field.set(cfg, Integer.parseInt(value));
       } else if (field.getType() == boolean.class) {
         field.set(cfg, Boolean.parseBoolean(value));
+      } else if (field.getType() == Boolean.class) {
+        field.set(cfg, Boolean.parseBoolean(value));
+      } else if (field.getType() == Duration.class) {
+        int seconds = Integer.parseInt(value);
+        field.set(cfg, seconds > 0 ? Duration.ofSeconds(seconds) : null);
       } else if (field.getType() == ProxyConfig.ProxyAuthType.class) {
-        if (value != null) {
-          field.set(cfg, ProxyConfig.ProxyAuthType.valueOf(value));
-        }
+        field.set(cfg, ProxyConfig.ProxyAuthType.valueOf(value));
       }
       field.setAccessible(false);
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.*;
 import org.apache.http.HttpMessage;
 
@@ -162,6 +163,13 @@ public class DatabricksConfig {
   /** Disable asynchronous token refresh when set to true. */
   @ConfigAttribute(env = "DATABRICKS_DISABLE_ASYNC_TOKEN_REFRESH")
   private Boolean disableAsyncTokenRefresh;
+
+  /**
+   * The duration to wait for a browser response during U2M authentication before timing out. 
+   * If set to 0 or null, the connector waits for an indefinite amount of time.
+   */
+  @ConfigAttribute(env = "DATABRICKS_OAUTH_BROWSER_AUTH_TIMEOUT")
+  private Duration oauthBrowserAuthTimeout;
 
   public Environment getEnv() {
     return env;
@@ -585,6 +593,20 @@ public class DatabricksConfig {
 
   public DatabricksConfig setDisableAsyncTokenRefresh(boolean disableAsyncTokenRefresh) {
     this.disableAsyncTokenRefresh = disableAsyncTokenRefresh;
+    return this;
+  }
+
+  public Duration getOAuthBrowserAuthTimeout() {
+    return oauthBrowserAuthTimeout;
+  }
+
+  public DatabricksConfig setOAuthBrowserAuthTimeout(Duration oauthBrowserAuthTimeout) {
+    this.oauthBrowserAuthTimeout = oauthBrowserAuthTimeout;
+    return this;
+  }
+
+  public DatabricksConfig setOAuthBrowserAuthTimeout(int seconds) {
+    this.oauthBrowserAuthTimeout = seconds > 0 ? Duration.ofSeconds(seconds) : null;
     return this;
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -614,11 +614,6 @@ public class DatabricksConfig {
     return this;
   }
 
-  public DatabricksConfig setOAuthBrowserAuthTimeout(int seconds) {
-    this.oauthBrowserAuthTimeout = seconds > 0 ? Duration.ofSeconds(seconds) : null;
-    return this;
-  }
-
   public boolean isAzure() {
     if (azureWorkspaceResourceId != null) {
       return true;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -165,8 +165,8 @@ public class DatabricksConfig {
   private Boolean disableAsyncTokenRefresh;
 
   /**
-   * The duration to wait for a browser response during U2M authentication before timing out. 
-   * If set to 0 or null, the connector waits for an indefinite amount of time.
+   * The duration to wait for a browser response during U2M authentication before timing out. If set
+   * to 0 or null, the connector waits for an indefinite amount of time.
    */
   @ConfigAttribute(env = "DATABRICKS_OAUTH_BROWSER_AUTH_TIMEOUT")
   private Duration oauthBrowserAuthTimeout;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
@@ -388,10 +388,10 @@ public class Consent implements Serializable {
       exchange.close();
     }
 
-    /** 
-     * Wait and return the params. 
-     * 
-     * This method might throw an exception in case of timeout.
+    /**
+     * Wait and return the params.
+     *
+     * <p>This method might throw an exception in case of timeout.
      */
     public Map<String, String> getParams() {
       synchronized (lock) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
@@ -113,10 +113,6 @@ public class Consent implements Serializable {
       return this;
     }
 
-    public Builder withBrowserTimeout(Duration browserTimeout) {
-      return withBrowserTimeout(Optional.of(browserTimeout));
-    }
-
     public Consent build() {
       return new Consent(this);
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
@@ -14,13 +14,12 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.time.Duration;
-
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -402,7 +401,8 @@ public class Consent implements Serializable {
               Duration t = timeout.get();
               lock.wait(t.toMillis());
               if (params == null) {
-                throw new DatabricksException("OAuth browser authentication timed out after " + t.getSeconds() + " seconds");
+                throw new DatabricksException(
+                    "OAuth browser authentication timed out after " + t.getSeconds() + " seconds");
               }
             } else {
               lock.wait();

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
@@ -297,8 +297,7 @@ public class Consent implements Serializable {
 
   static class CallbackResponseHandler implements HttpHandler {
     private final Logger LOG = LoggerFactory.getLogger(getClass().getName());
-    // Protects params
-    private final Object lock = new Object();
+    protected final Object lock = new Object(); // protected for testing
     private volatile Map<String, String> params;
     private final Optional<Duration> timeout;
 
@@ -343,10 +342,7 @@ public class Consent implements Serializable {
               });
 
       sendSuccess(exchange);
-      synchronized (lock) {
-        params = theseParams;
-        lock.notify();
-      }
+      setParams(theseParams);
     }
 
     private void sendError(
@@ -409,6 +405,13 @@ public class Consent implements Serializable {
           }
         }
         return params;
+      }
+    }
+
+    void setParams(Map<String, String> params) {
+      synchronized (lock) {
+        this.params = params;
+        lock.notify();
       }
     }
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
@@ -239,10 +239,13 @@ public class Consent implements Serializable {
         HttpServer.create(new InetSocketAddress(redirect.getHost(), redirect.getPort()), 0);
     httpServer.createContext("/", handler);
     httpServer.start();
-    desktopBrowser();
-    Map<String, String> params = handler.getParams();
-    httpServer.stop(0);
-    return params;
+
+    try {
+      desktopBrowser();
+      return handler.getParams();
+    } finally {
+      httpServer.stop(0);
+    }
   }
 
   /**

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/Consent.java
@@ -388,6 +388,11 @@ public class Consent implements Serializable {
       exchange.close();
     }
 
+    /** 
+     * Wait and return the params. 
+     * 
+     * This method might throw an exception in case of timeout.
+     */
     public Map<String, String> getParams() {
       synchronized (lock) {
         if (params == null) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProvider.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
-import java.time.Duration;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProvider.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
+import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,6 +116,7 @@ public class ExternalBrowserCredentialsProvider implements CredentialsProvider {
             .withAccountId(config.getAccountId())
             .withRedirectUrl(config.getEffectiveOAuthRedirectUrl())
             .withScopes(config.getScopes())
+            .withBrowserTimeout(config.getOAuthBrowserAuthTimeout())
             .build();
     Consent consent = client.initiateConsent();
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
@@ -211,7 +211,7 @@ public class OAuthClient {
         .withState(state)
         .withVerifier(verifier)
         .withHttpClient(hc)
-        .withBrowserTimeout(browserTimeout.orElse(Duration.ofSeconds(0)))
+        .withBrowserTimeout(browserTimeout)
         .build();
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
@@ -9,7 +9,14 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.*;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -36,6 +43,7 @@ public class OAuthClient {
     private String clientSecret;
     private HttpClient hc;
     private String accountId;
+    private Optional<Duration> browserTimeout = Optional.empty();
 
     public Builder() {}
 
@@ -77,6 +85,11 @@ public class OAuthClient {
       this.accountId = accountId;
       return this;
     }
+
+    public Builder withBrowserTimeout(Duration browserTimeout) {
+      this.browserTimeout = Optional.of(browserTimeout);
+      return this;
+    }
   }
 
   private final String clientId;
@@ -90,6 +103,7 @@ public class OAuthClient {
   private final SecureRandom random = new SecureRandom();
   private final boolean isAws;
   private final boolean isAzure;
+  private final Optional<Duration> browserTimeout;
 
   private OAuthClient(Builder b) throws IOException {
     this.clientId = Objects.requireNonNull(b.clientId);
@@ -120,6 +134,7 @@ public class OAuthClient {
               config.getEffectiveAzureLoginAppId() + "/user_impersonation", "offline_access");
     }
     this.scopes = scopes;
+    this.browserTimeout = b.browserTimeout;
   }
 
   public String getHost() {
@@ -207,6 +222,7 @@ public class OAuthClient {
         .withState(state)
         .withVerifier(verifier)
         .withHttpClient(hc)
+        .withBrowserTimeout(browserTimeout.orElse(Duration.ofSeconds(0)))
         .build();
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
@@ -10,13 +10,12 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.time.Duration;
-import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Base64;
-import java.util.HashMap;
 import java.util.stream.Collectors;
 
 /**

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -12,6 +12,7 @@ import com.databricks.sdk.core.oauth.Token;
 import com.databricks.sdk.core.oauth.TokenSource;
 import com.databricks.sdk.core.utils.Environment;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -249,5 +250,63 @@ public class DatabricksConfigTest {
     TokenSource tokenSource = config.getTokenSource();
     assertFalse(tokenSource instanceof ErrorTokenSource);
     assertEquals(tokenSource.getToken().getAccessToken(), "test-token");
+  }
+
+  @Test
+  public void testOAuthBrowserAuthTimeout() {
+    DatabricksConfig config = new DatabricksConfig();
+    
+    // Test default value (should be null)
+    assertNull(config.getOAuthBrowserAuthTimeout());
+    
+    // Test setting the timeout using Duration
+    config.setOAuthBrowserAuthTimeout(Duration.ofSeconds(30));
+    assertEquals(Duration.ofSeconds(30), config.getOAuthBrowserAuthTimeout());
+    
+    // Test setting the timeout using int (backward compatibility)
+    config.setOAuthBrowserAuthTimeout(60);
+    assertEquals(Duration.ofSeconds(60), config.getOAuthBrowserAuthTimeout());
+    
+    // Test setting to 0 (should be null for indefinite wait)
+    config.setOAuthBrowserAuthTimeout(0);
+    assertNull(config.getOAuthBrowserAuthTimeout());
+  }
+
+  @Test
+  public void testEnvironmentVariableLoading() {
+    // Test that environment variables are now loaded properly for Duration and Integer
+    DatabricksConfig config = new DatabricksConfig();
+    
+    // Set environment variable
+    Map<String, String> env = new HashMap<>();
+    env.put("DATABRICKS_OAUTH_BROWSER_AUTH_TIMEOUT", "30");
+    env.put("DATABRICKS_DEBUG_TRUNCATE_BYTES", "100");
+    env.put("DATABRICKS_RATE_LIMIT", "50");
+    
+    // Resolve config with environment
+    Environment environment = new Environment(env, new ArrayList<>(), "Linux");
+    config.resolve(environment);
+    
+    // These should now be loaded properly
+    assertEquals(Duration.ofSeconds(30), config.getOAuthBrowserAuthTimeout());
+    assertEquals(Integer.valueOf(100), config.getDebugTruncateBytes());
+    assertEquals(Integer.valueOf(50), config.getRateLimit());
+  }
+
+  @Test
+  public void testEnvironmentVariableLoadingZeroTimeout() {
+    // Test that environment variable with value 0 results in null Duration
+    DatabricksConfig config = new DatabricksConfig();
+    
+    // Set environment variable to 0
+    Map<String, String> env = new HashMap<>();
+    env.put("DATABRICKS_OAUTH_BROWSER_AUTH_TIMEOUT", "0");
+    
+    // Resolve config with environment
+    Environment environment = new Environment(env, new ArrayList<>(), "Linux");
+    config.resolve(environment);
+    
+    // Should be null for indefinite wait
+    assertNull(config.getOAuthBrowserAuthTimeout());
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -261,11 +261,11 @@ public class DatabricksConfigTest {
     config.setOAuthBrowserAuthTimeout(Duration.ofSeconds(30));
     assertEquals(Duration.ofSeconds(30), config.getOAuthBrowserAuthTimeout());
 
-    config.setOAuthBrowserAuthTimeout(60);
+    config.setOAuthBrowserAuthTimeout(Duration.ofSeconds(60));
     assertEquals(Duration.ofSeconds(60), config.getOAuthBrowserAuthTimeout());
 
-    config.setOAuthBrowserAuthTimeout(0);
-    assertNull(config.getOAuthBrowserAuthTimeout());
+    config.setOAuthBrowserAuthTimeout(Duration.ofSeconds(0));
+    assertEquals(Duration.ZERO, config.getOAuthBrowserAuthTimeout());
   }
 
   @Test

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -256,57 +256,30 @@ public class DatabricksConfigTest {
   public void testOAuthBrowserAuthTimeout() {
     DatabricksConfig config = new DatabricksConfig();
 
-    // Test default value (should be null)
     assertNull(config.getOAuthBrowserAuthTimeout());
 
-    // Test setting the timeout using Duration
     config.setOAuthBrowserAuthTimeout(Duration.ofSeconds(30));
     assertEquals(Duration.ofSeconds(30), config.getOAuthBrowserAuthTimeout());
 
-    // Test setting the timeout using int (backward compatibility)
     config.setOAuthBrowserAuthTimeout(60);
     assertEquals(Duration.ofSeconds(60), config.getOAuthBrowserAuthTimeout());
 
-    // Test setting to 0 (should be null for indefinite wait)
     config.setOAuthBrowserAuthTimeout(0);
     assertNull(config.getOAuthBrowserAuthTimeout());
   }
 
   @Test
   public void testEnvironmentVariableLoading() {
-    // Test that environment variables are now loaded properly for Duration and Integer
-    DatabricksConfig config = new DatabricksConfig();
-
-    // Set environment variable
     Map<String, String> env = new HashMap<>();
     env.put("DATABRICKS_OAUTH_BROWSER_AUTH_TIMEOUT", "30");
     env.put("DATABRICKS_DEBUG_TRUNCATE_BYTES", "100");
     env.put("DATABRICKS_RATE_LIMIT", "50");
 
-    // Resolve config with environment
-    Environment environment = new Environment(env, new ArrayList<>(), "Linux");
-    config.resolve(environment);
+    DatabricksConfig config = new DatabricksConfig();
+    config.resolve(new Environment(env, new ArrayList<>(), System.getProperty("os.name")));
 
-    // These should now be loaded properly
     assertEquals(Duration.ofSeconds(30), config.getOAuthBrowserAuthTimeout());
     assertEquals(Integer.valueOf(100), config.getDebugTruncateBytes());
     assertEquals(Integer.valueOf(50), config.getRateLimit());
-  }
-
-  @Test
-  public void testEnvironmentVariableLoadingZeroTimeout() {
-    // Test that environment variable with value 0 results in null Duration
-    DatabricksConfig config = new DatabricksConfig();
-
-    // Set environment variable to 0
-    Map<String, String> env = new HashMap<>();
-    env.put("DATABRICKS_OAUTH_BROWSER_AUTH_TIMEOUT", "0");
-
-    // Resolve config with environment
-    Environment environment = new Environment(env, new ArrayList<>(), "Linux");
-    config.resolve(environment);
-
-    // Should be null for indefinite wait
-    assertNull(config.getOAuthBrowserAuthTimeout());
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -255,18 +255,18 @@ public class DatabricksConfigTest {
   @Test
   public void testOAuthBrowserAuthTimeout() {
     DatabricksConfig config = new DatabricksConfig();
-    
+
     // Test default value (should be null)
     assertNull(config.getOAuthBrowserAuthTimeout());
-    
+
     // Test setting the timeout using Duration
     config.setOAuthBrowserAuthTimeout(Duration.ofSeconds(30));
     assertEquals(Duration.ofSeconds(30), config.getOAuthBrowserAuthTimeout());
-    
+
     // Test setting the timeout using int (backward compatibility)
     config.setOAuthBrowserAuthTimeout(60);
     assertEquals(Duration.ofSeconds(60), config.getOAuthBrowserAuthTimeout());
-    
+
     // Test setting to 0 (should be null for indefinite wait)
     config.setOAuthBrowserAuthTimeout(0);
     assertNull(config.getOAuthBrowserAuthTimeout());
@@ -276,17 +276,17 @@ public class DatabricksConfigTest {
   public void testEnvironmentVariableLoading() {
     // Test that environment variables are now loaded properly for Duration and Integer
     DatabricksConfig config = new DatabricksConfig();
-    
+
     // Set environment variable
     Map<String, String> env = new HashMap<>();
     env.put("DATABRICKS_OAUTH_BROWSER_AUTH_TIMEOUT", "30");
     env.put("DATABRICKS_DEBUG_TRUNCATE_BYTES", "100");
     env.put("DATABRICKS_RATE_LIMIT", "50");
-    
+
     // Resolve config with environment
     Environment environment = new Environment(env, new ArrayList<>(), "Linux");
     config.resolve(environment);
-    
+
     // These should now be loaded properly
     assertEquals(Duration.ofSeconds(30), config.getOAuthBrowserAuthTimeout());
     assertEquals(Integer.valueOf(100), config.getDebugTruncateBytes());
@@ -297,15 +297,15 @@ public class DatabricksConfigTest {
   public void testEnvironmentVariableLoadingZeroTimeout() {
     // Test that environment variable with value 0 results in null Duration
     DatabricksConfig config = new DatabricksConfig();
-    
+
     // Set environment variable to 0
     Map<String, String> env = new HashMap<>();
     env.put("DATABRICKS_OAUTH_BROWSER_AUTH_TIMEOUT", "0");
-    
+
     // Resolve config with environment
     Environment environment = new Environment(env, new ArrayList<>(), "Linux");
     config.resolve(environment);
-    
+
     // Should be null for indefinite wait
     assertNull(config.getOAuthBrowserAuthTimeout());
   }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ConsentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ConsentTest.java
@@ -2,8 +2,13 @@ package com.databricks.sdk.core.oauth;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.sdk.core.DatabricksException;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 public class ConsentTest {
@@ -22,7 +27,6 @@ public class ConsentTest {
             .withBrowserTimeout(Optional.of(Duration.ofSeconds(30)))
             .build();
 
-    // Verify that the timeout is properly set
     assertEquals(Optional.of(Duration.ofSeconds(30)), consent.getBrowserTimeout());
   }
 
@@ -39,7 +43,90 @@ public class ConsentTest {
             .withVerifier("test-verifier")
             .build();
 
-    // Verify that the timeout is empty when not set
     assertEquals(Optional.empty(), consent.getBrowserTimeout());
+  }
+
+  @Test
+  public void testTimeoutLogicWithShortTimeout() throws InterruptedException {
+    // Test that timeout is enforced correctly.
+    Consent.CallbackResponseHandler handler =
+        new Consent.CallbackResponseHandler(Optional.of(Duration.ofMillis(100))); // 100ms timeout
+
+    long startTime = System.currentTimeMillis();
+
+    try {
+      handler.getParams();
+      fail("Expected timeout exception");
+    } catch (DatabricksException e) {
+      long elapsedTime = System.currentTimeMillis() - startTime;
+      assertTrue(
+          elapsedTime >= 100, "Timeout should have taken at least 100ms, but took " + elapsedTime);
+      assertTrue(e.getMessage().contains("timed out after 0 seconds"));
+    }
+  }
+
+  @Test
+  public void testTimeoutLogicWithNoTimeout() throws InterruptedException {
+    // Test that no timeout means indefinite wait.
+    Consent.CallbackResponseHandler handler = new Consent.CallbackResponseHandler(Optional.empty());
+
+    CountDownLatch latch = new CountDownLatch(1);
+
+    Thread setterThread =
+        new Thread(
+            () -> {
+              try {
+                Thread.sleep(50);
+                synchronized (handler.lock) {
+                  Map<String, String> params = new HashMap<>();
+                  params.put("code", "test-code");
+                  params.put("state", "test-state");
+                  handler.setParams(params);
+                }
+                latch.countDown();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
+
+    setterThread.start();
+
+    Map<String, String> result = handler.getParams();
+    assertNotNull(result);
+    assertEquals("test-code", result.get("code"));
+    assertEquals("test-state", result.get("state"));
+    assertTrue(latch.await(1, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void testTimeoutLogicWithParamsSetBeforeTimeout() throws InterruptedException {
+    // Test that if params are set before timeout, no exception is thrown.
+    Consent.CallbackResponseHandler handler =
+        new Consent.CallbackResponseHandler(Optional.of(Duration.ofSeconds(1)));
+
+    CountDownLatch latch = new CountDownLatch(1);
+
+    Thread setterThread =
+        new Thread(
+            () -> {
+              try {
+                Thread.sleep(50);
+                synchronized (handler.lock) {
+                  Map<String, String> params = new HashMap<>();
+                  params.put("code", "test-code");
+                  handler.setParams(params);
+                }
+                latch.countDown();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
+
+    setterThread.start();
+
+    Map<String, String> result = handler.getParams();
+    assertNotNull(result);
+    assertEquals("test-code", result.get("code"));
+    assertTrue(latch.await(1, TimeUnit.SECONDS));
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ConsentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ConsentTest.java
@@ -1,0 +1,43 @@
+package com.databricks.sdk.core.oauth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class ConsentTest {
+
+  @Test
+  public void testConsentWithBrowserAuthTimeout() {
+    Consent consent = new Consent.Builder()
+        .withClientId("test-client-id")
+        .withClientSecret("test-client-secret")
+        .withAuthUrl("https://test.com/auth")
+        .withTokenUrl("https://test.com/token")
+        .withRedirectUrl("http://localhost:8080/callback")
+        .withState("test-state")
+        .withVerifier("test-verifier")
+        .withBrowserTimeout(Duration.ofSeconds(30))
+        .build();
+
+    // Verify that the timeout is properly set
+    assertEquals(Optional.of(Duration.ofSeconds(30)), consent.getBrowserTimeout());
+  }
+
+  @Test
+  public void testConsentWithoutBrowserAuthTimeout() {
+    Consent consent = new Consent.Builder()
+        .withClientId("test-client-id")
+        .withClientSecret("test-client-secret")
+        .withAuthUrl("https://test.com/auth")
+        .withTokenUrl("https://test.com/token")
+        .withRedirectUrl("http://localhost:8080/callback")
+        .withState("test-state")
+        .withVerifier("test-verifier")
+        .build();
+
+    // Verify that the timeout is empty when not set
+    assertEquals(Optional.empty(), consent.getBrowserTimeout());
+  }
+} 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ConsentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ConsentTest.java
@@ -10,16 +10,17 @@ public class ConsentTest {
 
   @Test
   public void testConsentWithBrowserAuthTimeout() {
-    Consent consent = new Consent.Builder()
-        .withClientId("test-client-id")
-        .withClientSecret("test-client-secret")
-        .withAuthUrl("https://test.com/auth")
-        .withTokenUrl("https://test.com/token")
-        .withRedirectUrl("http://localhost:8080/callback")
-        .withState("test-state")
-        .withVerifier("test-verifier")
-        .withBrowserTimeout(Duration.ofSeconds(30))
-        .build();
+    Consent consent =
+        new Consent.Builder()
+            .withClientId("test-client-id")
+            .withClientSecret("test-client-secret")
+            .withAuthUrl("https://test.com/auth")
+            .withTokenUrl("https://test.com/token")
+            .withRedirectUrl("http://localhost:8080/callback")
+            .withState("test-state")
+            .withVerifier("test-verifier")
+            .withBrowserTimeout(Duration.ofSeconds(30))
+            .build();
 
     // Verify that the timeout is properly set
     assertEquals(Optional.of(Duration.ofSeconds(30)), consent.getBrowserTimeout());
@@ -27,17 +28,18 @@ public class ConsentTest {
 
   @Test
   public void testConsentWithoutBrowserAuthTimeout() {
-    Consent consent = new Consent.Builder()
-        .withClientId("test-client-id")
-        .withClientSecret("test-client-secret")
-        .withAuthUrl("https://test.com/auth")
-        .withTokenUrl("https://test.com/token")
-        .withRedirectUrl("http://localhost:8080/callback")
-        .withState("test-state")
-        .withVerifier("test-verifier")
-        .build();
+    Consent consent =
+        new Consent.Builder()
+            .withClientId("test-client-id")
+            .withClientSecret("test-client-secret")
+            .withAuthUrl("https://test.com/auth")
+            .withTokenUrl("https://test.com/token")
+            .withRedirectUrl("http://localhost:8080/callback")
+            .withState("test-state")
+            .withVerifier("test-verifier")
+            .build();
 
     // Verify that the timeout is empty when not set
     assertEquals(Optional.empty(), consent.getBrowserTimeout());
   }
-} 
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ConsentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ConsentTest.java
@@ -19,7 +19,7 @@ public class ConsentTest {
             .withRedirectUrl("http://localhost:8080/callback")
             .withState("test-state")
             .withVerifier("test-verifier")
-            .withBrowserTimeout(Duration.ofSeconds(30))
+            .withBrowserTimeout(Optional.of(Duration.ofSeconds(30)))
             .build();
 
     // Verify that the timeout is properly set


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a configurable timeout for OAuth browser authentication in the Databricks SDK for Java. 

The OAuth browser authentication flow currently waits indefinitely for user interaction, which can cause applications to hang indefinitely if users don't complete the authentication process.

The key changes include:

- New configuration option: Added `setOAuthBrowserAuthTimeout(Duration timeout)` to `DatabricksConfig` with environment variable support via `DATABRICKS_OAUTH_BROWSER_AUTH_TIMEOUT`.
- Timeout implementation: Modified the OAuth consent flow in Consent.CallbackResponseHandler to enforce the configured timeout when waiting for browser callback parameters.
- Bug fixes: Fixed ConfigAttributeAccessor to properly handle Duration, Integer, and Boolean types from environment variables.

## How is this tested?

Added unit tests to verify that env variables are properly loaded and that the timeout logic works as expected.