### PR TITLE
Enable Encryption Keys test

### DIFF
--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/EncryptionKeysIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/EncryptionKeysIT.java
@@ -1,23 +1,23 @@
 package com.databricks.sdk.integration;
 
+import com.databricks.sdk.AccountClient;
+import com.databricks.sdk.integration.framework.CollectionUtils;
 import com.databricks.sdk.integration.framework.EnvContext;
 import com.databricks.sdk.integration.framework.EnvTest;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import com.databricks.sdk.service.provisioning.CustomerManagedKey;
+import org.junit.jupiter.api.Test;import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @EnvContext("account")
 @DisabledIfEnvironmentVariable(named = "ARM_CLIENT_ID", matches = ".*")
 @ExtendWith(EnvTest.class)
 public class EncryptionKeysIT {
-  // TODO: Enable this test when the test account is updated to support this.
-  // Either by upgrading the test account tier to Enterprise or by adding this
-  // feature to the test account.
-  // @Test
-  // void lists(AccountClient a) {
-  //   Iterable<CustomerManagedKey> list = a.encryptionKeys().list();
+  @Test
+  void lists(AccountClient a) {
+    Iterable<CustomerManagedKey> list = a.encryptionKeys().list();
 
-  //   java.util.List<CustomerManagedKey> all = CollectionUtils.asList(list);
+    java.util.List<CustomerManagedKey> all = CollectionUtils.asList(list);
 
-  //   CollectionUtils.assertUnique(all);
-  // }
+    CollectionUtils.assertUnique(all);
+  }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/EncryptionKeysIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/EncryptionKeysIT.java
@@ -5,7 +5,8 @@ import com.databricks.sdk.integration.framework.CollectionUtils;
 import com.databricks.sdk.integration.framework.EnvContext;
 import com.databricks.sdk.integration.framework.EnvTest;
 import com.databricks.sdk.service.provisioning.CustomerManagedKey;
-import org.junit.jupiter.api.Test;import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @EnvContext("account")


### PR DESCRIPTION
## What changes are proposed in this pull request?

This test was disabled because the test account didn't have the right privileges to perform this action. But it does now, so I'm enabling the test again.

## How is this tested?
This is a test.

NO_CHANGELOG=true