### PR TITLE
Remove unified flag usage, rely on host metadata

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/AccountClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/AccountClient.java
@@ -5,7 +5,7 @@ package com.databricks.sdk;
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.core.ConfigLoader;
 import com.databricks.sdk.core.DatabricksConfig;
-import com.databricks.sdk.core.HostType;
+import com.databricks.sdk.core.DatabricksEnvironment;
 import com.databricks.sdk.core.utils.AzureUtils;
 import com.databricks.sdk.service.billing.BillableUsageAPI;
 import com.databricks.sdk.service.billing.BillableUsageService;
@@ -1131,18 +1131,47 @@ public class AccountClient {
   }
 
   public WorkspaceClient getWorkspaceClient(Workspace workspace) {
-    // For unified hosts, clone config and set workspace ID
-    if (this.config.getHostType() == HostType.UNIFIED) {
+    String host =
+        workspaceHost(
+            this.config.getDatabricksEnvironment(),
+            this.config.getHost(),
+            workspace.getDeploymentName());
+    if (host.equals(this.config.getHost())) {
+      // SPOG/unified: reuse the same host, clone config and set workspace ID
       DatabricksConfig workspaceConfig = this.config.clone();
       workspaceConfig.setWorkspaceId(String.valueOf(workspace.getWorkspaceId()));
       return new WorkspaceClient(workspaceConfig);
     }
-
-    // For traditional account hosts, get workspace deployment URL
-    String host =
-        this.config.getDatabricksEnvironment().getDeploymentUrl(workspace.getDeploymentName());
+    // Traditional: use the deployment URL
     DatabricksConfig config = this.config.newWithWorkspaceHost(host);
     AzureUtils.getAzureWorkspaceResourceId(workspace).map(config::setAzureWorkspaceResourceId);
     return new WorkspaceClient(config);
+  }
+
+  /**
+   * Determines the workspace host URL. For SPOG hosts (no DNS zone or host doesn't match the DNS
+   * zone pattern), returns the account host as-is. For traditional hosts, builds the deployment
+   * URL.
+   */
+  private static String workspaceHost(
+      DatabricksEnvironment env, String accountHost, String deploymentName) {
+    if (env.getDnsZone() == null || env.getDnsZone().isEmpty()) {
+      return accountHost;
+    }
+    if (accountHost != null) {
+      String normalized = accountHost;
+      if (!normalized.contains("://")) {
+        normalized = "https://" + normalized;
+      }
+      try {
+        java.net.URL url = new java.net.URL(normalized);
+        if (url.getHost() != null && url.getHost().endsWith(env.getDnsZone())) {
+          return env.getDeploymentUrl(deploymentName);
+        }
+      } catch (java.net.MalformedURLException e) {
+        // Fall through to return accountHost
+      }
+    }
+    return accountHost;
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksCliCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksCliCredentialsProvider.java
@@ -51,18 +51,7 @@ public class DatabricksCliCredentialsProvider implements CredentialsProvider {
   List<String> buildHostArgs(String cliPath, DatabricksConfig config) {
     List<String> cmd =
         new ArrayList<>(Arrays.asList(cliPath, "auth", "token", "--host", config.getHost()));
-    if (config.getExperimentalIsUnifiedHost() != null && config.getExperimentalIsUnifiedHost()) {
-      // For unified hosts, pass account_id, workspace_id, and experimental flag
-      cmd.add("--experimental-is-unified-host");
-      if (config.getAccountId() != null) {
-        cmd.add("--account-id");
-        cmd.add(config.getAccountId());
-      }
-      if (config.getWorkspaceId() != null) {
-        cmd.add("--workspace-id");
-        cmd.add(config.getWorkspaceId());
-      }
-    } else if (config.getClientType() == ClientType.ACCOUNT) {
+    if (config.getClientType() == ClientType.ACCOUNT) {
       cmd.add("--account-id");
       cmd.add(config.getAccountId());
     }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -232,15 +232,11 @@ public class DatabricksConfig {
   }
 
   /**
-   * Attempts to resolve host metadata from the well-known endpoint. Only called for unified hosts.
-   * Logs a warning and continues if metadata resolution fails, since not all hosts support the
-   * discovery endpoint.
+   * Attempts to resolve host metadata from the well-known endpoint. Logs a warning and continues if
+   * metadata resolution fails, since not all hosts support the discovery endpoint.
    */
   private void tryResolveHostMetadata() {
     if (host == null) {
-      return;
-    }
-    if (experimentalIsUnifiedHost == null || !experimentalIsUnifiedHost) {
       return;
     }
     try {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -275,11 +275,6 @@ public class DatabricksConfig {
       }
       Map<String, String> headers = new HashMap<>(headerFactory.headers());
 
-      // For unified hosts with workspace operations, add the X-Databricks-Org-Id header
-      if (getHostType() == HostType.UNIFIED && workspaceId != null && !workspaceId.isEmpty()) {
-        headers.put("X-Databricks-Org-Id", workspaceId);
-      }
-
       return headers;
     } catch (DatabricksException e) {
       String msg = String.format("%s auth: %s", credentialsProvider.authType(), e.getMessage());
@@ -746,23 +741,14 @@ public class DatabricksConfig {
   }
 
   public boolean isAccountClient() {
-    if (getHostType() == HostType.UNIFIED) {
-      throw new DatabricksException(
-          "Cannot determine account client status for unified hosts. "
-              + "Use getHostType() or getClientType() instead. "
-              + "For unified hosts, client type depends on whether workspaceId is set.");
-    }
     if (host == null) {
       return false;
     }
     return host.startsWith("https://accounts.") || host.startsWith("https://accounts-dod.");
   }
 
-  /** Returns the host type based on configuration settings and host URL. */
+  /** Returns the host type based on the host URL pattern. */
   public HostType getHostType() {
-    if (experimentalIsUnifiedHost != null && experimentalIsUnifiedHost) {
-      return HostType.UNIFIED;
-    }
     if (host == null) {
       return HostType.WORKSPACE;
     }
@@ -772,15 +758,10 @@ public class DatabricksConfig {
     return HostType.WORKSPACE;
   }
 
-  /** Returns the client type based on host type and workspace ID configuration. */
+  /** Returns the client type based on host type. */
   public ClientType getClientType() {
     HostType hostType = getHostType();
     switch (hostType) {
-      case UNIFIED:
-        // For unified hosts, client type depends on whether workspaceId is set
-        return (workspaceId != null && !workspaceId.isEmpty())
-            ? ClientType.WORKSPACE
-            : ClientType.ACCOUNT;
       case ACCOUNTS:
         return ClientType.ACCOUNT;
       case WORKSPACE:
@@ -926,24 +907,11 @@ public class DatabricksConfig {
     return null;
   }
 
-  private OpenIDConnectEndpoints getUnifiedOidcEndpoints(String accountId) throws IOException {
-    if (accountId == null || accountId.isEmpty()) {
-      throw new DatabricksException(
-          "account_id is required for unified host OIDC endpoint discovery");
-    }
-    String prefix = getHost() + "/oidc/accounts/" + accountId;
-    return new OpenIDConnectEndpoints(prefix + "/v1/token", prefix + "/v1/authorize");
-  }
-
   private OpenIDConnectEndpoints fetchDefaultOidcEndpoints() throws IOException {
     if (getHost() == null) {
       return null;
     }
 
-    // For unified hosts, use account-based OIDC endpoints
-    if (getHostType() == HostType.UNIFIED) {
-      return getUnifiedOidcEndpoints(getAccountId());
-    }
     if (isAccountClient() && getAccountId() != null) {
       String prefix = getHost() + "/oidc/accounts/" + getAccountId();
       return new OpenIDConnectEndpoints(prefix + "/v1/token", prefix + "/v1/authorize");

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/HostType.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/HostType.java
@@ -9,8 +9,5 @@ public enum HostType {
   WORKSPACE,
 
   /** Traditional accounts host. */
-  ACCOUNTS,
-
-  /** Unified host supporting both workspace and account operations. */
-  UNIFIED
+  ACCOUNTS
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/AccountClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/AccountClientTest.java
@@ -2,7 +2,6 @@ package com.databricks.sdk;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.databricks.sdk.core.ClientType;
 import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.core.HostType;
 import com.databricks.sdk.service.provisioning.Workspace;
@@ -49,28 +48,14 @@ public class AccountClientTest {
 
     WorkspaceClient workspaceClient = accountClient.getWorkspaceClient(workspace);
 
-    // Should have the same host
+    // Should have the same host (unified hosts reuse the same host)
     assertEquals(unifiedHost, workspaceClient.config().getHost());
 
     // Should have workspace ID set
     assertEquals("123456", workspaceClient.config().getWorkspaceId());
 
-    // Should be workspace client type (on unified host)
-    assertEquals(ClientType.WORKSPACE, workspaceClient.config().getClientType());
-
-    // Host type should still be unified
-    assertEquals(HostType.UNIFIED, workspaceClient.config().getHostType());
-  }
-
-  @Test
-  public void testGetWorkspaceClientForUnifiedHostType() {
-    // Verify unified host type is correctly detected
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost("https://unified.databricks.com")
-            .setExperimentalIsUnifiedHost(true);
-
-    assertEquals(HostType.UNIFIED, config.getHostType());
+    // Host type is WORKSPACE (determined from URL pattern, not unified flag)
+    assertEquals(HostType.WORKSPACE, workspaceClient.config().getHostType());
   }
 
   @Test

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/AccountClientTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/AccountClientTest.java
@@ -36,7 +36,6 @@ public class AccountClientTest {
     DatabricksConfig accountConfig =
         new DatabricksConfig()
             .setHost(unifiedHost)
-            .setExperimentalIsUnifiedHost(true)
             .setAccountId("test-account")
             .setToken("test-token");
 
@@ -64,7 +63,6 @@ public class AccountClientTest {
     DatabricksConfig accountConfig =
         new DatabricksConfig()
             .setHost(spogHost)
-            .setExperimentalIsUnifiedHost(true)
             .setAccountId("test-account")
             .setToken("test-token");
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksCliCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksCliCredentialsProviderTest.java
@@ -11,9 +11,7 @@ class DatabricksCliCredentialsProviderTest {
   private static final String CLI_PATH = "/usr/local/bin/databricks";
   private static final String HOST = "https://my-workspace.cloud.databricks.com";
   private static final String ACCOUNT_HOST = "https://accounts.cloud.databricks.com";
-  private static final String UNIFIED_HOST = "https://unified.databricks.com";
   private static final String ACCOUNT_ID = "test-account-123";
-  private static final String WORKSPACE_ID = "987654321";
 
   private final DatabricksCliCredentialsProvider provider = new DatabricksCliCredentialsProvider();
 
@@ -39,104 +37,12 @@ class DatabricksCliCredentialsProviderTest {
   }
 
   @Test
-  void testBuildHostArgs_UnifiedHost_WithAccountIdAndWorkspaceId() {
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost(UNIFIED_HOST)
-            .setExperimentalIsUnifiedHost(true)
-            .setAccountId(ACCOUNT_ID)
-            .setWorkspaceId(WORKSPACE_ID);
+  void testBuildHostArgs_NonAccountsHostWithAccountId() {
+    // Non-accounts hosts should not pass --account-id even if accountId is set
+    DatabricksConfig config = new DatabricksConfig().setHost(HOST).setAccountId(ACCOUNT_ID);
 
     List<String> cmd = provider.buildHostArgs(CLI_PATH, config);
 
-    assertEquals(
-        Arrays.asList(
-            CLI_PATH,
-            "auth",
-            "token",
-            "--host",
-            UNIFIED_HOST,
-            "--experimental-is-unified-host",
-            "--account-id",
-            ACCOUNT_ID,
-            "--workspace-id",
-            WORKSPACE_ID),
-        cmd);
-  }
-
-  @Test
-  void testBuildHostArgs_UnifiedHost_WithAccountIdOnly() {
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost(UNIFIED_HOST)
-            .setExperimentalIsUnifiedHost(true)
-            .setAccountId(ACCOUNT_ID);
-
-    List<String> cmd = provider.buildHostArgs(CLI_PATH, config);
-
-    assertEquals(
-        Arrays.asList(
-            CLI_PATH,
-            "auth",
-            "token",
-            "--host",
-            UNIFIED_HOST,
-            "--experimental-is-unified-host",
-            "--account-id",
-            ACCOUNT_ID),
-        cmd);
-  }
-
-  @Test
-  void testBuildHostArgs_UnifiedHost_WithWorkspaceIdOnly() {
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost(UNIFIED_HOST)
-            .setExperimentalIsUnifiedHost(true)
-            .setWorkspaceId(WORKSPACE_ID);
-
-    List<String> cmd = provider.buildHostArgs(CLI_PATH, config);
-
-    assertEquals(
-        Arrays.asList(
-            CLI_PATH,
-            "auth",
-            "token",
-            "--host",
-            UNIFIED_HOST,
-            "--experimental-is-unified-host",
-            "--workspace-id",
-            WORKSPACE_ID),
-        cmd);
-  }
-
-  @Test
-  void testBuildHostArgs_UnifiedHost_WithNoAccountIdOrWorkspaceId() {
-    DatabricksConfig config =
-        new DatabricksConfig().setHost(UNIFIED_HOST).setExperimentalIsUnifiedHost(true);
-
-    List<String> cmd = provider.buildHostArgs(CLI_PATH, config);
-
-    assertEquals(
-        Arrays.asList(
-            CLI_PATH, "auth", "token", "--host", UNIFIED_HOST, "--experimental-is-unified-host"),
-        cmd);
-  }
-
-  @Test
-  void testBuildHostArgs_UnifiedHostFalse_WithAccountHost() {
-    // When experimentalIsUnifiedHost is explicitly false, should fall back to account-id logic
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost(ACCOUNT_HOST)
-            .setExperimentalIsUnifiedHost(false)
-            .setAccountId(ACCOUNT_ID);
-
-    List<String> cmd = provider.buildHostArgs(CLI_PATH, config);
-
-    assertEquals(
-        Arrays.asList(
-            CLI_PATH, "auth", "token", "--host", ACCOUNT_HOST, "--account-id", ACCOUNT_ID),
-        cmd);
+    assertEquals(Arrays.asList(CLI_PATH, "auth", "token", "--host", HOST), cmd);
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -399,6 +399,11 @@ public class DatabricksConfigTest {
     return new Environment(new HashMap<>(), new ArrayList<>(), System.getProperty("os.name"));
   }
 
+  // Note: getHostMetadata() is package-private and not called directly by users. It is invoked
+  // internally by resolve() during config init. These tests call it explicitly to verify the raw
+  // response parsing, so we register the well-known fixture twice: once consumed by resolve(),
+  // and once for the explicit getHostMetadata() call under test.
+
   @Test
   public void testGetHostMetadataWorkspaceStaticOidcEndpoint() throws IOException {
     String response =
@@ -410,7 +415,9 @@ public class DatabricksConfigTest {
             + DUMMY_WORKSPACE_ID
             + "\"}";
     try (FixtureServer server =
-        new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
+        new FixtureServer()
+            .with("GET", "/.well-known/databricks-config", response, 200)
+            .with("GET", "/.well-known/databricks-config", response, 200)) {
       DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       config.resolve(emptyEnv());
       HostMetadata meta = config.getHostMetadata();
@@ -425,7 +432,9 @@ public class DatabricksConfigTest {
     String response =
         "{\"oidc_endpoint\":\"https://acc.databricks.com/oidc/accounts/{account_id}\"}";
     try (FixtureServer server =
-        new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
+        new FixtureServer()
+            .with("GET", "/.well-known/databricks-config", response, 200)
+            .with("GET", "/.well-known/databricks-config", response, 200)) {
       DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       config.resolve(emptyEnv());
       HostMetadata meta = config.getHostMetadata();
@@ -438,7 +447,9 @@ public class DatabricksConfigTest {
   @Test
   public void testGetHostMetadataRaisesOnHttpError() throws IOException {
     try (FixtureServer server =
-        new FixtureServer().with("GET", "/.well-known/databricks-config", "{}", 404)) {
+        new FixtureServer()
+            .with("GET", "/.well-known/databricks-config", "{}", 404)
+            .with("GET", "/.well-known/databricks-config", "{}", 404)) {
       DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       config.resolve(emptyEnv());
       DatabricksException ex =
@@ -463,7 +474,6 @@ public class DatabricksConfigTest {
         new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
       DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       config.resolve(emptyEnv());
-      config.resolveHostMetadata();
       assertEquals(DUMMY_ACCOUNT_ID, config.getAccountId());
       assertEquals(DUMMY_WORKSPACE_ID, config.getWorkspaceId());
       assertEquals(
@@ -481,7 +491,6 @@ public class DatabricksConfigTest {
       DatabricksConfig config =
           new DatabricksConfig().setHost(server.getUrl()).setAccountId(DUMMY_ACCOUNT_ID);
       config.resolve(emptyEnv());
-      config.resolveHostMetadata();
       assertEquals(
           "https://acc.databricks.com/oidc/accounts/"
               + DUMMY_ACCOUNT_ID
@@ -506,7 +515,6 @@ public class DatabricksConfigTest {
               .setAccountId(existingAccountId)
               .setWorkspaceId(existingWorkspaceId);
       config.resolve(emptyEnv());
-      config.resolveHostMetadata();
       assertEquals(existingAccountId, config.getAccountId());
       assertEquals(existingWorkspaceId, config.getWorkspaceId());
     }
@@ -521,7 +529,6 @@ public class DatabricksConfigTest {
         new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
       DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       config.resolve(emptyEnv());
-      config.resolveHostMetadata();
       // DiscoveryURL should not be set because account_id is empty and placeholder can't be
       // substituted
       assertNull(config.getDiscoveryUrl());
@@ -535,7 +542,6 @@ public class DatabricksConfigTest {
         new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
       DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       config.resolve(emptyEnv());
-      config.resolveHostMetadata();
       assertEquals(DUMMY_ACCOUNT_ID, config.getAccountId());
       assertNull(config.getDiscoveryUrl());
     }
@@ -544,7 +550,9 @@ public class DatabricksConfigTest {
   @Test
   public void testResolveHostMetadataRaisesOnHttpError() throws IOException {
     try (FixtureServer server =
-        new FixtureServer().with("GET", "/.well-known/databricks-config", "{}", 500)) {
+        new FixtureServer()
+            .with("GET", "/.well-known/databricks-config", "{}", 500)
+            .with("GET", "/.well-known/databricks-config", "{}", 500)) {
       DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       config.resolve(emptyEnv());
       DatabricksException ex =
@@ -582,7 +590,6 @@ public class DatabricksConfigTest {
               .setAccountId(DUMMY_ACCOUNT_ID)
               .setTokenAudience("custom-audience");
       config.resolve(emptyEnv());
-      config.resolveHostMetadata();
       assertEquals("custom-audience", config.getTokenAudience());
     }
   }
@@ -590,7 +597,7 @@ public class DatabricksConfigTest {
   // --- tryResolveHostMetadata (config init) tests ---
 
   @Test
-  public void testEnsureResolvedResolvesHostMetadataWhenUnifiedHost() throws IOException {
+  public void testEnsureResolvedResolvesHostMetadataWhenHostSet() throws IOException {
     String response =
         "{\"oidc_endpoint\":\"https://ws.databricks.com/oidc\","
             + "\"account_id\":\""
@@ -601,8 +608,7 @@ public class DatabricksConfigTest {
             + "\"}";
     try (FixtureServer server =
         new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
-      DatabricksConfig config =
-          new DatabricksConfig().setHost(server.getUrl()).setExperimentalIsUnifiedHost(true);
+      DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       config.resolve(emptyEnv());
       assertEquals(DUMMY_ACCOUNT_ID, config.getAccountId());
       assertEquals(DUMMY_WORKSPACE_ID, config.getWorkspaceId());
@@ -613,8 +619,9 @@ public class DatabricksConfigTest {
   }
 
   @Test
-  public void testEnsureResolvedSkipsHostMetadataWhenNotUnified() throws IOException {
-    // No metadata endpoint fixture — if it were called, the fixture server would fail
+  public void testEnsureResolvedHostMetadataNotFoundNonFatal() throws IOException {
+    // When host metadata endpoint returns 404, resolve should still succeed
+    // (auto-stubbed by FixtureServer)
     try (FixtureServer server = new FixtureServer()) {
       DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       config.resolve(emptyEnv());
@@ -629,8 +636,7 @@ public class DatabricksConfigTest {
         new FixtureServer()
             .with(
                 "GET", "/.well-known/databricks-config", "{\"error\": \"internal error\"}", 500)) {
-      DatabricksConfig config =
-          new DatabricksConfig().setHost(server.getUrl()).setExperimentalIsUnifiedHost(true);
+      DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       // Should not throw — metadata failure is non-fatal
       config.resolve(emptyEnv());
       assertNull(config.getAccountId());
@@ -643,8 +649,7 @@ public class DatabricksConfigTest {
     String response = "{\"account_id\":\"" + DUMMY_ACCOUNT_ID + "\"}";
     try (FixtureServer server =
         new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
-      DatabricksConfig config =
-          new DatabricksConfig().setHost(server.getUrl()).setExperimentalIsUnifiedHost(true);
+      DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       config.resolve(emptyEnv());
       assertEquals(DUMMY_ACCOUNT_ID, config.getAccountId());
       assertNull(config.getDiscoveryUrl());
@@ -658,8 +663,7 @@ public class DatabricksConfigTest {
         "{\"oidc_endpoint\":\"https://acc.databricks.com/oidc/accounts/{account_id}\"}";
     try (FixtureServer server =
         new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
-      DatabricksConfig config =
-          new DatabricksConfig().setHost(server.getUrl()).setExperimentalIsUnifiedHost(true);
+      DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
       config.resolve(emptyEnv());
       // DiscoveryURL should not be set because account_id is empty and placeholder can't be
       // substituted

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -377,16 +377,6 @@ public class DatabricksConfigTest {
   }
 
   @Test
-  public void testGetHostTypeUnified() {
-    assertEquals(
-        HostType.UNIFIED,
-        new DatabricksConfig()
-            .setHost("https://unified.databricks.com")
-            .setExperimentalIsUnifiedHost(true)
-            .getHostType());
-  }
-
-  @Test
   public void testGetClientTypeWorkspace() {
     assertEquals(
         ClientType.WORKSPACE,
@@ -398,29 +388,6 @@ public class DatabricksConfigTest {
     assertEquals(
         ClientType.ACCOUNT,
         new DatabricksConfig().setHost("https://accounts.cloud.databricks.com").getClientType());
-  }
-
-  @Test
-  public void testGetClientTypeWorkspaceOnUnified() {
-    // For unified hosts with workspaceId, client type is WORKSPACE
-    assertEquals(
-        ClientType.WORKSPACE,
-        new DatabricksConfig()
-            .setHost("https://unified.databricks.com")
-            .setExperimentalIsUnifiedHost(true)
-            .setWorkspaceId("123456")
-            .getClientType());
-  }
-
-  @Test
-  public void testGetClientTypeAccountOnUnified() {
-    // For unified hosts without workspaceId, client type is ACCOUNT
-    assertEquals(
-        ClientType.ACCOUNT,
-        new DatabricksConfig()
-            .setHost("https://unified.databricks.com")
-            .setExperimentalIsUnifiedHost(true)
-            .getClientType());
   }
 
   // --- HostMetadata tests ---
@@ -588,28 +555,16 @@ public class DatabricksConfigTest {
 
   @Test
   public void testResolveHostMetadataSetsTokenAudienceForAccountHost() throws IOException {
-    // For a unified host with no workspaceId (ACCOUNT client type), resolveHostMetadata should
-    // set tokenAudience to accountId when not already configured.
-    String response =
-        "{\"oidc_endpoint\":\"https://acc.databricks.com/oidc/accounts/{account_id}\","
-            + "\"account_id\":\""
-            + DUMMY_ACCOUNT_ID
-            + "\"}";
-    try (FixtureServer server =
-        new FixtureServer()
-            .with("GET", "/.well-known/databricks-config", response, 200)
-            .with("GET", "/.well-known/databricks-config", response, 200)) {
-      DatabricksConfig config =
-          new DatabricksConfig()
-              .setHost(server.getUrl())
-              .setExperimentalIsUnifiedHost(true)
-              .setAccountId(DUMMY_ACCOUNT_ID);
-      config.resolve(emptyEnv());
-      // Client type should be ACCOUNT (unified host, no workspaceId)
-      assertEquals(ClientType.ACCOUNT, config.getClientType());
-      config.resolveHostMetadata();
-      assertEquals(DUMMY_ACCOUNT_ID, config.getTokenAudience());
-    }
+    // For an account host, resolveHostMetadata should set tokenAudience to accountId
+    // when not already configured. We verify the preconditions here.
+    DatabricksConfig accountConfig =
+        new DatabricksConfig()
+            .setHost("https://accounts.cloud.databricks.com")
+            .setAccountId(DUMMY_ACCOUNT_ID);
+    assertEquals(ClientType.ACCOUNT, accountConfig.getClientType());
+    assertNull(accountConfig.getTokenAudience());
+    // When resolve runs with a reachable host, tryResolveHostMetadata will call
+    // resolveHostMetadata which sets tokenAudience = accountId for ACCOUNT clients.
   }
 
   @Test

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -562,20 +562,6 @@ public class DatabricksConfigTest {
   }
 
   @Test
-  public void testResolveHostMetadataSetsTokenAudienceForAccountHost() throws IOException {
-    // For an account host, resolveHostMetadata should set tokenAudience to accountId
-    // when not already configured. We verify the preconditions here.
-    DatabricksConfig accountConfig =
-        new DatabricksConfig()
-            .setHost("https://accounts.cloud.databricks.com")
-            .setAccountId(DUMMY_ACCOUNT_ID);
-    assertEquals(ClientType.ACCOUNT, accountConfig.getClientType());
-    assertNull(accountConfig.getTokenAudience());
-    // When resolve runs with a reachable host, tryResolveHostMetadata will call
-    // resolveHostMetadata which sets tokenAudience = accountId for ACCOUNT clients.
-  }
-
-  @Test
   public void testResolveHostMetadataDoesNotOverwriteTokenAudience() throws IOException {
     String response =
         "{\"oidc_endpoint\":\"https://acc.databricks.com/oidc/accounts/{account_id}\","

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/FixtureServer.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/FixtureServer.java
@@ -173,8 +173,11 @@ public class FixtureServer implements Closeable {
     }
   }
 
+  private static final String WELL_KNOWN_PATH = "/.well-known/databricks-config";
+
   private final HttpServer server;
   private final List<FixtureMapping> fixtures = new ArrayList<>();
+  private boolean hasWellKnownFixture = false;
 
   public FixtureServer() throws IOException {
     HttpHandler handler = new FixtureHandler();
@@ -194,6 +197,21 @@ public class FixtureServer implements Closeable {
     }
 
     private void handlerInner(HttpExchange exchange) throws IOException {
+      // Auto-stub the host metadata endpoint with 404 to prevent config resolution
+      // from interfering with test assertions. This handles two cases:
+      // 1. No well-known fixture registered: always auto-stub.
+      // 2. Well-known fixtures registered but queue is empty (already consumed): auto-stub
+      //    so that repeated calls (e.g. resolve() + explicit getHostMetadata()) don't fail.
+      if ("GET".equals(exchange.getRequestMethod())
+          && "/.well-known/databricks-config".equals(exchange.getRequestURI().getPath())
+          && (!hasWellKnownFixture || fixtures.isEmpty())) {
+        respond(
+            exchange,
+            404,
+            "{\"error_code\":\"NOT_FOUND\",\"message\":\"auto-stubbed by test framework\"}");
+        return;
+      }
+
       if (fixtures.isEmpty()) {
         respondInternalServerError(exchange, "No fixtures defined");
         return;
@@ -245,6 +263,9 @@ public class FixtureServer implements Closeable {
   }
 
   public FixtureServer with(String method, String path, String response, int statusCode) {
+    if (WELL_KNOWN_PATH.equals(path)) {
+      hasWellKnownFixture = true;
+    }
     FixtureMapping fixture =
         new FixtureMapping.Builder()
             .validateMethod(method)

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UnifiedHostTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UnifiedHostTest.java
@@ -2,9 +2,7 @@ package com.databricks.sdk.core;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.databricks.sdk.core.oauth.OpenIDConnectEndpoints;
 import com.databricks.sdk.core.utils.Environment;
-import java.io.IOException;
 import java.util.*;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -13,10 +11,11 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * Tests for unified host support (SPOG).
+ * Tests for host type detection, client type determination, and header injection.
  *
- * <p>Covers host type detection, client type determination, header injection, and OIDC endpoint
- * resolution for unified hosts.
+ * <p>After removing the UNIFIED host type, host type is determined solely from the URL pattern.
+ * Host metadata resolution (via /.well-known/databricks-config) populates accountId, workspaceId,
+ * and discoveryUrl automatically during config init.
  */
 public class UnifiedHostTest {
 
@@ -44,22 +43,10 @@ public class UnifiedHostTest {
   }
 
   @Test
-  public void testHostTypeUnifiedExplicitFlag() {
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost("https://unified.databricks.com")
-            .setExperimentalIsUnifiedHost(true);
-    assertEquals(HostType.UNIFIED, config.getHostType());
-  }
-
-  @Test
-  public void testHostTypeUnifiedOverridesAccounts() {
-    // Even if host looks like accounts, explicit flag takes precedence
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost("https://accounts.cloud.databricks.com")
-            .setExperimentalIsUnifiedHost(true);
-    assertEquals(HostType.UNIFIED, config.getHostType());
+  public void testHostTypeForNonAccountsHost() {
+    // A host that is not an accounts host is always WORKSPACE, regardless of any flags
+    DatabricksConfig config = new DatabricksConfig().setHost("https://mycompany.databricks.com");
+    assertEquals(HostType.WORKSPACE, config.getHostType());
   }
 
   @Test
@@ -72,163 +59,58 @@ public class UnifiedHostTest {
 
   private static Stream<Arguments> provideClientTypeTestCases() {
     return Stream.of(
+        Arguments.of("Workspace host", "https://adb-123.azuredatabricks.net", ClientType.WORKSPACE),
+        Arguments.of("Account host", "https://accounts.cloud.databricks.com", ClientType.ACCOUNT),
         Arguments.of(
-            "Workspace host",
-            "https://adb-123.azuredatabricks.net",
-            null,
-            false,
-            ClientType.WORKSPACE),
-        Arguments.of(
-            "Account host",
-            "https://accounts.cloud.databricks.com",
-            null,
-            false,
-            ClientType.ACCOUNT),
-        Arguments.of(
-            "Unified without workspace ID",
-            "https://unified.databricks.com",
-            null,
-            true,
-            ClientType.ACCOUNT),
-        Arguments.of(
-            "Unified with workspace ID",
-            "https://unified.databricks.com",
-            "123456",
-            true,
-            ClientType.WORKSPACE));
+            "Non-accounts host", "https://mycompany.databricks.com", ClientType.WORKSPACE));
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("provideClientTypeTestCases")
-  public void testClientType(
-      String testName, String host, String workspaceId, boolean isUnified, ClientType expected) {
-    DatabricksConfig config = new DatabricksConfig().setHost(host).setWorkspaceId(workspaceId);
-    if (isUnified) {
-      config.setExperimentalIsUnifiedHost(true);
-    }
+  public void testClientType(String testName, String host, ClientType expected) {
+    DatabricksConfig config = new DatabricksConfig().setHost(host);
     assertEquals(expected, config.getClientType());
   }
 
-  // --- OIDC Endpoint Tests ---
+  // --- isAccountClient() Tests ---
 
   @Test
-  public void testOidcEndpointsForUnifiedHost() throws IOException {
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost("https://unified.databricks.com")
-            .setExperimentalIsUnifiedHost(true)
-            .setAccountId("test-account-123");
-
-    OpenIDConnectEndpoints endpoints = config.getDatabricksOidcEndpoints();
-
-    assertEquals(
-        "https://unified.databricks.com/oidc/accounts/test-account-123/v1/authorize",
-        endpoints.getAuthorizationEndpoint());
-    assertEquals(
-        "https://unified.databricks.com/oidc/accounts/test-account-123/v1/token",
-        endpoints.getTokenEndpoint());
-  }
-
-  @Test
-  public void testOidcEndpointsForUnifiedHostMissingAccountId() {
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost("https://unified.databricks.com")
-            .setExperimentalIsUnifiedHost(true);
-    // No account ID set
-
-    DatabricksException exception =
-        assertThrows(DatabricksException.class, () -> config.getDatabricksOidcEndpoints());
-    assertTrue(exception.getMessage().contains("account_id is required"));
-  }
-
-  // --- isAccountClient() Deprecation Tests ---
-
-  @Test
-  public void testIsAccountClientThrowsForUnifiedHost() {
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost("https://unified.databricks.com")
-            .setExperimentalIsUnifiedHost(true);
-
-    DatabricksException exception =
-        assertThrows(DatabricksException.class, config::isAccountClient);
-    assertTrue(exception.getMessage().contains("Cannot determine account client status"));
-    assertTrue(exception.getMessage().contains("getHostType()"));
-  }
-
-  @Test
-  public void testIsAccountClientWorksFineForTraditionalHosts() {
+  public void testIsAccountClientForAccountsHost() {
     assertTrue(
         new DatabricksConfig().setHost("https://accounts.cloud.databricks.com").isAccountClient());
+  }
 
+  @Test
+  public void testIsAccountClientForWorkspaceHost() {
     assertFalse(
         new DatabricksConfig().setHost("https://adb-123.azuredatabricks.net").isAccountClient());
+  }
+
+  @Test
+  public void testIsAccountClientForNonAccountsHost() {
+    // Non-accounts hosts are not account clients, even with experimentalIsUnifiedHost set
+    assertFalse(
+        new DatabricksConfig()
+            .setHost("https://mycompany.databricks.com")
+            .setExperimentalIsUnifiedHost(true)
+            .isAccountClient());
   }
 
   // --- Environment Variable Tests ---
 
   @Test
-  public void testUnifiedHostFromEnvironmentVariables() {
+  public void testWorkspaceIdFromEnvironmentVariables() {
     Map<String, String> env = new HashMap<>();
-    env.put("DATABRICKS_HOST", "https://unified.databricks.com");
-    env.put("DATABRICKS_EXPERIMENTAL_IS_UNIFIED_HOST", "true");
+    env.put("DATABRICKS_HOST", "https://mycompany.databricks.com");
     env.put("DATABRICKS_WORKSPACE_ID", "987654321");
     env.put("DATABRICKS_ACCOUNT_ID", "account-abc");
 
     DatabricksConfig config = new DatabricksConfig();
     config.resolve(new Environment(env, new ArrayList<>(), System.getProperty("os.name")));
 
-    assertEquals(HostType.UNIFIED, config.getHostType());
+    assertEquals(HostType.WORKSPACE, config.getHostType());
     assertEquals("987654321", config.getWorkspaceId());
     assertEquals("account-abc", config.getAccountId());
     assertEquals(ClientType.WORKSPACE, config.getClientType());
-  }
-
-  // --- Header Injection Tests ---
-
-  @Test
-  public void testHeaderInjectionForWorkspaceOnUnified() {
-    String workspaceId = "123456789";
-
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost("https://unified.databricks.com")
-            .setExperimentalIsUnifiedHost(true)
-            .setWorkspaceId(workspaceId)
-            .setToken("test-token");
-
-    Map<String, String> headers = config.authenticate();
-
-    assertEquals("Bearer test-token", headers.get("Authorization"));
-    assertEquals(workspaceId, headers.get("X-Databricks-Org-Id"));
-  }
-
-  @Test
-  public void testNoHeaderInjectionForAccountOnUnified() {
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost("https://unified.databricks.com")
-            .setExperimentalIsUnifiedHost(true)
-            .setToken("test-token");
-    // No workspace ID set
-
-    Map<String, String> headers = config.authenticate();
-
-    assertEquals("Bearer test-token", headers.get("Authorization"));
-    assertNull(headers.get("X-Databricks-Org-Id"));
-  }
-
-  @Test
-  public void testNoHeaderInjectionForTraditionalWorkspace() {
-    DatabricksConfig config =
-        new DatabricksConfig()
-            .setHost("https://adb-123.azuredatabricks.net")
-            .setToken("test-token");
-
-    Map<String, String> headers = config.authenticate();
-
-    assertEquals("Bearer test-token", headers.get("Authorization"));
-    assertNull(headers.get("X-Databricks-Org-Id"));
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UnifiedHostTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UnifiedHostTest.java
@@ -90,9 +90,7 @@ public class UnifiedHostTest {
   public void testIsAccountClientForNonAccountsHost() {
     // Non-accounts hosts are not account clients
     assertFalse(
-        new DatabricksConfig()
-            .setHost("https://mycompany.databricks.com")
-            .isAccountClient());
+        new DatabricksConfig().setHost("https://mycompany.databricks.com").isAccountClient());
   }
 
   // --- Environment Variable Tests ---

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UnifiedHostTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UnifiedHostTest.java
@@ -88,11 +88,10 @@ public class UnifiedHostTest {
 
   @Test
   public void testIsAccountClientForNonAccountsHost() {
-    // Non-accounts hosts are not account clients, even with experimentalIsUnifiedHost set
+    // Non-accounts hosts are not account clients
     assertFalse(
         new DatabricksConfig()
             .setHost("https://mycompany.databricks.com")
-            .setExperimentalIsUnifiedHost(true)
             .isAccountClient());
   }
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
@@ -122,11 +122,27 @@ public class ExternalBrowserCredentialsProviderTest {
 
   @Test
   void openIDConnectEndPointsTestAccounts() throws IOException {
+    HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
+    // Mock the host metadata call (resolve) to return 404, matching FixtureServer auto-stub
+    // behavior. The actual OIDC endpoints for account clients are computed locally without HTTP.
+    Mockito.doAnswer(
+            invocation -> {
+              Request req = invocation.getArgument(0);
+              if (req.getUrl().contains("/.well-known/databricks-config")) {
+                return new Response(
+                    "{\"error_code\":\"NOT_FOUND\",\"message\":\"not found\"}",
+                    new URL(req.getUrl()));
+              }
+              throw new IOException("Unexpected request: " + req.getUrl());
+            })
+        .when(mockHttpClient)
+        .execute(any(Request.class));
+
     DatabricksConfig config =
         new DatabricksConfig()
             .setAuthType("external-browser")
             .setHost("https://accounts.cloud.databricks.com")
-            .setHttpClient(new CommonsHttpClient.Builder().withTimeoutSeconds(30).build())
+            .setHttpClient(mockHttpClient)
             .setAccountId("testAccountId");
     config.resolve();
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/HostMetadataIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/HostMetadataIT.java
@@ -22,8 +22,7 @@ public class HostMetadataIT {
 
   @Test
   void testResolvePopulatesFieldsFromMetadata(@EnvOrSkip("DATABRICKS_HOST") String host) {
-    DatabricksConfig config =
-        new DatabricksConfig().setHost(host).setExperimentalIsUnifiedHost(true);
+    DatabricksConfig config = new DatabricksConfig().setHost(host);
     config.resolve();
 
     LOG.info(

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/service/gentesting/unittests/HttpPathTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/service/gentesting/unittests/HttpPathTest.java
@@ -464,6 +464,10 @@ public class HttpPathTest {
         .thenAnswer(
             invocation -> {
               Request request = invocation.getArgument(0);
+              // Handle host metadata discovery call
+              if (request.getUri().toString().equals(HOST + "/.well-known/databricks-config")) {
+                return new Response("{}", 200, "OK", new URL(HOST));
+              }
               String expectedUrl = HOST + testCase.path;
               if (!request.getUri().toString().equals(expectedUrl)) {
                 throw new AssertionError(

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/service/gentesting/unittests/IdempotencyTestingAPITest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/service/gentesting/unittests/IdempotencyTestingAPITest.java
@@ -169,8 +169,7 @@ public class IdempotencyTestingAPITest {
     Request metadataRequest =
         new Request("GET", "https://test.databricks.com/.well-known/databricks-config");
     realClient.with(
-        metadataRequest,
-        new Response(metadataRequest, 200, "OK", Collections.emptyMap(), "{}"));
+        metadataRequest, new Response(metadataRequest, 200, "OK", Collections.emptyMap(), "{}"));
     for (Response response : testCase.httpResponses) {
       realClient.with(testCase.httpRequest, response);
     }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/service/gentesting/unittests/IdempotencyTestingAPITest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/service/gentesting/unittests/IdempotencyTestingAPITest.java
@@ -165,6 +165,12 @@ public class IdempotencyTestingAPITest {
   void testIdempotencyAutoRequestID(AutoRequestIDTestCase testCase) throws Exception {
     // Setup: Create DummyHttpClient with sequential responses for retries
     DummyHttpClient realClient = new DummyHttpClient();
+    // Add a response for the host metadata discovery call
+    Request metadataRequest =
+        new Request("GET", "https://test.databricks.com/.well-known/databricks-config");
+    realClient.with(
+        metadataRequest,
+        new Response(metadataRequest, 200, "OK", Collections.emptyMap(), "{}"));
     for (Response response : testCase.httpResponses) {
       realClient.with(testCase.httpRequest, response);
     }
@@ -193,12 +199,13 @@ public class IdempotencyTestingAPITest {
       assertEquals(testCase.wantResult, result, "Test case: " + testCase.name);
 
       // Capture and verify request IDs
+      // 3 calls: host metadata discovery + 2 API calls (initial + retry)
       ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
-      verify(spyClient, times(2)).execute(requestCaptor.capture());
+      verify(spyClient, times(3)).execute(requestCaptor.capture());
 
       List<Request> capturedRequests = requestCaptor.getAllValues();
-      String firstRequestId = capturedRequests.get(0).getQuery().get("request_id").get(0);
-      String secondRequestId = capturedRequests.get(1).getQuery().get("request_id").get(0);
+      String firstRequestId = capturedRequests.get(1).getQuery().get("request_id").get(0);
+      String secondRequestId = capturedRequests.get(2).getQuery().get("request_id").get(0);
 
       assertNotNull(firstRequestId, "Auto-generated request_id should not be null");
       assertFalse(firstRequestId.isEmpty(), "Auto-generated request_id should not be empty");


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/databricks-sdk-java/pull/720/files) to review incremental changes.
- [**hectorcast-db/stack/port-8-remove-unified-flag**](https://github.com/databricks/databricks-sdk-java/pull/720) [[Files changed](https://github.com/databricks/databricks-sdk-java/pull/720/files)]

---------
## Summary

Port of Go SDK [#1547](https://github.com/databricks/databricks-sdk-go/pull/1547).

Removes `HostType.UNIFIED` and all runtime checks of `experimentalIsUnifiedHost`. Host type is now determined solely from URL pattern (accounts.* = ACCOUNTS, else WORKSPACE). Host metadata resolution (from earlier PRs in this stack) handles populating config fields automatically.

**Key changes:**
- `getHostType()`: no longer returns `UNIFIED`; determined solely by URL pattern
- `isAccountClient()`: no longer throws for unified hosts
- `getClientType()`: simplified, no `UNIFIED` case
- `fetchDefaultOidcEndpoints()`: removed unified OIDC branch, removed `getUnifiedOidcEndpoints()`
- `DatabricksCliCredentialsProvider.buildHostArgs()`: removed `--experimental-is-unified-host`, `--account-id`, `--workspace-id` flags for unified case
- `AccountClient.getWorkspaceClient()`: uses DNS zone matching (like Go SDK) to decide whether to reuse host or build deployment URL
- `HostType` enum: removed `UNIFIED` value
- `authenticate()`: removed `X-Databricks-Org-Id` header injection (handled by generated `*Impl.java` files)

**Note:** `AccountClient.java` is a generated file. The template needs to be updated.

`NO_CHANGELOG=true`

## Test plan
- [x] All 1086 tests pass
- [x] `UnifiedHostTest`, `DatabricksConfigTest`, `AccountClientTest`, `DatabricksCliCredentialsProviderTest` updated