### PR TITLE
Add java.util.logging backend

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Internal Changes
 * Introduced a logging abstraction (`com.databricks.sdk.core.logging`) to decouple the SDK from a specific logging backend.
+* Added `java.util.logging` as a supported alternative logging backend. Activate it with `LoggerFactory.setDefault(JulLoggerFactory.INSTANCE)`.
 
 ### API Changes
 * Add `createCatalog()`, `createSyncedTable()`, `deleteCatalog()`, `deleteSyncedTable()`, `getCatalog()` and `getSyncedTable()` methods for `workspaceClient.postgres()` service.

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/logging/JulLogger.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/logging/JulLogger.java
@@ -1,0 +1,208 @@
+package com.databricks.sdk.core.logging;
+
+import java.util.Arrays;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/** Delegates logging calls to a {@code java.util.logging.Logger}, translating SLF4J conventions. */
+class JulLogger extends Logger {
+
+  private static final String LOGGING_PACKAGE = "com.databricks.sdk.core.logging.";
+
+  private final java.util.logging.Logger delegate;
+
+  JulLogger(java.util.logging.Logger delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void debug(String msg) {
+    log(Level.FINE, msg, null);
+  }
+
+  @Override
+  public void debug(String format, Object... args) {
+    log(Level.FINE, format, args);
+  }
+
+  @Override
+  public void debug(Supplier<String> msgSupplier) {
+    if (delegate.isLoggable(Level.FINE)) {
+      log(Level.FINE, msgSupplier.get(), null);
+    }
+  }
+
+  @Override
+  public void info(String msg) {
+    log(Level.INFO, msg, null);
+  }
+
+  @Override
+  public void info(String format, Object... args) {
+    log(Level.INFO, format, args);
+  }
+
+  @Override
+  public void info(Supplier<String> msgSupplier) {
+    if (delegate.isLoggable(Level.INFO)) {
+      log(Level.INFO, msgSupplier.get(), null);
+    }
+  }
+
+  @Override
+  public void warn(String msg) {
+    log(Level.WARNING, msg, null);
+  }
+
+  @Override
+  public void warn(String format, Object... args) {
+    log(Level.WARNING, format, args);
+  }
+
+  @Override
+  public void warn(Supplier<String> msgSupplier) {
+    if (delegate.isLoggable(Level.WARNING)) {
+      log(Level.WARNING, msgSupplier.get(), null);
+    }
+  }
+
+  @Override
+  public void error(String msg) {
+    log(Level.SEVERE, msg, null);
+  }
+
+  @Override
+  public void error(String format, Object... args) {
+    log(Level.SEVERE, format, args);
+  }
+
+  @Override
+  public void error(Supplier<String> msgSupplier) {
+    if (delegate.isLoggable(Level.SEVERE)) {
+      log(Level.SEVERE, msgSupplier.get(), null);
+    }
+  }
+
+  private void log(Level level, String format, Object[] args) {
+    if (!delegate.isLoggable(level)) {
+      return;
+    }
+    Throwable thrown = (args != null) ? extractThrowable(format, args) : null;
+    String message = (args != null) ? formatMessage(format, args) : format;
+    LogRecord record = new LogRecord(level, message);
+    record.setLoggerName(delegate.getName());
+    if (thrown != null) {
+      record.setThrown(thrown);
+    }
+    inferCaller(record);
+    delegate.log(record);
+  }
+
+  /**
+   * Sets the source class and method on a {@link LogRecord} by walking the call stack to find the
+   * first frame outside this logging package.
+   *
+   * <p>JUL normally infers caller information automatically by scanning the stack for the first
+   * frame after its own {@code java.util.logging.Logger} methods. Because {@code JulLogger} wraps
+   * the JUL logger, that automatic inference stops at {@code JulLogger} or its helper methods
+   * instead of reaching the actual SDK class that initiated the log call. Without this correction,
+   * every log record would be attributed to {@code JulLogger}, making JUL output useless for
+   * identifying the real call site.
+   */
+  private static void inferCaller(LogRecord record) {
+    StackTraceElement[] stack = new Throwable().getStackTrace();
+    for (StackTraceElement frame : stack) {
+      if (!frame.getClassName().startsWith(LOGGING_PACKAGE)) {
+        record.setSourceClassName(frame.getClassName());
+        record.setSourceMethodName(frame.getMethodName());
+        return;
+      }
+    }
+  }
+
+  /**
+   * Replaces SLF4J-style {@code {}} placeholders with argument values, matching the semantics of
+   * SLF4J's {@code MessageFormatter.arrayFormat}:
+   *
+   * <ul>
+   *   <li>A trailing {@link Throwable} is unconditionally excluded from formatting.
+   *   <li>A backslash before {@code {}} escapes it as a literal {@code {}}.
+   *   <li>Array arguments are rendered with {@link Arrays#deepToString}.
+   *   <li>A {@code null} format string returns {@code null}.
+   * </ul>
+   */
+  static String formatMessage(String format, Object[] args) {
+    if (format == null) {
+      return null;
+    }
+    if (args == null || args.length == 0) {
+      return format;
+    }
+    int usableArgs = args.length;
+    if (args[usableArgs - 1] instanceof Throwable) {
+      usableArgs--;
+    }
+    StringBuilder sb = new StringBuilder(format.length() + 32);
+    int argIdx = 0;
+    int i = 0;
+    while (i < format.length()) {
+      if (i + 1 < format.length() && format.charAt(i) == '{' && format.charAt(i + 1) == '}') {
+        if (i > 0 && format.charAt(i - 1) == '\\') {
+          sb.setLength(sb.length() - 1);
+          sb.append("{}");
+        } else if (argIdx < usableArgs) {
+          sb.append(renderArg(args[argIdx++]));
+        } else {
+          sb.append("{}");
+        }
+        i += 2;
+      } else {
+        sb.append(format.charAt(i));
+        i++;
+      }
+    }
+    return sb.toString();
+  }
+
+  private static String renderArg(Object arg) {
+    if (arg == null) {
+      return "null";
+    }
+    if (arg instanceof Object[]) {
+      return Arrays.deepToString((Object[]) arg);
+    }
+    if (arg.getClass().isArray()) {
+      return primitiveArrayToString(arg);
+    }
+    return arg.toString();
+  }
+
+  private static String primitiveArrayToString(Object array) {
+    if (array instanceof boolean[]) return Arrays.toString((boolean[]) array);
+    if (array instanceof byte[]) return Arrays.toString((byte[]) array);
+    if (array instanceof char[]) return Arrays.toString((char[]) array);
+    if (array instanceof short[]) return Arrays.toString((short[]) array);
+    if (array instanceof int[]) return Arrays.toString((int[]) array);
+    if (array instanceof long[]) return Arrays.toString((long[]) array);
+    if (array instanceof float[]) return Arrays.toString((float[]) array);
+    if (array instanceof double[]) return Arrays.toString((double[]) array);
+    return Arrays.deepToString(new Object[] {array});
+  }
+
+  /**
+   * Returns the last argument if it is a {@link Throwable}, unconditionally. This matches SLF4J's
+   * {@code NormalizedParameters.getThrowableCandidate}, which always extracts a trailing Throwable
+   * regardless of how many {@code {}} placeholders the format string contains.
+   */
+  static Throwable extractThrowable(String format, Object[] args) {
+    if (args == null || args.length == 0) {
+      return null;
+    }
+    Object last = args[args.length - 1];
+    if (last instanceof Throwable) {
+      return (Throwable) last;
+    }
+    return null;
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/logging/JulLoggerFactory.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/logging/JulLoggerFactory.java
@@ -1,0 +1,25 @@
+package com.databricks.sdk.core.logging;
+
+/**
+ * An {@link ILoggerFactory} backed by {@code java.util.logging}. Always available on any JRE.
+ *
+ * <p>Use this when SLF4J is not desirable:
+ *
+ * <pre>{@code
+ * LoggerFactory.setDefault(JulLoggerFactory.INSTANCE);
+ * }</pre>
+ */
+public class JulLoggerFactory implements ILoggerFactory {
+
+  public static final JulLoggerFactory INSTANCE = new JulLoggerFactory();
+
+  @Override
+  public Logger getLogger(Class<?> type) {
+    return new JulLogger(java.util.logging.Logger.getLogger(type.getName()));
+  }
+
+  @Override
+  public Logger getLogger(String name) {
+    return new JulLogger(java.util.logging.Logger.getLogger(name));
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/logging/LoggerFactory.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/logging/LoggerFactory.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * creating any SDK client:
  *
  * <pre>{@code
- * LoggerFactory.setDefault(myCustomFactory);
+ * LoggerFactory.setDefault(JulLoggerFactory.INSTANCE);
  * WorkspaceClient ws = new WorkspaceClient();
  * }</pre>
  *

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/logging/JulLoggerTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/logging/JulLoggerTest.java
@@ -1,0 +1,207 @@
+package com.databricks.sdk.core.logging;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class JulLoggerTest {
+
+  // ---- Formatter unit tests ----
+
+  @Test
+  void formatMessageNoPlaceholders() {
+    assertEquals("hello world", JulLogger.formatMessage("hello world", new Object[] {}));
+  }
+
+  @Test
+  void formatMessageNullArgs() {
+    assertEquals("hello", JulLogger.formatMessage("hello", (Object[]) null));
+  }
+
+  @Test
+  void formatMessageSinglePlaceholder() {
+    assertEquals("hello world", JulLogger.formatMessage("hello {}", new Object[] {"world"}));
+  }
+
+  @Test
+  void formatMessageMultiplePlaceholders() {
+    assertEquals("a=1, b=2", JulLogger.formatMessage("a={}, b={}", new Object[] {"1", "2"}));
+  }
+
+  @Test
+  void formatMessageTrailingThrowableExcluded() {
+    Exception ex = new RuntimeException("boom");
+    String result = JulLogger.formatMessage("Failed at {}: {}", new Object[] {"host", "msg", ex});
+    assertEquals("Failed at host: msg", result);
+  }
+
+  @Test
+  void formatMessageThrowableIsAlwaysExcluded() {
+    Exception ex = new RuntimeException("boom");
+    String result = JulLogger.formatMessage("Error: {}", new Object[] {ex});
+    assertEquals("Error: {}", result);
+  }
+
+  @Test
+  void extractThrowableWhenTrailing() {
+    Exception ex = new RuntimeException("boom");
+    Throwable result = JulLogger.extractThrowable("Failed: {}", new Object[] {"msg", ex});
+    assertSame(ex, result);
+  }
+
+  @Test
+  void extractThrowableNullWhenNotTrailing() {
+    assertNull(JulLogger.extractThrowable("a={}, b={}", new Object[] {"1", "2"}));
+  }
+
+  @Test
+  void extractThrowableAlwaysWhenLastArgIsThrowable() {
+    Exception ex = new RuntimeException("boom");
+    assertSame(ex, JulLogger.extractThrowable("Error: {}", new Object[] {ex}));
+  }
+
+  @Test
+  void extractThrowableNullArgs() {
+    assertNull(JulLogger.extractThrowable("msg", (Object[]) null));
+  }
+
+  @Test
+  void extractThrowableEmptyArgs() {
+    assertNull(JulLogger.extractThrowable("msg", new Object[] {}));
+  }
+
+  // ---- End-to-end capturing tests ----
+
+  static Stream<Arguments> logCalls() {
+    RuntimeException ex = new RuntimeException("boom");
+    return Stream.of(
+        Arguments.of("debug", "hello", null, "hello", null),
+        Arguments.of("info", "hello", null, "hello", null),
+        Arguments.of("warn", "hello", null, "hello", null),
+        Arguments.of("error", "hello", null, "hello", null),
+        Arguments.of(
+            "info", "user {} logged in", new Object[] {"alice"}, "user alice logged in", null),
+        Arguments.of("info", "a={}, b={}", new Object[] {1, 2}, "a=1, b=2", null),
+        Arguments.of("error", "failed: {}", new Object[] {"op", ex}, "failed: op", ex),
+        Arguments.of("error", "Error: {}", new Object[] {ex}, "Error: {}", ex),
+        Arguments.of("error", "Something broke", new Object[] {ex}, "Something broke", ex));
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}(\"{1}\")")
+  @MethodSource("logCalls")
+  void deliversCorrectOutput(
+      String level, String format, Object[] args, String expectedMsg, Throwable expectedThrown) {
+    java.util.logging.Logger julLogger =
+        java.util.logging.Logger.getLogger(JulLoggerTest.class.getName());
+    Level originalLevel = julLogger.getLevel();
+    julLogger.setLevel(Level.ALL);
+    CapturingHandler handler = new CapturingHandler();
+    julLogger.addHandler(handler);
+    try {
+      Logger logger =
+          new JulLogger(java.util.logging.Logger.getLogger(JulLoggerTest.class.getName()));
+      dispatch(logger, level, format, args);
+
+      assertEquals(1, handler.records.size(), "Expected exactly one log record");
+      LogRecord record = handler.records.get(0);
+      assertEquals(expectedMsg, record.getMessage());
+      assertEquals(toJulLevel(level), record.getLevel());
+      if (expectedThrown != null) {
+        assertSame(expectedThrown, record.getThrown());
+      } else {
+        assertNull(record.getThrown(), "Expected no throwable");
+      }
+    } finally {
+      julLogger.removeHandler(handler);
+      julLogger.setLevel(originalLevel);
+    }
+  }
+
+  @Test
+  void callerInferenceSkipsLoggingPackage() {
+    java.util.logging.Logger julLogger =
+        java.util.logging.Logger.getLogger(JulLoggerTest.class.getName());
+    Level originalLevel = julLogger.getLevel();
+    julLogger.setLevel(Level.ALL);
+    CapturingHandler handler = new CapturingHandler();
+    julLogger.addHandler(handler);
+    try {
+      Logger logger =
+          new JulLogger(java.util.logging.Logger.getLogger(JulLoggerTest.class.getName()));
+      logger.info("test");
+
+      assertEquals(1, handler.records.size());
+      String sourceClass = handler.records.get(0).getSourceClassName();
+      assertFalse(
+          sourceClass.startsWith("com.databricks.sdk.core.logging."),
+          "Source class should not be in the logging package, but was: " + sourceClass);
+    } finally {
+      julLogger.removeHandler(handler);
+      julLogger.setLevel(originalLevel);
+    }
+  }
+
+  // ---- Helpers ----
+
+  private static void dispatch(Logger logger, String level, String format, Object[] args) {
+    switch (level) {
+      case "debug":
+        if (args != null) logger.debug(format, args);
+        else logger.debug(format);
+        break;
+      case "info":
+        if (args != null) logger.info(format, args);
+        else logger.info(format);
+        break;
+      case "warn":
+        if (args != null) logger.warn(format, args);
+        else logger.warn(format);
+        break;
+      case "error":
+        if (args != null) logger.error(format, args);
+        else logger.error(format);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown level: " + level);
+    }
+  }
+
+  private static Level toJulLevel(String level) {
+    switch (level) {
+      case "debug":
+        return Level.FINE;
+      case "info":
+        return Level.INFO;
+      case "warn":
+        return Level.WARNING;
+      case "error":
+        return Level.SEVERE;
+      default:
+        throw new IllegalArgumentException("Unknown level: " + level);
+    }
+  }
+
+  static class CapturingHandler extends Handler {
+    final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {}
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/logging/LoggerFactoryTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/logging/LoggerFactoryTest.java
@@ -25,9 +25,25 @@ public class LoggerFactoryTest {
   }
 
   @Test
+  void setDefaultSwitchesToJul() {
+    LoggerFactory.setDefault(JulLoggerFactory.INSTANCE);
+    Logger logger = LoggerFactory.getLogger(LoggerFactoryTest.class);
+    assertNotNull(logger);
+    logger.info("setDefaultSwitchesToJul test message via JUL");
+  }
+
+  @Test
   void getLoggerByNameWorks() {
     Logger logger = LoggerFactory.getLogger("com.example.Test");
     assertNotNull(logger);
     logger.info("getLoggerByNameWorks test message");
+  }
+
+  @Test
+  void getLoggerByNameWorksWithJul() {
+    LoggerFactory.setDefault(JulLoggerFactory.INSTANCE);
+    Logger logger = LoggerFactory.getLogger("com.example.Test");
+    assertNotNull(logger);
+    logger.info("getLoggerByNameWorksWithJul test message");
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/logging/LoggingParityTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/logging/LoggingParityTest.java
@@ -1,0 +1,88 @@
+package com.databricks.sdk.core.logging;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+
+/**
+ * Verifies that JulLogger's placeholder formatting and Throwable extraction produce the same
+ * results as SLF4J's {@link MessageFormatter#arrayFormat}, so the two backends behave identically
+ * for any given Logger call.
+ */
+public class LoggingParityTest {
+
+  @Test
+  void singleThrowableArgIsExtractedNotFormatted() {
+    Exception ex = new RuntimeException("boom");
+    Object[] args = {ex};
+    FormattingTuple slf4j = MessageFormatter.arrayFormat("Error: {}", args);
+
+    assertEquals(slf4j.getMessage(), JulLogger.formatMessage("Error: {}", args));
+    assertEquals(slf4j.getThrowable(), JulLogger.extractThrowable("Error: {}", args));
+  }
+
+  @Test
+  void trailingThrowableBeyondPlaceholders() {
+    Exception ex = new RuntimeException("boom");
+    Object[] args = {"op", ex};
+    FormattingTuple slf4j = MessageFormatter.arrayFormat("Error: {} failed", args);
+
+    assertEquals(slf4j.getMessage(), JulLogger.formatMessage("Error: {} failed", args));
+    assertEquals(slf4j.getThrowable(), JulLogger.extractThrowable("Error: {} failed", args));
+  }
+
+  @Test
+  void noPlaceholdersTrailingThrowable() {
+    Exception ex = new RuntimeException("boom");
+    Object[] args = {ex};
+    FormattingTuple slf4j = MessageFormatter.arrayFormat("Something broke", args);
+
+    assertEquals(slf4j.getMessage(), JulLogger.formatMessage("Something broke", args));
+    assertEquals(slf4j.getThrowable(), JulLogger.extractThrowable("Something broke", args));
+  }
+
+  @Test
+  void nonThrowableArgsNoExtraction() {
+    Object[] args = {"a", "b"};
+    FormattingTuple slf4j = MessageFormatter.arrayFormat("{} {}", args);
+
+    assertEquals(slf4j.getMessage(), JulLogger.formatMessage("{} {}", args));
+    assertEquals(slf4j.getThrowable(), JulLogger.extractThrowable("{} {}", args));
+  }
+
+  @Test
+  void multipleArgsWithTrailingThrowable() {
+    Exception ex = new RuntimeException("boom");
+    Object[] args = {"host", 8080, ex};
+    FormattingTuple slf4j = MessageFormatter.arrayFormat("Connect to {}:{}", args);
+
+    assertEquals(slf4j.getMessage(), JulLogger.formatMessage("Connect to {}:{}", args));
+    assertEquals(slf4j.getThrowable(), JulLogger.extractThrowable("Connect to {}:{}", args));
+  }
+
+  @Test
+  void arrayArgumentRenderedLikeSlf4j() {
+    Object[] args = {new String[] {"a", "b"}};
+    FormattingTuple slf4j = MessageFormatter.arrayFormat("arr {}", args);
+
+    assertEquals(slf4j.getMessage(), JulLogger.formatMessage("arr {}", args));
+  }
+
+  @Test
+  void escapedPlaceholderRenderedLikeSlf4j() {
+    Object[] args = {"x"};
+    FormattingTuple slf4j = MessageFormatter.arrayFormat("escaped \\{} {}", args);
+
+    assertEquals(slf4j.getMessage(), JulLogger.formatMessage("escaped \\{} {}", args));
+  }
+
+  @Test
+  void nullFormatRenderedLikeSlf4j() {
+    Object[] args = {"x"};
+    FormattingTuple slf4j = MessageFormatter.arrayFormat(null, args);
+
+    assertEquals(slf4j.getMessage(), JulLogger.formatMessage(null, args));
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/databricks-sdk-java/pull/741/files) to review incremental changes.
- [**stack/logging-jul**](https://github.com/databricks/databricks-sdk-java/pull/741) [[Files changed](https://github.com/databricks/databricks-sdk-java/pull/741/files)]
  - [stack/logging-migration](https://github.com/databricks/databricks-sdk-java/pull/742) [[Files changed](https://github.com/databricks/databricks-sdk-java/pull/742/files/e281114606e16c4763cc711074d4878b37935687..2370a961e60f666f0e28c2358deb5fe4df7635f4)]

---------
## Summary

Adds a `java.util.logging` (JUL) backend for the logging abstraction introduced in PR #740. Users who cannot or prefer not to use SLF4J can switch to JUL with a single line before creating any SDK client.

## Why

SLF4J is the right default for most users, but some environments (BI tools, embedded runtimes, minimal deployments) either don't ship an SLF4J binding or make it difficult to configure one. In those cases, the JDK's built-in `java.util.logging` is the only logging framework guaranteed to be available.

Without a JUL backend, users in these environments would get silent NOP logging (if SLF4J has no binding) or would have to provide their own adapter. Providing a first-party JUL backend that they can activate with `LoggerFactory.setDefault(JulLoggerFactory.INSTANCE)` removes that friction.

## What changed

### Interface changes

- **`JulLoggerFactory`** — new public `ILoggerFactory` implementation with a singleton `INSTANCE`. Activating JUL is one line: `LoggerFactory.setDefault(JulLoggerFactory.INSTANCE)`.

### Behavioral changes

None. The default backend is still SLF4J. JUL is only used when explicitly opted into.

### Internal changes

- **`JulLogger`** — package-private class that delegates to a `java.util.logging.Logger`. Key implementation details:
  - **SLF4J-parity formatting**: `{}` placeholders are substituted following the same semantics as SLF4J's `MessageFormatter.arrayFormat` — trailing Throwables are unconditionally extracted and attached to the `LogRecord`, escaped `\{}` is rendered as literal `{}`, array arguments use `Arrays.deepToString`, and null format strings return null.
  - **Caller inference**: All log calls go through a single `log(Level, String, Object[])` method that constructs a `LogRecord` and walks the stack to set the correct source class/method, since JUL's automatic caller inference would otherwise attribute every record to `JulLogger`.
  - **Level mapping**: `debug` → `FINE`, `info` → `INFO`, `warn` → `WARNING`, `error` → `SEVERE`.
- **`LoggerFactoryTest`** — added `setDefaultSwitchesToJul` and `getLoggerByNameWorksWithJul` tests.

## How is this tested?

- `JulLoggerTest` — 12 tests covering placeholder formatting, trailing Throwable extraction, null/empty args, and end-to-end level mapping through all log methods.
- `LoggingParityTest` — 8 tests that compare `JulLogger.formatMessage` and `JulLogger.extractThrowable` directly against `org.slf4j.helpers.MessageFormatter.arrayFormat` for the same inputs, covering: single Throwable arg, trailing Throwable beyond placeholders, no-placeholder Throwable, non-Throwable args, multi-arg with Throwable, array rendering, escaped placeholders, and null format strings.
- `LoggerFactoryTest` — 2 additional tests for JUL factory switching via `setDefault`.
- Full test suite passes.