### PR TITLE
Add X-Databricks-Org-Id header to deprecated workspace SCIM APIs

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added automatic detection of AI coding agents (Antigravity, Claude Code, Cline, Codex, Copilot CLI, Cursor, Gemini CLI, OpenCode) in the user-agent string. The SDK now appends `agent/<name>` to HTTP request headers when running inside a known AI agent environment.
 
 ### Bug Fixes
+* Added `X-Databricks-Org-Id` header to deprecated workspace SCIM APIs (Groups, ServicePrincipals, Users) for SPOG host compatibility.
 * Fixed Databricks CLI authentication to detect when the cached token's scopes don't match the SDK's configured scopes. Previously, a scope mismatch was silently ignored, causing requests to use wrong permissions. The SDK now raises an error with instructions to re-authenticate.
 
 ### Security Vulnerabilities

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/GroupsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/GroupsImpl.java
@@ -24,6 +24,9 @@ class GroupsImpl implements GroupsService {
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
       req.withHeader("Content-Type", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, Group.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -36,6 +39,9 @@ class GroupsImpl implements GroupsService {
     try {
       Request req = new Request("DELETE", path);
       ApiClient.setQuery(req, request);
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       apiClient.execute(req, Void.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -49,6 +55,9 @@ class GroupsImpl implements GroupsService {
       Request req = new Request("GET", path);
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, Group.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -62,6 +71,9 @@ class GroupsImpl implements GroupsService {
       Request req = new Request("GET", path);
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, ListGroupsResponse.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -75,6 +87,9 @@ class GroupsImpl implements GroupsService {
       Request req = new Request("PATCH", path, apiClient.serialize(request));
       ApiClient.setQuery(req, request);
       req.withHeader("Content-Type", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       apiClient.execute(req, Void.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -88,6 +103,9 @@ class GroupsImpl implements GroupsService {
       Request req = new Request("PUT", path, apiClient.serialize(request));
       ApiClient.setQuery(req, request);
       req.withHeader("Content-Type", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       apiClient.execute(req, Void.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/ServicePrincipalsImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/ServicePrincipalsImpl.java
@@ -24,6 +24,9 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
       req.withHeader("Content-Type", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, ServicePrincipal.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -36,6 +39,9 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
     try {
       Request req = new Request("DELETE", path);
       ApiClient.setQuery(req, request);
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       apiClient.execute(req, Void.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -49,6 +55,9 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
       Request req = new Request("GET", path);
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, ServicePrincipal.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -62,6 +71,9 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
       Request req = new Request("GET", path);
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, ListServicePrincipalResponse.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -75,6 +87,9 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
       Request req = new Request("PATCH", path, apiClient.serialize(request));
       ApiClient.setQuery(req, request);
       req.withHeader("Content-Type", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       apiClient.execute(req, Void.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -88,6 +103,9 @@ class ServicePrincipalsImpl implements ServicePrincipalsService {
       Request req = new Request("PUT", path, apiClient.serialize(request));
       ApiClient.setQuery(req, request);
       req.withHeader("Content-Type", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       apiClient.execute(req, Void.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/UsersImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/iam/UsersImpl.java
@@ -24,6 +24,9 @@ class UsersImpl implements UsersService {
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
       req.withHeader("Content-Type", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, User.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -36,6 +39,9 @@ class UsersImpl implements UsersService {
     try {
       Request req = new Request("DELETE", path);
       ApiClient.setQuery(req, request);
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       apiClient.execute(req, Void.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -49,6 +55,9 @@ class UsersImpl implements UsersService {
       Request req = new Request("GET", path);
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, User.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -61,6 +70,9 @@ class UsersImpl implements UsersService {
     try {
       Request req = new Request("GET", path);
       req.withHeader("Accept", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, GetPasswordPermissionLevelsResponse.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -73,6 +85,9 @@ class UsersImpl implements UsersService {
     try {
       Request req = new Request("GET", path);
       req.withHeader("Accept", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, PasswordPermissions.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -86,6 +101,9 @@ class UsersImpl implements UsersService {
       Request req = new Request("GET", path);
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, ListUsersResponse.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -99,6 +117,9 @@ class UsersImpl implements UsersService {
       Request req = new Request("PATCH", path, apiClient.serialize(request));
       ApiClient.setQuery(req, request);
       req.withHeader("Content-Type", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       apiClient.execute(req, Void.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -113,6 +134,9 @@ class UsersImpl implements UsersService {
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
       req.withHeader("Content-Type", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, PasswordPermissions.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -126,6 +150,9 @@ class UsersImpl implements UsersService {
       Request req = new Request("PUT", path, apiClient.serialize(request));
       ApiClient.setQuery(req, request);
       req.withHeader("Content-Type", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       apiClient.execute(req, Void.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);
@@ -140,6 +167,9 @@ class UsersImpl implements UsersService {
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
       req.withHeader("Content-Type", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, PasswordPermissions.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/UnifiedHostGroupsIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/UnifiedHostGroupsIT.java
@@ -2,6 +2,7 @@ package com.databricks.sdk.integration;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.sdk.AccountClient;
 import com.databricks.sdk.WorkspaceClient;
 import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.integration.framework.EnvContext;
@@ -10,23 +11,28 @@ import com.databricks.sdk.integration.framework.EnvTest;
 import com.databricks.sdk.service.iam.Group;
 import com.databricks.sdk.service.iam.ListGroupsRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @EnvContext("account")
 @ExtendWith(EnvTest.class)
+@EnabledIfEnvironmentVariable(named = "UNIFIED_HOST", matches = ".+")
 public class UnifiedHostGroupsIT {
   @Test
+  @DisabledIfEnvironmentVariable(named = "CLOUD_PROVIDER", matches = "GCP")
   void listWorkspaceGroupsViaUnifiedHost(
-      @EnvOrSkip("UNIFIED_HOST") String host,
+      AccountClient a,
+      @EnvOrSkip("UNIFIED_HOST") String unifiedHost,
       @EnvOrSkip("TEST_WORKSPACE_ID") String workspaceId,
-      @EnvOrSkip("DATABRICKS_CLIENT_ID") String clientId,
-      @EnvOrSkip("DATABRICKS_CLIENT_SECRET") String clientSecret) {
+      @EnvOrSkip("TEST_ACCOUNT_ID") String accountId) {
     DatabricksConfig config =
         new DatabricksConfig()
-            .setHost(host)
+            .setHost(unifiedHost)
+            .setClientId(a.config().getClientId())
+            .setClientSecret(a.config().getClientSecret())
             .setWorkspaceId(workspaceId)
-            .setClientId(clientId)
-            .setClientSecret(clientSecret);
+            .setAccountId(accountId);
     WorkspaceClient ws = new WorkspaceClient(config);
 
     Iterable<Group> groups = ws.groups().list(new ListGroupsRequest().setAttributes("displayName"));

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/UnifiedHostGroupsIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/UnifiedHostGroupsIT.java
@@ -1,0 +1,36 @@
+package com.databricks.sdk.integration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.databricks.sdk.WorkspaceClient;
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.integration.framework.EnvContext;
+import com.databricks.sdk.integration.framework.EnvOrSkip;
+import com.databricks.sdk.integration.framework.EnvTest;
+import com.databricks.sdk.service.iam.Group;
+import com.databricks.sdk.service.iam.ListGroupsRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@EnvContext("account")
+@ExtendWith(EnvTest.class)
+public class UnifiedHostGroupsIT {
+  @Test
+  void listWorkspaceGroupsViaUnifiedHost(
+      @EnvOrSkip("UNIFIED_HOST") String host,
+      @EnvOrSkip("TEST_WORKSPACE_ID") String workspaceId,
+      @EnvOrSkip("DATABRICKS_CLIENT_ID") String clientId,
+      @EnvOrSkip("DATABRICKS_CLIENT_SECRET") String clientSecret) {
+    DatabricksConfig config =
+        new DatabricksConfig()
+            .setHost(host)
+            .setWorkspaceId(workspaceId)
+            .setClientId(clientId)
+            .setClientSecret(clientSecret);
+    WorkspaceClient ws = new WorkspaceClient(config);
+
+    Iterable<Group> groups = ws.groups().list(new ListGroupsRequest().setAttributes("displayName"));
+    Group first = groups.iterator().next();
+    assertNotNull(first.getDisplayName());
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/UnifiedHostGroupsIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/UnifiedHostGroupsIT.java
@@ -10,6 +10,7 @@ import com.databricks.sdk.integration.framework.EnvOrSkip;
 import com.databricks.sdk.integration.framework.EnvTest;
 import com.databricks.sdk.service.iam.Group;
 import com.databricks.sdk.service.iam.ListGroupsRequest;
+import java.util.Iterator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -36,7 +37,9 @@ public class UnifiedHostGroupsIT {
     WorkspaceClient ws = new WorkspaceClient(config);
 
     Iterable<Group> groups = ws.groups().list(new ListGroupsRequest().setAttributes("displayName"));
-    Group first = groups.iterator().next();
+    Iterator<Group> it = groups.iterator();
+    assertTrue(it.hasNext(), "Expected at least one group");
+    Group first = it.next();
     assertNotNull(first.getDisplayName());
   }
 }


### PR DESCRIPTION
## Summary
- Added `X-Databricks-Org-Id` header to all methods in the deprecated `GroupsImpl`, `ServicePrincipalsImpl`, and `UsersImpl` workspace services (22 methods total)
- These were the only workspace-level services missing this header, which is required for SPOG (unified) host compatibility
- Added integration test `UnifiedHostGroupsIT` to verify Groups API works through a SPOG host

## Test plan
- [ ] Verify `UnifiedHostGroupsIT.listWorkspaceGroupsViaUnifiedHost` passes against a SPOG host
- [ ] Verify existing workspace SCIM integration tests still pass

This pull request was AI-assisted by Isaac.