### PR TITLE
Add integration tests for OIDC endpoints

### DIFF
--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/OidcAccountEndpointIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/OidcAccountEndpointIT.java
@@ -1,0 +1,48 @@
+package com.databricks.sdk.integration;
+
+import com.databricks.sdk.AccountClient;
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.oauth.OpenIDConnectEndpoints;
+import com.databricks.sdk.integration.framework.EnvContext;
+import com.databricks.sdk.integration.framework.EnvTest;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@EnvContext("account")
+@ExtendWith(EnvTest.class)
+public class OidcAccountEndpointIT {
+  @Test
+  void checkEndpoints(AccountClient a) throws IOException {
+    OpenIDConnectEndpoints endpoints = a.config().getOidcEndpoints();
+    String host = a.config().getHost();
+    String accountId = a.config().getAccountId();
+    if (a.config().isAzure()) {
+      assert endpoints.getAuthorizationEndpoint().equals(host + "/oidc/v1/authorize");
+      assert endpoints.getTokenEndpoint().equals(host + "/oidc/v1/token");
+    } else {
+      assert endpoints
+          .getAuthorizationEndpoint()
+          .equals(host + "/oidc/accounts/" + accountId + "/v1/authorize");
+      assert endpoints
+          .getTokenEndpoint()
+          .equals(host + "/oidc/accounts/" + accountId + "/v1/token");
+    }
+  }
+
+  @Test
+  @EnabledIfEnvironmentVariable(named = "UNIFIED_HOST", matches = ".+")
+  void unifiedEndpointsForSpog(AccountClient a) throws IOException {
+    String unifiedHost = System.getenv("UNIFIED_HOST");
+    DatabricksConfig cfg = a.config();
+    cfg.setHost(unifiedHost);
+    OpenIDConnectEndpoints endpoints = cfg.getOidcEndpoints();
+    String host = cfg.getHost();
+    String accountId = cfg.getAccountId();
+    assert endpoints
+        .getAuthorizationEndpoint()
+        .equals(host + "/oidc/accounts/" + accountId + "/v1/authorize");
+    assert endpoints.getTokenEndpoint().equals(host + "/oidc/accounts/" + accountId + "/v1/token");
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/OidcUcAccountEndpointIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/OidcUcAccountEndpointIT.java
@@ -1,0 +1,48 @@
+package com.databricks.sdk.integration;
+
+import com.databricks.sdk.AccountClient;
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.oauth.OpenIDConnectEndpoints;
+import com.databricks.sdk.integration.framework.EnvContext;
+import com.databricks.sdk.integration.framework.EnvTest;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@EnvContext("ucacct")
+@ExtendWith(EnvTest.class)
+public class OidcUcAccountEndpointIT {
+  @Test
+  void checkEndpoints(AccountClient a) throws IOException {
+    OpenIDConnectEndpoints endpoints = a.config().getOidcEndpoints();
+    String host = a.config().getHost();
+    String accountId = a.config().getAccountId();
+    if (a.config().isAzure()) {
+      assert endpoints.getAuthorizationEndpoint().equals(host + "/oidc/v1/authorize");
+      assert endpoints.getTokenEndpoint().equals(host + "/oidc/v1/token");
+    } else {
+      assert endpoints
+          .getAuthorizationEndpoint()
+          .equals(host + "/oidc/accounts/" + accountId + "/v1/authorize");
+      assert endpoints
+          .getTokenEndpoint()
+          .equals(host + "/oidc/accounts/" + accountId + "/v1/token");
+    }
+  }
+
+  @Test
+  @EnabledIfEnvironmentVariable(named = "UNIFIED_HOST", matches = ".+")
+  void unifiedEndpointsForSpog(AccountClient a) throws IOException {
+    String unifiedHost = System.getenv("UNIFIED_HOST");
+    DatabricksConfig cfg = a.config();
+    cfg.setHost(unifiedHost);
+    OpenIDConnectEndpoints endpoints = cfg.getOidcEndpoints();
+    String host = cfg.getHost();
+    String accountId = cfg.getAccountId();
+    assert endpoints
+        .getAuthorizationEndpoint()
+        .equals(host + "/oidc/accounts/" + accountId + "/v1/authorize");
+    assert endpoints.getTokenEndpoint().equals(host + "/oidc/accounts/" + accountId + "/v1/token");
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/OidcUcWorkspaceEndpointIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/OidcUcWorkspaceEndpointIT.java
@@ -1,0 +1,21 @@
+package com.databricks.sdk.integration;
+
+import com.databricks.sdk.WorkspaceClient;
+import com.databricks.sdk.core.oauth.OpenIDConnectEndpoints;
+import com.databricks.sdk.integration.framework.EnvContext;
+import com.databricks.sdk.integration.framework.EnvTest;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@EnvContext("ucws")
+@ExtendWith(EnvTest.class)
+public class OidcUcWorkspaceEndpointIT {
+  @Test
+  void checkEndpoints(WorkspaceClient w) throws IOException {
+    OpenIDConnectEndpoints endpoints = w.config().getOidcEndpoints();
+    String host = w.config().getHost();
+    assert endpoints.getAuthorizationEndpoint().equals(host + "/oidc/v1/authorize");
+    assert endpoints.getTokenEndpoint().equals(host + "/oidc/v1/token");
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/OidcWorkspaceEndpointIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/OidcWorkspaceEndpointIT.java
@@ -1,0 +1,21 @@
+package com.databricks.sdk.integration;
+
+import com.databricks.sdk.WorkspaceClient;
+import com.databricks.sdk.core.oauth.OpenIDConnectEndpoints;
+import com.databricks.sdk.integration.framework.EnvContext;
+import com.databricks.sdk.integration.framework.EnvTest;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@EnvContext("workspace")
+@ExtendWith(EnvTest.class)
+public class OidcWorkspaceEndpointIT {
+  @Test
+  void checkEndpoints(WorkspaceClient w) throws IOException {
+    OpenIDConnectEndpoints endpoints = w.config().getOidcEndpoints();
+    String host = w.config().getHost();
+    assert endpoints.getAuthorizationEndpoint().equals(host + "/oidc/v1/authorize");
+    assert endpoints.getTokenEndpoint().equals(host + "/oidc/v1/token");
+  }
+}


### PR DESCRIPTION
## Summary
- Adds integration tests for OIDC endpoint resolution across workspace, UC workspace, account, and UC account environments
- Includes unified host endpoint tests gated on `UNIFIED_HOST` environment variable for account contexts

## Test plan
- [ ] CI passes
- [ ] Integration tests run successfully in `workspace`, `ucws`, `account`, and `ucacct` environments
- [ ] Unified host tests are skipped when `UNIFIED_HOST` is not set

This pull request was AI-assisted by Isaac.