### PR TITLE
[Internal] Resolve TokenAudience from token_federation_default_oidc_audiences in host metadata

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Internal Changes
 * Introduced a logging abstraction (`com.databricks.sdk.core.logging`) to decouple the SDK from a specific logging backend.
+* Added `token_federation_default_oidc_audiences` resolution from host metadata. The SDK now sets `tokenAudience` from the first element of this field during config initialization, with fallback to `accountId` for account hosts.
 
 ### API Changes
 * Add `createCatalog()`, `createSyncedTable()`, `deleteCatalog()`, `deleteSyncedTable()`, `getCatalog()` and `getSyncedTable()` methods for `workspaceClient.postgres()` service.

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -884,8 +884,16 @@ public class DatabricksConfig {
       discoveryUrl = oidcUri.resolve(".well-known/oauth-authorization-server").toString();
       LOG.debug("Resolved discovery_url from host metadata: \"{}\"", discoveryUrl);
     }
-    // For account hosts, use the accountId as the token audience if not already set.
+    List<String> audiences = meta.getTokenFederationDefaultOidcAudiences();
+    if (tokenAudience == null && audiences != null && !audiences.isEmpty()) {
+      LOG.debug(
+          "Resolved token_audience from host metadata token_federation_default_oidc_audiences: \"{}\"",
+          audiences.get(0));
+      tokenAudience = audiences.get(0);
+    }
+    // Fallback: for account hosts, use the accountId as the token audience if not already set.
     if (tokenAudience == null && getClientType() == ClientType.ACCOUNT && accountId != null) {
+      LOG.debug("Setting token_audience to account_id for account host: \"{}\"", accountId);
       tokenAudience = accountId;
     }
   }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/HostMetadata.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/HostMetadata.java
@@ -2,6 +2,7 @@ package com.databricks.sdk.core.oauth;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
 /**
  * [Experimental] Parsed response from the /.well-known/databricks-config discovery endpoint.
@@ -22,6 +23,9 @@ public class HostMetadata {
 
   @JsonProperty("cloud")
   private String cloud;
+
+  @JsonProperty("token_federation_default_oidc_audiences")
+  private List<String> tokenFederationDefaultOidcAudiences;
 
   public HostMetadata() {}
 
@@ -52,5 +56,9 @@ public class HostMetadata {
 
   public String getCloud() {
     return cloud;
+  }
+
+  public List<String> getTokenFederationDefaultOidcAudiences() {
+    return tokenFederationDefaultOidcAudiences;
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -657,6 +657,42 @@ public class DatabricksConfigTest {
     }
   }
 
+  // --- resolveHostMetadata token_federation_default_oidc_audiences tests ---
+
+  @Test
+  public void testResolveHostMetadataSetsTokenAudienceFromOidcAudiences() throws IOException {
+    String response =
+        "{\"oidc_endpoint\":\"https://ws.databricks.com/oidc\","
+            + "\"account_id\":\""
+            + DUMMY_ACCOUNT_ID
+            + "\","
+            + "\"token_federation_default_oidc_audiences\":[\"https://ws.databricks.com/oidc/v1/token\"]}";
+    try (FixtureServer server =
+        new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
+      DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
+      config.resolve(emptyEnv());
+      assertEquals("https://ws.databricks.com/oidc/v1/token", config.getTokenAudience());
+    }
+  }
+
+  @Test
+  public void testResolveHostMetadataDoesNotOverrideExistingTokenAudienceWithOidcAudiences()
+      throws IOException {
+    String response =
+        "{\"oidc_endpoint\":\"https://ws.databricks.com/oidc\","
+            + "\"account_id\":\""
+            + DUMMY_ACCOUNT_ID
+            + "\","
+            + "\"token_federation_default_oidc_audiences\":[\"metadata-audience\"]}";
+    try (FixtureServer server =
+        new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
+      DatabricksConfig config =
+          new DatabricksConfig().setHost(server.getUrl()).setTokenAudience("existing-audience");
+      config.resolve(emptyEnv());
+      assertEquals("existing-audience", config.getTokenAudience());
+    }
+  }
+
   // --- discoveryUrl / OIDC endpoint tests ---
 
   @Test

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -693,6 +693,91 @@ public class DatabricksConfigTest {
     }
   }
 
+  @Test
+  public void testResolveHostMetadataNoAudiencesFieldLeavesTokenAudienceNull() throws IOException {
+    // When token_federation_default_oidc_audiences is absent, tokenAudience stays null
+    String response =
+        "{\"oidc_endpoint\":\"https://ws.databricks.com/oidc\","
+            + "\"account_id\":\""
+            + DUMMY_ACCOUNT_ID
+            + "\"}";
+    try (FixtureServer server =
+        new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
+      DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
+      config.resolve(emptyEnv());
+      assertNull(config.getTokenAudience());
+    }
+  }
+
+  @Test
+  public void testResolveHostMetadataEmptyAudiencesListLeavesTokenAudienceNull()
+      throws IOException {
+    // When token_federation_default_oidc_audiences is an empty array, tokenAudience stays null
+    String response =
+        "{\"oidc_endpoint\":\"https://ws.databricks.com/oidc\","
+            + "\"account_id\":\""
+            + DUMMY_ACCOUNT_ID
+            + "\","
+            + "\"token_federation_default_oidc_audiences\":[]}";
+    try (FixtureServer server =
+        new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
+      DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
+      config.resolve(emptyEnv());
+      assertNull(config.getTokenAudience());
+    }
+  }
+
+  @Test
+  public void testResolveHostMetadataEmptyStringAudienceSetsTokenAudience() throws IOException {
+    // When first element is empty string, tokenAudience is set to empty string
+    String response =
+        "{\"oidc_endpoint\":\"https://ws.databricks.com/oidc\","
+            + "\"account_id\":\""
+            + DUMMY_ACCOUNT_ID
+            + "\","
+            + "\"token_federation_default_oidc_audiences\":[\"\"]}";
+    try (FixtureServer server =
+        new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
+      DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
+      config.resolve(emptyEnv());
+      assertEquals("", config.getTokenAudience());
+    }
+  }
+
+  @Test
+  public void testResolveHostMetadataMultipleAudiencesPicksFirst() throws IOException {
+    // When multiple audiences, the first element is used
+    String response =
+        "{\"oidc_endpoint\":\"https://ws.databricks.com/oidc\","
+            + "\"account_id\":\""
+            + DUMMY_ACCOUNT_ID
+            + "\","
+            + "\"token_federation_default_oidc_audiences\":[\"first-audience\",\"second-audience\",\"third-audience\"]}";
+    try (FixtureServer server =
+        new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
+      DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
+      config.resolve(emptyEnv());
+      assertEquals("first-audience", config.getTokenAudience());
+    }
+  }
+
+  @Test
+  public void testResolveHostMetadataNullFirstAudienceLeavesTokenAudienceNull() throws IOException {
+    // When first element is null, tokenAudience stays null
+    String response =
+        "{\"oidc_endpoint\":\"https://ws.databricks.com/oidc\","
+            + "\"account_id\":\""
+            + DUMMY_ACCOUNT_ID
+            + "\","
+            + "\"token_federation_default_oidc_audiences\":[null,\"second-audience\"]}";
+    try (FixtureServer server =
+        new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
+      DatabricksConfig config = new DatabricksConfig().setHost(server.getUrl());
+      config.resolve(emptyEnv());
+      assertNull(config.getTokenAudience());
+    }
+  }
+
   // --- discoveryUrl / OIDC endpoint tests ---
 
   @Test

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -694,6 +694,28 @@ public class DatabricksConfigTest {
   }
 
   @Test
+  public void testResolveHostMetadataOidcAudiencesPriorityOverAccountIdFallback()
+      throws IOException {
+    // token_federation_default_oidc_audiences should take priority over the account_id fallback.
+    // The audiences check runs before the fallback, so once tokenAudience is set from audiences,
+    // the fallback's null check prevents it from overriding.
+    String response =
+        "{\"oidc_endpoint\":\"https://acc.databricks.com/oidc/accounts/{account_id}\","
+            + "\"account_id\":\""
+            + DUMMY_ACCOUNT_ID
+            + "\","
+            + "\"token_federation_default_oidc_audiences\":[\"custom-audience\"]}";
+    try (FixtureServer server =
+        new FixtureServer().with("GET", "/.well-known/databricks-config", response, 200)) {
+      DatabricksConfig config =
+          new DatabricksConfig().setHost(server.getUrl()).setAccountId(DUMMY_ACCOUNT_ID);
+      config.resolve(emptyEnv());
+      // Should use first element of token_federation_default_oidc_audiences, NOT account_id
+      assertEquals("custom-audience", config.getTokenAudience());
+    }
+  }
+
+  @Test
   public void testResolveHostMetadataNoAudiencesFieldLeavesTokenAudienceNull() throws IOException {
     // When token_federation_default_oidc_audiences is absent, tokenAudience stays null
     String response =


### PR DESCRIPTION
  ## Summary

  Resolves `tokenAudience` automatically from the `token_federation_default_oidc_audiences` field returned by the `/.well-known/databricks-config` host metadata endpoint, removing the need for manual audience configuration when using OIDC-based authentication.

  ## Why

  Today, when using Workload Identity Federation or other OIDC-based credential providers, the `tokenAudience` must either be explicitly configured by the user or falls back to `accountId` for account-level hosts. The host metadata endpoint now returns a  `token_federation_default_oidc_audiences` field containing the recommended audience values. Without this change, users must manually configure `tokenAudience` even though the server already advertises the correct value — adding unnecessary friction to OIDC auth setup.

  This PR reads the new field during config initialization so that the SDK automatically picks up the correct audience from host metadata, with user-configured values still taking priority.

  ## What changed

  ### Interface changes

  - **`HostMetadata.getTokenFederationDefaultOidcAudiences()`** — New getter returning `List<String>` of OIDC audiences from host metadata.

  ### Behavioral changes

  - `tokenAudience` resolution now follows a three-tier priority chain:
    1. User-configured `tokenAudience` (highest priority, unchanged)
    2. First element of `token_federation_default_oidc_audiences` from host metadata (**new**)
    3. `accountId` for account hosts (fallback, unchanged)

  ### Internal changes

  - `HostMetadata`: Added `token_federation_default_oidc_audiences` field (`List<String>`) with `@JsonProperty` annotation
  - `DatabricksConfig.resolveHostMetadata()`: Added audience resolution logic before the existing `accountId` fallback
  - `NEXT_CHANGELOG.md`: Added internal changelog entry

  ## How is this tested?
- All integration tests passed (manually triggered)
- Three new unit tests in `DatabricksConfigTest.java`:
  - `testResolveHostMetadataSetsTokenAudienceFromOidcAudiences` — verifies audience is resolved from metadata
  - `testResolveHostMetadataDoesNotOverrideExistingTokenAudienceWithOidcAudiences` — verifies user-configured audience takes priority
  - `testResolveHostMetadataOidcAudiencesPriorityOverAccountIdFallback` — verifies metadata audience takes priority over accountId fallback