### PR TITLE
Add X-Databricks-Org-Id header to Shares.list() extension for SPOG hosts

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 * Fixed non-JSON error responses (e.g. plain-text "Invalid Token" with HTTP 403) producing `Unknown` instead of the correct typed exception (`PermissionDenied`, `Unauthenticated`, etc.). The error message no longer contains Jackson deserialization internals.
 * Added `X-Databricks-Org-Id` header to deprecated workspace SCIM APIs (Groups, ServicePrincipals, Users) for SPOG host compatibility.
+* Added `X-Databricks-Org-Id` header to hand-written `Shares.list()` extension for SPOG host compatibility.
 * Fixed Databricks CLI authentication to detect when the cached token's scopes don't match the SDK's configured scopes. Previously, a scope mismatch was silently ignored, causing requests to use wrong permissions. The SDK now raises an error with instructions to re-authenticate.
 
 ### Security Vulnerabilities

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/SharesExtImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/SharesExtImpl.java
@@ -19,6 +19,9 @@ class SharesExtImpl implements SharesExtService {
       Request req = new Request("GET", path);
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, ListSharesResponse.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);


### PR DESCRIPTION
## Why

Hand-written extension methods that make direct `apiClient.execute()` calls are missing the `X-Databricks-Org-Id` header that SPOG hosts require for routing. The generated service implementations already include this header per-call, but `SharesExtImpl.list()` was missing it.

Linked Go SDK PR: databricks/databricks-sdk-go#1634

## Changes

Added the `X-Databricks-Org-Id` header to `SharesExtImpl.list()`, matching the pattern used by generated code:

```java
if (apiClient.workspaceId() != null) {
  req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
}
```

## Test plan

- [x] `mvn compile -pl databricks-sdk-java` passes

This pull request was AI-assisted by Isaac.