### PR TITLE
Handle null PATH environment variable in UserAgent

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed non-JSON error responses (e.g. plain-text "Invalid Token" with HTTP 403) producing `Unknown` instead of the correct typed exception (`PermissionDenied`, `Unauthenticated`, etc.). The error message no longer contains Jackson deserialization internals.
 * Added `X-Databricks-Org-Id` header to deprecated workspace SCIM APIs (Groups, ServicePrincipals, Users) for SPOG host compatibility.
 * Fixed Databricks CLI authentication to detect when the cached token's scopes don't match the SDK's configured scopes. Previously, a scope mismatch was silently ignored, causing requests to use wrong permissions. The SDK now raises an error with instructions to re-authenticate.
+* Fixed `NullPointerException` in `UserAgent.env()` when the `PATH` environment variable is not set ([#550](https://github.com/databricks/databricks-sdk-java/issues/550)).
 
 ### Security Vulnerabilities
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -299,11 +299,9 @@ public class UserAgent {
 
   private static Environment env() {
     if (env == null) {
-      env =
-          new Environment(
-              System.getenv(),
-              System.getenv("PATH").split(File.pathSeparator),
-              System.getProperty("os.name"));
+      String pathEnv = System.getenv("PATH");
+      String[] pathEntries = pathEnv != null ? pathEnv.split(File.pathSeparator) : new String[0];
+      env = new Environment(System.getenv(), pathEntries, System.getProperty("os.name"));
     }
     return env;
   }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -248,6 +248,16 @@ public class UserAgentTest {
   }
 
   @Test
+  public void testEnvWithNullPath() {
+    UserAgent.env =
+        new Environment(new HashMap<>(), new ArrayList<>(), System.getProperty("os.name"));
+    UserAgent.cicdProvider = null;
+    UserAgent.agentProvider = null;
+    String userAgent = UserAgent.asString();
+    Assertions.assertTrue(userAgent.contains("databricks-sdk-java/"));
+  }
+
+  @Test
   public void testAgentProviderCached() {
     // Set up with cursor agent
     setupAgentEnv(


### PR DESCRIPTION
## Summary
- `System.getenv("PATH")` returns null in environments where PATH is not set (serverless runtimes, minimal containers, custom Docker images). This caused an NPE in `UserAgent.env()`.
- Fall back to an empty path array when PATH is null, so CI/CD and agent detection simply find nothing instead of crashing.

## Test plan
- [x] Added `testEnvWithNullPath` test in `UserAgentTest`
- [x] All existing `UserAgentTest` tests pass
- [x] Formatted with `fmt-maven-plugin`

Fixes #550