### PR TITLE
Make clientId optional in DatabricksOAuthTokenSource

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed non-JSON error responses (e.g. plain-text "Invalid Token" with HTTP 403) producing `Unknown` instead of the correct typed exception (`PermissionDenied`, `Unauthenticated`, etc.). The error message no longer contains Jackson deserialization internals.
 * Added `X-Databricks-Org-Id` header to deprecated workspace SCIM APIs (Groups, ServicePrincipals, Users) for SPOG host compatibility.
 * Fixed Databricks CLI authentication to detect when the cached token's scopes don't match the SDK's configured scopes. Previously, a scope mismatch was silently ignored, causing requests to use wrong permissions. The SDK now raises an error with instructions to re-authenticate.
+* Made `clientId` optional in `DatabricksOAuthTokenSource` to support web browser OIDC federation flows where no client ID is available. The `client_id` parameter is now only included in token exchange requests when non-null and non-empty, per RFC 8693 ([#757](https://github.com/databricks/databricks-sdk-java/issues/757)).
 
 ### Security Vulnerabilities
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSource.java
@@ -72,7 +72,7 @@ public class DatabricksOAuthTokenSource implements TokenSource {
     /**
      * Creates a new Builder with required parameters.
      *
-     * @param clientId OAuth client ID.
+     * @param clientId OAuth client ID, or null for web OAuth2 flows that don't require one.
      * @param host Databricks host URL.
      * @param endpoints OpenID Connect endpoints configuration.
      * @param idTokenSource Source of ID tokens.
@@ -145,15 +145,11 @@ public class DatabricksOAuthTokenSource implements TokenSource {
    */
   @Override
   public Token getToken() {
-    Objects.requireNonNull(clientId, "ClientID cannot be null");
     Objects.requireNonNull(host, "Host cannot be null");
     Objects.requireNonNull(endpoints, "Endpoints cannot be null");
     Objects.requireNonNull(idTokenSource, "IDTokenSource cannot be null");
     Objects.requireNonNull(httpClient, "HttpClient cannot be null");
 
-    if (clientId.isEmpty()) {
-      throw new IllegalArgumentException("ClientID cannot be empty");
-    }
     if (host.isEmpty()) {
       throw new IllegalArgumentException("Host cannot be empty");
     }
@@ -166,7 +162,9 @@ public class DatabricksOAuthTokenSource implements TokenSource {
     params.put(SUBJECT_TOKEN_PARAM, idToken.getValue());
     params.put(SUBJECT_TOKEN_TYPE_PARAM, SUBJECT_TOKEN_TYPE);
     params.put(SCOPE_PARAM, String.join(" ", scopes));
-    params.put(CLIENT_ID_PARAM, clientId);
+    if (!Strings.isNullOrEmpty(clientId)) {
+      params.put(CLIENT_ID_PARAM, clientId);
+    }
 
     OAuthResponse response;
     try {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSourceTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSourceTest.java
@@ -108,7 +108,7 @@ class DatabricksOAuthTokenSourceTest {
       final String errorJson = mapper.writeValueAsString(errorResponse);
       final String successJson = mapper.writeValueAsString(successResponse);
 
-      // Create the expected request that will be used in all test cases
+      // Create the expected request with client_id for standard test cases
       Map<String, String> formParams = new HashMap<>();
       formParams.put("client_id", TEST_CLIENT_ID);
       formParams.put("subject_token", TEST_ID_TOKEN);
@@ -116,6 +116,14 @@ class DatabricksOAuthTokenSourceTest {
       formParams.put("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
       formParams.put("scope", "all-apis");
       FormRequest expectedRequest = new FormRequest(TEST_TOKEN_ENDPOINT, formParams);
+
+      // Create the expected request without client_id for null/empty client ID cases
+      Map<String, String> noClientIdFormParams = new HashMap<>();
+      noClientIdFormParams.put("subject_token", TEST_ID_TOKEN);
+      noClientIdFormParams.put("subject_token_type", "urn:ietf:params:oauth:token-type:jwt");
+      noClientIdFormParams.put("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      noClientIdFormParams.put("scope", "all-apis");
+      FormRequest noClientIdRequest = new FormRequest(TEST_TOKEN_ENDPOINT, noClientIdFormParams);
 
       return Stream.of(
           // Token exchange test cases
@@ -198,27 +206,27 @@ class DatabricksOAuthTokenSourceTest {
               DatabricksException.class),
           // Parameter validation test cases
           new TestCase(
-              "Null client ID",
+              "Null client ID omits client_id from request",
               null,
               TEST_HOST,
               testEndpoints,
               testIdTokenSource,
-              createMockHttpClient(expectedRequest, 200, successJson),
+              createMockHttpClient(noClientIdRequest, 200, successJson),
               null,
               null,
-              null,
-              NullPointerException.class),
+              TEST_TOKEN_ENDPOINT,
+              null),
           new TestCase(
-              "Empty client ID",
+              "Empty client ID omits client_id from request",
               "",
               TEST_HOST,
               testEndpoints,
               testIdTokenSource,
-              createMockHttpClient(expectedRequest, 200, successJson),
+              createMockHttpClient(noClientIdRequest, 200, successJson),
               null,
               null,
-              null,
-              IllegalArgumentException.class),
+              TEST_TOKEN_ENDPOINT,
+              null),
           new TestCase(
               "Null host",
               TEST_CLIENT_ID,


### PR DESCRIPTION
## Summary
- `DatabricksOAuthTokenSource` required a non-null, non-empty `clientId`, which blocked users authenticating via web browser OIDC federation flows where no client ID is available in the IdP JWT token.
- RFC 8693 makes `client_id` optional for token exchange requests. The `client_id` parameter is now only included when the value is non-null and non-empty. Fully backward compatible.

## Test plan
- [x] Updated "Null client ID" test: now expects successful token exchange (was `NullPointerException`)
- [x] Updated "Empty client ID" test: now expects successful token exchange (was `IllegalArgumentException`)
- [x] Both tests verify `client_id` is absent from the request body
- [x] All 14 `DatabricksOAuthTokenSourceTest` tests pass
- [x] Formatted with `fmt-maven-plugin`

Fixes #757