### PR TITLE
Add X-Databricks-Org-Id header to SharesExtImpl.list() for SPOG

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added automatic detection of AI coding agents (Amp, Antigravity, Augment, Claude Code, Cline, Codex, Copilot CLI, Copilot VS Code, Cursor, Gemini CLI, Goose, Kiro, OpenClaw, OpenCode, Windsurf) in the user-agent string. The SDK now appends `agent/<name>` to HTTP request headers when running inside a known AI agent environment. Also honors the `AGENT=<name>` standard: when `AGENT` is set to a known product name the SDK reports that product, and when set to an unrecognized non-empty value the SDK reports `agent/unknown`. Environment variables set to the empty string (e.g. `CLAUDECODE=""`) now count as "set" for presence-only matchers, matching `databricks-sdk-go` semantics; previously they were treated as unset. Explicit agent env vars (e.g. `CLAUDECODE`, `GOOSE_TERMINAL`) always take precedence over the generic `AGENT=<name>` signal. When multiple agent env vars are present (e.g. a Cursor CLI subagent invoked from Claude Code), the user-agent reports `agent/multiple`.
 
 ### Bug Fixes
+* Add `X-Databricks-Org-Id` header to `SharesExtImpl.list()` for SPOG host compatibility. Without this header, calls to the hand-written extension were rejected by the SPOG proxy with `Unable to load OAuth Config (400 UNKNOWN)`. Mirrors [databricks/databricks-sdk-go#1635](https://github.com/databricks/databricks-sdk-go/pull/1635).
 
 ### Security Vulnerabilities
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/SharesExtImpl.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/service/sharing/SharesExtImpl.java
@@ -19,6 +19,9 @@ class SharesExtImpl implements SharesExtService {
       Request req = new Request("GET", path);
       ApiClient.setQuery(req, request);
       req.withHeader("Accept", "application/json");
+      if (apiClient.workspaceId() != null) {
+        req.withHeader("X-Databricks-Org-Id", apiClient.workspaceId());
+      }
       return apiClient.execute(req, ListSharesResponse.class);
     } catch (IOException e) {
       throw new DatabricksException("IO error: " + e.getMessage(), e);


### PR DESCRIPTION
## Summary

Ports [databricks/databricks-sdk-go#1635](https://github.com/databricks/databricks-sdk-go/pull/1635) and the applicable piece of [databricks/databricks-sdk-py#1397](https://github.com/databricks/databricks-sdk-py/pull/1397) to the Java SDK.

`SharesExtImpl.list()` is a hand-written extension that calls `apiClient.execute()` directly and was missing the `X-Databricks-Org-Id` request header. On SPOG hosts this causes the call to fail with:

```
Error: Unable to load OAuth Config (400 UNKNOWN)
```

Generated service methods already set this header when `cfg.workspaceId` is populated (see any `*Impl.java` under `service/`, e.g. `WorkspaceImpl.export()` / `importContent()` or `SharesImpl.create()`). This change brings the hand-written extension in line.

## Scope vs. the Python PR

[databricks-sdk-py#1397](https://github.com/databricks/databricks-sdk-py/pull/1397) contains three fixes; only one applies to Java:

| Python fix | Applies to Java? |
|---|---|
| `SharesExt.list()` missing `X-Databricks-Org-Id` | ✅ ported here |
| `WorkspaceExt.upload()` / `WorkspaceExt.download()` missing header | ❌ no equivalent — Java has no hand-written `WorkspaceExt`; generated `WorkspaceImpl.export()` / `importContent()` already include the header |
| `WorkspaceClient.get_workspace_id()` short-circuit | ❌ no equivalent — Java `WorkspaceClient` has no `getWorkspaceId()` method |

## Test plan

- [x] `mvn compile` clean
- [x] Spotless clean
- [ ] Integration tests on a SPOG host (requires a real SPOG workspace)

No dedicated unit test added, matching the Go PR (`#1635`) and Python PR which applied the same pattern without one — there is no test infrastructure for asserting per-request headers on the hand-written extensions.

This pull request was AI-assisted by Isaac.