### PR TITLE
Remove legacy tag-triggered release workflow

### DIFF
--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -1,11 +1,12 @@
-name: Release
+name: Release Build Check
 
 on:
   push:
-    # Run a real release on pushes to tags like v1.0, v2.3.4, etc.
-    tags:
-      - "v*"
-    # Run a dry-run on pushes to any branch
+    # Run a release build dry-run on pushes to any branch to verify
+    # that the release build still succeeds. Actual releases are driven
+    # by the secure release pipeline in
+    # databricks/secure-public-registry-releases-eng via workflow_dispatch
+    # against tagging.yml and package.yml.
     branches:
       - "**"
 
@@ -15,8 +16,7 @@ permissions:
 
 jobs:
   publish:
-    # Dynamically set the job name based on the trigger
-    name: ${{ startsWith(github.ref, 'refs/tags/') && 'Publish Release' || 'Run Release Dry-Run' }}
+    name: Run Release Dry-Run
 
     runs-on:
       group: databricks-protected-runner-group
@@ -82,42 +82,9 @@ jobs:
           </settings>
           EOF
 
-      # This step runs ONLY on branch pushes (dry-run)
       - name: Run Release Dry-Run (Verify)
-        if: "!startsWith(github.ref, 'refs/tags/')"
         run: mvn -Prelease -DskipTests=true --batch-mode verify
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-
-      # This step runs ONLY on tag pushes (real release)
-      - name: Publish to Maven Central Repository (Deploy)
-        if: "startsWith(github.ref, 'refs/tags/')"
-        run: mvn -Prelease -DskipTests=true --batch-mode deploy
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-
-      - name: Write release notes to file
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            RELEASE_NOTES_DIR=/tmp/release-notes
-            mkdir -p "$RELEASE_NOTES_DIR"
-            RELEASE_NOTES_FILE="$RELEASE_NOTES_DIR/release-notes.md"
-            git for-each-ref --format='%(body)' ${{ github.ref }} > "$RELEASE_NOTES_FILE"
-            echo "Release notes file: $RELEASE_NOTES_FILE"
-            echo "Release notes contents:"
-            cat "$RELEASE_NOTES_FILE"
-          else
-            echo "Not a release tag, skipping release notes"
-          fi
-
-      # This step also runs ONLY on tag pushes (real release)
-      - name: Create GitHub release
-        if: "startsWith(github.ref, 'refs/tags/')"
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
-        with:
-          files: databricks-sdk-java/target/*.jar
-          body_path: /tmp/release-notes/release-notes.md


### PR DESCRIPTION
NO_CHANGELOG=true

## Summary

The secure release pipeline in [`databricks/secure-public-registry-releases-eng`](https://github.com/databricks/secure-public-registry-releases-eng) now owns the Maven Central and GitHub release for this repo. It dispatches `tagging.yml` (to create the tag) and `package.yml` (to build + sign artifacts), then does the actual publish + GH release from the secure side.

The previous in-repo tag-triggered path in `release.yml` is the legacy entry point that the secure pipeline has replaced. This PR removes it and keeps only the release-build dry-run that runs on every branch push.

## Per-file decisions

- `.github/workflows/release.yml` -- **edited and renamed** to `.github/workflows/release-build-check.yml` (top-level `name: Release Build Check`).
  - Removed: the `push.tags: ['v*']` trigger.
  - Removed: the tag-gated steps (`if: startsWith(github.ref, 'refs/tags/')`) -- `Publish to Maven Central Repository (Deploy)`, `Write release notes to file`, `Create GitHub release`.
  - Removed: the `!startsWith(...)` guard on the dry-run step (no longer needed now that the tag trigger is gone).
  - Preserved: the branch-push trigger and the `Run Release Dry-Run (Verify)` step, which is what "verify the release build still works" means in this repo.
- `.github/workflows/debug-prelease.yml` -- **not present in the repo**, nothing to do.
- `.github/workflows/tagging.yml` -- unchanged (dispatched by the secure release pipeline).
- `.github/workflows/package.yml` -- unchanged (dispatched by the secure release pipeline).
- All other workflows (`push.yml`, `conftest.yml`, `integration-tests.yml`, `external-message.yml`, `next-changelog.yml`) -- unchanged; they are PR / `merge_group` CI or unrelated automation.

## Heads up: required-check rename

The job name inside the renamed workflow is now constant (`Run Release Dry-Run`) instead of the previous dynamic name (`${{ startsWith(github.ref, 'refs/tags/') && 'Publish Release' || 'Run Release Dry-Run' }}`). The dry-run side produced the same `Run Release Dry-Run` string before, so if anything on the branch side was using that exact name as a required status check it should continue to match. If branch protection was referencing the workflow file by path (`release.yml`), that reference will need to be updated to `release-build-check.yml`.

## Test plan

- [ ] Confirm this PR's own CI (`build` from `push.yml` on `pull_request`) runs green.
- [ ] On merge to `main`, confirm the renamed workflow fires on the push and the `Run Release Dry-Run` job succeeds.
- [ ] Confirm no tag-push events target this workflow any longer.
- [ ] Update any branch-protection required-check references from `release.yml` to `release-build-check.yml` if they existed.