### PR TITLE
Fix spotless:apply failure on modern JDKs

### DIFF
--- a/.codegen.json
+++ b/.codegen.json
@@ -14,6 +14,6 @@
   "toolchain": {
     "require": ["mvn", "java"],
     "setup": ["bash scripts/cleanup-services.sh"],
-    "post_generate": ["mvn spotless:apply","mvn --errors clean test"]
+    "post_generate": ["bash scripts/mvn-spotless-apply.sh","mvn --errors clean test"]
   }
 }

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/AccountClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/AccountClient.java
@@ -665,6 +665,7 @@ public class AccountClient {
   public AccountGroupsAPI groups() {
     return groupsAPI;
   }
+
   /**
    * Identities for use with jobs, automated tools, and systems such as scripts, apps, and CI/CD
    * platforms. Databricks recommends creating service principals to run production jobs or modify
@@ -675,6 +676,7 @@ public class AccountClient {
   public AccountServicePrincipalsAPI servicePrincipals() {
     return servicePrincipalsAPI;
   }
+
   /**
    * User identities recognized by Databricks and represented by email addresses.
    *

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GrpcTranscodingQueryParamsSerializer.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GrpcTranscodingQueryParamsSerializer.java
@@ -37,6 +37,7 @@ public class GrpcTranscodingQueryParamsSerializer {
       return value;
     }
   }
+
   /**
    * Serializes an object into a map of query parameter values compatible with gRPC-transcoding.
    *

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/http/Request.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/http/Request.java
@@ -22,21 +22,25 @@ public class Request {
   private final Map<String, String> headers = new HashMap<>();
   private final Map<String, List<String>> query = new TreeMap<>();
   private Optional<Boolean> redirectionBehavior = Optional.empty();
+
   /**
    * The body of the request for requests with streaming bodies. At most one of {@link #bodyStream}
    * and {@link #bodyString} can be non-null.
    */
   private final InputStream bodyStream;
+
   /**
    * The body of the request for requests with string bodies. At most one of {@link #bodyStream} and
    * {@link #bodyString} can be non-null.
    */
   private final String bodyString;
+
   /**
    * Whether the body of the request is a streaming body. At most one of {@link #isBodyStreaming}
    * and {@link #isBodyString} can be true.
    */
   private final boolean isBodyStreaming;
+
   /**
    * Whether the body of the request is a string body. At most one of {@link #isBodyStreaming} and
    * {@link #isBodyString} can be true.

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DataPlaneTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DataPlaneTokenSource.java
@@ -21,6 +21,7 @@ public class DataPlaneTokenSource {
   private final String host;
   private final boolean asyncDisabled;
   private final ConcurrentHashMap<TokenSourceKey, CachedTokenSource> sourcesCache;
+
   /**
    * Caching key for {@link EndpointTokenSource}, based on endpoint and authorization details. This
    * is a value object that uniquely identifies a token source configuration.

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSource.java
@@ -21,18 +21,25 @@ public class DatabricksOAuthTokenSource implements TokenSource {
 
   /** OAuth client ID used for token exchange. */
   private final String clientId;
+
   /** Databricks host URL. */
   private final String host;
+
   /** Databricks account ID, used as audience if provided. */
   private final String accountId;
+
   /** OpenID Connect endpoints configuration. */
   private final OpenIDConnectEndpoints endpoints;
+
   /** Custom audience value for token exchange. */
   private final String audience;
+
   /** Source of ID tokens used in token exchange. */
   private final IDTokenSource idTokenSource;
+
   /** HTTP client for making token exchange requests. */
   private final HttpClient httpClient;
+
   /** Scopes to request during token exchange. */
   private final List<String> scopes;
 

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/service/gentesting/unittests/LroTestingAPITest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/service/gentesting/unittests/LroTestingAPITest.java
@@ -389,6 +389,7 @@ public class LroTestingAPITest {
           testCase.wantMetadata, metadata, "Metadata mismatch for test case: " + testCase.name);
     }
   }
+
   // Done test cases.
   static List<DoneTestCase> doneTestCases() throws JsonProcessingException, JsonMappingException {
     return Arrays.asList(

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,13 @@
         <configuration>
           <java>
             <!--            <cleanthat/> This can be added after we drop java 8 support -->
-            <googleJavaFormat/>
+            <googleJavaFormat>
+              <!-- 1.22.0 is the last GJF release that supports JRE 11 (1.23+ requires JRE 17).
+                   Needed to support newer JDKs (e.g. the code-generator's JDK 25) where the
+                   spotless-bundled default (1.15.0) fails with NoSuchMethodError against
+                   javac internals (Log$DeferredDiagnosticHandler.getDiagnostics). -->
+              <version>1.22.0</version>
+            </googleJavaFormat>
             <importOrder/>
             <removeUnusedImports/>
             <formatAnnotations/>

--- a/scripts/mvn-spotless-apply.sh
+++ b/scripts/mvn-spotless-apply.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Wrapper for `mvn spotless:apply` that exports the javac-internals flags required by
+# google-java-format on JDK 16+. Without these, GJF fails on JDK 17+ with either
+# IllegalAccessError or NoSuchMethodError when it reaches into com.sun.tools.javac.*.
+# On JDK <= 15 the flags are unrecognized and would break Maven startup, so we only
+# set them when detected JDK major version is >= 16.
+
+set -euo pipefail
+
+JDK_VERSION_OUTPUT=$(java -version 2>&1 | head -1)
+# Matches `"1.8.0_xxx"` (legacy) and `"17.0.1"` / `"25"` (modern) forms.
+JDK_MAJOR=$(echo "$JDK_VERSION_OUTPUT" | sed -E 's/.*version "([0-9]+)(\.[0-9]+)?.*/\1/')
+if [ "$JDK_MAJOR" = "1" ]; then
+  JDK_MAJOR=$(echo "$JDK_VERSION_OUTPUT" | sed -E 's/.*version "1\.([0-9]+).*/\1/')
+fi
+
+if [ "${JDK_MAJOR:-0}" -ge 16 ]; then
+  export MAVEN_OPTS="${MAVEN_OPTS:-} \
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+fi
+
+exec mvn spotless:apply


### PR DESCRIPTION
## Summary

  - Pin `google-java-format` to **1.22.0** in the root `pom.xml` so `mvn spotless:apply` stops crashing on modern JDKs
  (the code generator runs on JDK 25, where spotless-maven-plugin 2.30.0's bundled GJF 1.15.0 throws
  `NoSuchMethodError` against the renamed `com.sun.tools.javac.util.Log$DeferredDiagnosticHandler.getDiagnostics()`
  signature). 1.22.0 is the last GJF release that still supports JRE 11, keeping local dev and the JDK 11 `fmt` CI job
  working.
  - Add `scripts/mvn-spotless-apply.sh`, a drop-in wrapper that exports `MAVEN_OPTS` with the
  `--add-exports=jdk.compiler/com.sun.tools.javac.*=ALL-UNNAMED` flags required by GJF on JDK 16+. It detects the JDK
  major version and only sets the flags when needed, so older JDKs (including the JDK 8 CI matrix rows) are untouched.
  `.codegen.json`'s `post_generate` now invokes the wrapper instead of `mvn spotless:apply` directly, mirroring the
  existing `bash scripts/cleanup-services.sh` pattern.
  - One-time reformat of 6 files (16 blank lines inserted, 0 deletions) to satisfy GJF 1.22.0's stricter rules around
  blank lines between documented fields. No semantic changes.

  ### Why a wrapper script and not `.mvn/jvm.config`?

  `.mvn/jvm.config` applies to every Maven invocation, and this repo's CI matrix runs `mvn test` / release jobs under
  JDK 8, where `--add-exports` is an unrecognized arg and Maven would fail to start. Scoping the flags to the one
  command that actually needs them (`spotless:apply`) avoids that blast radius.

  ### Impact on CI

  - `fmt` (JDK 11 → `spotless:check`): GJF 1.22.0 loads fine on JRE 11.
  - `unit-tests` matrix (JDK 8/11/17/20 → `mvn test`): unaffected, spotless plugin has no `<execution>` binding so it
  never runs during tests.
  - `release-build-check` / `package` (JDK 8): unaffected, same reason.
  - Compiled bytecode target remains Java 8; GJF only reformats source whitespace.

  ## Test plan

  - [x] `mvn spotless:check` passes on local JDK 11 after the reformat
  - [x] `mvn spotless:apply` on clean HEAD (after pom bump) produces the expected 6-file reformat only; subsequent runs
   are no-ops (idempotent)
  - [x] `bash scripts/mvn-spotless-apply.sh` on JDK 11 correctly skips the `MAVEN_OPTS` export (`JDK < 16`) and
  delegates to `mvn spotless:apply` with `BUILD SUCCESS`
  - [x] CI green across all matrix rows (JDK 8/11/17/20 unit-tests, JDK 11 fmt, JDK 8 release-build-check)
  
  NO_CHANGELOG=true