### PR TITLE
Detect VS Code agent via VSCODE_AGENT, remove COPILOT_MODEL heuristic

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+* Detect VS Code agent-initiated terminal commands via the `VSCODE_AGENT` environment variable (VS Code 1.121+). The User-Agent header now reports `agent/vscode-agent` when set. The previous `COPILOT_MODEL` heuristic (which reported `agent/copilot-vscode`) has been removed; it produced false positives for Copilot CLI BYOK users and never reliably identified VS Code.
+
 ### Breaking Changes
 
 ### Bug Fixes

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### New Features and Improvements
 
-* Detect VS Code agent-initiated terminal commands via the `VSCODE_AGENT` environment variable (VS Code 1.121+). The User-Agent header now reports `agent/vscode-agent` when set. The previous `COPILOT_MODEL` heuristic (which reported `agent/copilot-vscode`) has been removed; it produced false positives for Copilot CLI BYOK users and never reliably identified VS Code.
-
 ### Breaking Changes
 
 ### Bug Fixes

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -267,8 +267,6 @@ public class UserAgent {
         new KnownAgent("CLINE_ACTIVE", "cline"), // https://github.com/cline/cline (v3.24.0+)
         new KnownAgent("CODEX_CI", "codex"), // https://github.com/openai/codex
         new KnownAgent("COPILOT_CLI", "copilot-cli"), // https://github.com/features/copilot
-        // VS Code Copilot terminal; best-effort heuristic, not officially identified.
-        new KnownAgent("COPILOT_MODEL", "copilot-vscode"),
         new KnownAgent("CURSOR_AGENT", "cursor"), // Closed source
         new KnownAgent("GEMINI_CLI", "gemini-cli"), // https://google-gemini.github.io/gemini-cli
         new KnownAgent(
@@ -277,6 +275,9 @@ public class UserAgent {
         new KnownAgent("KIRO", "kiro"), // https://kiro.dev/ (Amazon)
         new KnownAgent("OPENCLAW_SHELL", "openclaw"), // https://github.com/anthropics/openclaw
         new KnownAgent("OPENCODE", "opencode"), // https://github.com/opencode-ai/opencode
+        // Set by VS Code 1.121+ for agent-initiated terminal commands
+        // (https://code.visualstudio.com/updates/v1_121).
+        new KnownAgent("VSCODE_AGENT", "vscode-agent"),
         new KnownAgent("WINDSURF_AGENT", "windsurf")); // https://codeium.com/windsurf (Codeium)
   }
 
@@ -308,13 +309,6 @@ public class UserAgent {
       if (env.get(a.envVar) != null) {
         matches.add(a.product);
       }
-    }
-
-    // Known BYOK false positive: Copilot CLI users often set COPILOT_MODEL
-    // alongside COPILOT_CLI. Treat that pair as a single copilot-cli signal
-    // rather than a stacked multi-agent setup.
-    if (matches.contains("copilot-cli") && matches.contains("copilot-vscode")) {
-      matches.removeIf(m -> m.equals("copilot-vscode"));
     }
 
     if (matches.size() == 1) {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -252,19 +252,6 @@ public class UserAgentTest {
   }
 
   @Test
-  public void testAgentProviderCopilotModelAloneNotDetected() {
-    // COPILOT_MODEL is set by Copilot CLI BYOK users and does not by itself
-    // identify any agent.
-    setupAgentEnv(
-        new HashMap<String, String>() {
-          {
-            put("COPILOT_MODEL", "gpt-4");
-          }
-        });
-    Assertions.assertFalse(UserAgent.asString().contains("agent/"));
-  }
-
-  @Test
   public void testAgentProviderGoose() {
     setupAgentEnv(
         new HashMap<String, String>() {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -241,14 +241,27 @@ public class UserAgentTest {
   }
 
   @Test
-  public void testAgentProviderCopilotVscode() {
+  public void testAgentProviderVscodeAgent() {
+    setupAgentEnv(
+        new HashMap<String, String>() {
+          {
+            put("VSCODE_AGENT", "1");
+          }
+        });
+    Assertions.assertTrue(UserAgent.asString().contains("agent/vscode-agent"));
+  }
+
+  @Test
+  public void testAgentProviderCopilotModelAloneNotDetected() {
+    // COPILOT_MODEL is set by Copilot CLI BYOK users and does not by itself
+    // identify any agent.
     setupAgentEnv(
         new HashMap<String, String>() {
           {
             put("COPILOT_MODEL", "gpt-4");
           }
         });
-    Assertions.assertTrue(UserAgent.asString().contains("agent/copilot-vscode"));
+    Assertions.assertFalse(UserAgent.asString().contains("agent/"));
   }
 
   @Test
@@ -415,30 +428,14 @@ public class UserAgentTest {
   }
 
   @Test
-  public void testAgentProviderCopilotCliAndCopilotVscodeCollapseToCopilotCli() {
-    // Copilot CLI users (BYOK mode) often set COPILOT_MODEL alongside
-    // COPILOT_CLI. Treat the pair as a single copilot-cli signal rather
-    // than a stacked multi-agent setup.
+  public void testAgentProviderVscodeAgentAndCopilotCliReportsMultiple() {
+    // VSCODE_AGENT can legitimately stack with other agents (e.g. running
+    // Copilot CLI from a VS Code agent terminal).
     setupAgentEnv(
         new HashMap<String, String>() {
           {
+            put("VSCODE_AGENT", "1");
             put("COPILOT_CLI", "1");
-            put("COPILOT_MODEL", "gpt-4");
-          }
-        });
-    Assertions.assertTrue(UserAgent.asString().contains("agent/copilot-cli"));
-  }
-
-  @Test
-  public void testAgentProviderCopilotByokCollapseStillMultiple() {
-    // The Copilot BYOK collapse only drops the copilot-vscode match. If
-    // another agent is also present, the result is still "multiple".
-    setupAgentEnv(
-        new HashMap<String, String>() {
-          {
-            put("COPILOT_CLI", "1");
-            put("COPILOT_MODEL", "gpt-4");
-            put("CLAUDECODE", "1");
           }
         });
     Assertions.assertTrue(UserAgent.asString().contains("agent/multiple"));


### PR DESCRIPTION
## Why

[VS Code 1.121](https://code.visualstudio.com/updates/v1_121) introduced the `VSCODE_AGENT` environment variable, set for any agent-initiated terminal command (Copilot Chat agent mode and other agent extensions). This is the official signal for VS Code agent usage.

The previous heuristic detected `COPILOT_MODEL` and reported `copilot-vscode`, but `COPILOT_MODEL` is actually set by Copilot CLI users who bring their own key, not specifically by VS Code. This produced false positives and required a BYOK collapse workaround (drop `copilot-vscode` whenever `COPILOT_CLI` was also set). Over the last 13 weeks, the heuristic identified 3 users / 52 events; `copilot-cli` saw 539 users / 175k events. The signal was effectively dead.

## Changes

- Add `VSCODE_AGENT` to `listKnownAgents()`, reported as `agent/vscode-agent`.
- Remove the `COPILOT_MODEL` to `copilot-vscode` mapping.
- Remove the BYOK collapse logic. `VSCODE_AGENT` can legitimately stack with `COPILOT_CLI` (e.g. running Copilot CLI from a VS Code agent terminal), so the multi-agent path covers it without special handling.

## Tests

- [x] Updated `UserAgentTest.java`: new `testAgentProviderVscodeAgent` and stacking test.
- [x] `mvn test -Dtest=UserAgentTest` passes (40 tests, 0 failures).
- [x] `make fmt` clean.

This PR mirrors parallel changes in [databricks-sdk-go](https://github.com/databricks/databricks-sdk-go/pull/1697), [databricks-sdk-py](https://github.com/databricks/databricks-sdk-py/pull/1444), and [sdk-js](https://github.com/databricks/sdk-js/pull/152).

NO_CHANGELOG=true