### PR TITLE
Make client ID optional in DatabricksOAuthTokenSource

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Bug Fixes
 
+- Make the client ID optional in `DatabricksOAuthTokenSource`. Previously `getToken()` threw a
+  `NullPointerException` ("ClientID cannot be null") when no client ID was set, which prevented
+  token exchange for users authenticated through a web browser OAuth flow whose IdP JWT does not
+  contain a client ID. When the client ID is null or empty, the `client_id` parameter is now
+  omitted from the token exchange request to perform account-wide token federation.
+
 ### Security Vulnerabilities
 
 ### Documentation

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSource.java
@@ -79,7 +79,9 @@ public class DatabricksOAuthTokenSource implements TokenSource {
     /**
      * Creates a new Builder with required parameters.
      *
-     * @param clientId OAuth client ID.
+     * @param clientId OAuth client ID. May be null or empty for account-wide token federation (e.g.
+     *     users authenticated through a web browser OAuth flow whose IdP JWT has no client ID); in
+     *     that case the client_id parameter is omitted from the token exchange request.
      * @param host Databricks host URL.
      * @param endpoints OpenID Connect endpoints configuration.
      * @param idTokenSource Source of ID tokens.
@@ -147,20 +149,17 @@ public class DatabricksOAuthTokenSource implements TokenSource {
    *
    * @return A Token containing the access token and related information.
    * @throws DatabricksException when the token exchange fails.
-   * @throws IllegalArgumentException when the required string parameters are empty.
-   * @throws NullPointerException when any of the required parameters are null.
+   * @throws IllegalArgumentException when the host is empty.
+   * @throws NullPointerException when any of the required parameters (host, endpoints,
+   *     idTokenSource, httpClient) are null. The client ID is optional.
    */
   @Override
   public Token getToken() {
-    Objects.requireNonNull(clientId, "ClientID cannot be null");
     Objects.requireNonNull(host, "Host cannot be null");
     Objects.requireNonNull(endpoints, "Endpoints cannot be null");
     Objects.requireNonNull(idTokenSource, "IDTokenSource cannot be null");
     Objects.requireNonNull(httpClient, "HttpClient cannot be null");
 
-    if (clientId.isEmpty()) {
-      throw new IllegalArgumentException("ClientID cannot be empty");
-    }
     if (host.isEmpty()) {
       throw new IllegalArgumentException("Host cannot be empty");
     }
@@ -173,7 +172,12 @@ public class DatabricksOAuthTokenSource implements TokenSource {
     params.put(SUBJECT_TOKEN_PARAM, idToken.getValue());
     params.put(SUBJECT_TOKEN_TYPE_PARAM, SUBJECT_TOKEN_TYPE);
     params.put(SCOPE_PARAM, String.join(" ", scopes));
-    params.put(CLIENT_ID_PARAM, clientId);
+    // The client ID is optional. Service principals (Workload Identity Federation) send it, but
+    // users authenticated through a web browser OAuth flow have no client ID in their IdP JWT and
+    // perform account-wide token federation without one.
+    if (!Strings.isNullOrEmpty(clientId)) {
+      params.put(CLIENT_ID_PARAM, clientId);
+    }
 
     OAuthResponse response;
     try {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSourceTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSourceTest.java
@@ -117,6 +117,13 @@ class DatabricksOAuthTokenSourceTest {
       formParams.put("scope", "all-apis");
       FormRequest expectedRequest = new FormRequest(TEST_TOKEN_ENDPOINT, formParams);
 
+      // Expected request for account-wide token federation, where no client ID is provided (e.g.
+      // users authenticated through a web browser OAuth flow). The client_id param is omitted.
+      Map<String, String> formParamsNoClientId = new HashMap<>(formParams);
+      formParamsNoClientId.remove("client_id");
+      FormRequest expectedRequestNoClientId =
+          new FormRequest(TEST_TOKEN_ENDPOINT, formParamsNoClientId);
+
       return Stream.of(
           // Token exchange test cases
           new TestCase(
@@ -198,27 +205,27 @@ class DatabricksOAuthTokenSourceTest {
               DatabricksException.class),
           // Parameter validation test cases
           new TestCase(
-              "Null client ID",
+              "Null client ID performs account-wide token federation",
               null,
               TEST_HOST,
               testEndpoints,
               testIdTokenSource,
-              createMockHttpClient(expectedRequest, 200, successJson),
+              createMockHttpClient(expectedRequestNoClientId, 200, successJson),
               null,
               null,
-              null,
-              NullPointerException.class),
+              TEST_TOKEN_ENDPOINT,
+              null),
           new TestCase(
-              "Empty client ID",
+              "Empty client ID performs account-wide token federation",
               "",
               TEST_HOST,
               testEndpoints,
               testIdTokenSource,
-              createMockHttpClient(expectedRequest, 200, successJson),
+              createMockHttpClient(expectedRequestNoClientId, 200, successJson),
               null,
               null,
-              null,
-              IllegalArgumentException.class),
+              TEST_TOKEN_ENDPOINT,
+              null),
           new TestCase(
               "Null host",
               TEST_CLIENT_ID,


### PR DESCRIPTION
## Summary

Makes the OAuth client ID optional in `DatabricksOAuthTokenSource` so that users authenticated through a web browser OAuth flow can perform token exchange (account-wide token federation).

## Why

`DatabricksOAuthTokenSource.getToken()` required a non-null, non-empty `clientId` (`Objects.requireNonNull(clientId, "ClientID cannot be null")` plus an `isEmpty()` check) and unconditionally sent it as the `client_id` form parameter. This assumes a service-principal (Workload Identity Federation) flow.

Users authenticated through a web browser OAuth flow do not have a client ID in their IdP JWT, so they hit:

```
java.lang.NullPointerException: ClientID cannot be null
	at com.databricks.sdk.core.oauth.DatabricksOAuthTokenSource.getToken(DatabricksOAuthTokenSource.java:148)
```

This made the [OAuth federation token exchange](https://docs.databricks.com/aws/en/dev-tools/auth/oauth-federation-exchange) flow unusable for these users, who had to set a dummy service-principal client ID as a workaround.

The Go SDK already treats an empty client ID as account-wide token federation and simply omits the parameter. This PR brings the Java SDK in line.

Fixes #757.

## What changed

### Interface changes

None. The `DatabricksOAuthTokenSource.Builder(clientId, ...)` constructor signature is unchanged; `clientId` may now be `null` or empty.

### Behavioral changes

- When `clientId` is `null` or empty, `getToken()` no longer throws — it omits the `client_id` parameter from the token exchange request, performing account-wide token federation.
- A non-null/non-empty `clientId` continues to be sent exactly as before.

### Internal changes

- Removed the `requireNonNull`/`isEmpty` validation for `clientId` and made the `client_id` form parameter conditional on a non-empty value.
- Updated the `Builder` and `getToken()` Javadoc to document that the client ID is optional.

## How is this tested?

Updated `DatabricksOAuthTokenSourceTest`: the "Null client ID" and "Empty client ID" cases now assert a successful token exchange against a request that omits `client_id`, instead of expecting an exception. `mvn test -Dtest=DatabricksOAuthTokenSourceTest` passes (14 tests, 0 failures).
