### PR TITLE
Disable DbfsIT integration tests (DBFS disabled on test workspace)

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,4 +14,6 @@
 
 ### Internal Changes
 
+* Disable `DbfsIT` integration tests; legacy DBFS root is disabled on the test workspace (DBFS deprecation).
+
 ### API Changes

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/DbfsIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/DbfsIT.java
@@ -16,11 +16,13 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @EnvContext("workspace")
 @ExtendWith(EnvTest.class)
+@Disabled("Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 public class DbfsIT {
   // An integration test for DbfsExt which writes a file of 10 KiB to DBFS, reads the written file
   // back, and ensures that the contents of the file are the same as what was written out.


### PR DESCRIPTION
The deco test workspace has legacy DBFS root disabled (DBFS deprecation, now GA), so `DbfsIT` fails with `Public DBFS root is disabled`. This disables `DbfsIT` (kept, not deleted) via `@Disabled` so it no longer blocks CI. It's the only Java integration test that touches the DBFS root.