### PR TITLE
Fix selectSparkVersion() crash on non-SemVer runtime keys

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/ClustersExt.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/ClustersExt.java
@@ -63,9 +63,30 @@ public class ClustersExt extends ClustersAPI {
       if (!selector.latest) {
         throw new IllegalArgumentException("spark versions query returned multiple results");
       }
-      versions.sort((v1, v2) -> SemVer.parse(v2).compareTo(SemVer.parse(v1)));
+      versions.sort(ClustersExt::compareSparkVersionsDescending);
     }
     return versions.get(0);
+  }
+
+  /**
+   * Compares two Spark runtime keys so that the latest version sorts first. Mirrors the
+   * databricks-sdk-go behavior (golang.org/x/mod/semver.Compare), where keys that are not valid
+   * SemVer (for example "v18.x-scala2.13") are treated as lowest priority instead of throwing. This
+   * ensures a single unparseable runtime key returned by the API cannot break version selection.
+   */
+  private static int compareSparkVersionsDescending(String v1, String v2) {
+    SemVer s1 = SemVer.parseOrNull(v1);
+    SemVer s2 = SemVer.parseOrNull(v2);
+    if (s1 == null && s2 == null) {
+      return 0;
+    }
+    if (s1 == null) {
+      return 1; // v1 is unparseable: sort it after v2
+    }
+    if (s2 == null) {
+      return -1; // v2 is unparseable: keep v1 before v2
+    }
+    return s2.compareTo(s1); // descending order: latest first
   }
 
   public String selectNodeType(NodeTypeSelector selector) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/SemVer.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/mixin/SemVer.java
@@ -47,6 +47,19 @@ public class SemVer implements Comparable<SemVer> {
         m.group("build"));
   }
 
+  /**
+   * Parses the given version string, returning {@code null} instead of throwing when it is not a
+   * valid SemVer. Useful when sorting collections that may contain non-SemVer values (for example
+   * Spark runtime keys such as "v18.x-scala2.13").
+   */
+  public static SemVer parseOrNull(String v) {
+    try {
+      return parse(v);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
   @Override
   public int compareTo(SemVer other) {
     if (other == null) {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/ClustersExtTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/ClustersExtTest.java
@@ -143,4 +143,34 @@ class ClustersExtTest {
         clustersExt.selectSparkVersion(new SparkVersionSelector().withSparkVersion("3.4.1"));
     assertEquals("13.3.x-scala2.12", sparkVersion);
   }
+
+  private GetSparkVersionsResponse testGetSparkVersionsWithUnparseableKey() {
+    Collection<SparkVersion> versions = new ArrayList<>();
+    versions.add(
+        new SparkVersion()
+            .setName("14.3 LTS (includes Apache Spark 3.5.0, Scala 2.12)")
+            .setKey("14.3.x-scala2.12"));
+    versions.add(
+        new SparkVersion()
+            .setName("15.4 LTS (includes Apache Spark 3.5.0, Scala 2.12)")
+            .setKey("15.4.x-scala2.12"));
+    // Non-SemVer runtime key returned by the API. Sorting this with SemVer.parse() previously threw
+    // "Not a valid SemVer: v18.x-scala2.13" and broke selection for every caller.
+    versions.add(
+        new SparkVersion()
+            .setName("18.x (includes Apache Spark 4.0.0, Scala 2.13)")
+            .setKey("v18.x-scala2.13"));
+    return new GetSparkVersionsResponse().setVersions(versions);
+  }
+
+  @Test
+  void selectLatestSparkVersionIgnoresUnparseableKey() {
+    ClustersExt clustersExt = new ClustersExt(clustersMock);
+    Mockito.doReturn(testGetSparkVersionsWithUnparseableKey()).when(clustersMock).sparkVersions();
+
+    // Must not throw on the non-SemVer key, and must return the latest parseable runtime - matching
+    // databricks-sdk-go, which ranks unparseable keys lowest rather than failing.
+    String sparkVersion = clustersExt.selectSparkVersion(new SparkVersionSelector().withLatest());
+    assertEquals("15.4.x-scala2.12", sparkVersion);
+  }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/SemVerTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/mixin/SemVerTest.java
@@ -37,4 +37,21 @@ public class SemVerTest {
     int compareResult = parsedSemVer.compareTo(expectedSemVer);
     assertEquals(0, compareResult);
   }
+
+  @Test
+  void parseOrNullReturnsNullForInvalid() {
+    // Spark runtime key shape that crashed selectSparkVersion(): only two version segments and a
+    // leading "v", which is not a valid SemVer.
+    assertNull(SemVer.parseOrNull("v18.x-scala2.13"));
+    assertNull(SemVer.parseOrNull("not-a-version"));
+    assertNull(SemVer.parseOrNull(null));
+    assertNull(SemVer.parseOrNull(""));
+  }
+
+  @Test
+  void parseOrNullParsesValid() {
+    SemVer parsed = SemVer.parseOrNull("v1.2.3-alpha+build-20230510");
+    assertNotNull(parsed);
+    assertEquals(0, parsed.compareTo(new SemVer(1, 2, 3, "alpha", "build-20230510")));
+  }
 }


### PR DESCRIPTION
## Summary

`WorkspaceClient.clusters().selectSparkVersion(...)` throws `IllegalArgumentException: Not a valid SemVer: ...` when the Spark versions API returns a runtime key that is not a valid SemVer. This makes the sort that picks the latest runtime resilient to such keys, mirroring the behavior of the Go SDK.

## Why

`selectSparkVersion(latest)` gathers the matching runtime keys and sorts them to pick the newest:

```java
versions.sort((v1, v2) -> SemVer.parse(v2).compareTo(SemVer.parse(v1)));
```

`SemVer.parse` throws `IllegalArgumentException` on any string it cannot parse, and because that happens *inside* the sort comparator, a single unparseable key aborts the entire selection. The clusters API recently started returning the key `v18.x-scala2.13` — two version segments (`18.x`) plus a leading `v` — which the SemVer regex (it expects `major.minor.patch`) rejects. As a result, every caller of `selectSparkVersion(latest)` in such a workspace fails, and the `ClustersIT.latestRuntime` integration test started failing across all clouds.

The Go SDK does not have this problem: its comparator uses `golang.org/x/mod/semver.Compare`, which is total and never throws — invalid versions simply sort lowest and are effectively ignored when picking "latest". This PR brings the Java behavior in line, which also keeps the two SDKs consistent and makes selection robust to any future malformed key, not just this specific shape.

## What changed

### Interface changes

- **`SemVer.parseOrNull(String)`** — parses a version string, returning `null` instead of throwing when the input is not a valid SemVer.

### Behavioral changes

- `selectSparkVersion(latest)` no longer throws when the API returns a non-SemVer runtime key. Unparseable keys are ranked lowest and the latest parseable runtime is returned, matching the Go SDK. (Previously every such call threw `IllegalArgumentException`.)

### Internal changes

- The version sort in `ClustersExt.selectSparkVersion` now uses a null-safe comparator (`compareSparkVersionsDescending`) built on `SemVer.parseOrNull`.

## How is this tested?

Unit tests (run via `mvn`):

- `SemVerTest` — `parseOrNull` returns `null` for the `v18.x-scala2.13` shape, malformed input, `null`, and empty string, and still parses valid versions.
- `ClustersExtTest` — new regression test feeds a versions list containing `v18.x-scala2.13` and asserts `selectSparkVersion(latest)` does not throw and returns the latest parseable runtime (`15.4.x-scala2.12`). This test fails on the pre-fix code.

NO_CHANGELOG=true
