### PR TITLE
Add meta-harness user-agent dimension for omnigent

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+- Added a `meta-harness` user-agent dimension that reports the omnigent meta-harness (detected via the `OMNIGENT` environment variable) independently of agent detection.
+
 ### Breaking Changes
 
 ### Bug Fixes

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -133,6 +133,10 @@ public class UserAgent {
     if (!agent.isEmpty()) {
       segments.add(String.format("agent/%s", agent));
     }
+    String metaHarness = metaHarnessProvider();
+    if (!metaHarness.isEmpty()) {
+      segments.add(String.format("meta-harness/%s", metaHarness));
+    }
     // Concurrent iteration over ArrayList must be guarded with synchronized.
     synchronized (otherInfo) {
       segments.addAll(
@@ -173,6 +177,8 @@ public class UserAgent {
   protected static volatile String cicdProvider = null;
 
   protected static volatile String agentProvider = null;
+
+  protected static volatile String metaHarnessProvider = null;
 
   protected static Environment env = null;
 
@@ -360,6 +366,47 @@ public class UserAgent {
       }
     }
     return agentProvider;
+  }
+
+  // Describes a single meta-harness: the env var that identifies it and the
+  // product name reported in the user agent.
+  private static class KnownMetaHarness {
+    private final String envVar;
+    private final String product;
+
+    KnownMetaHarness(String envVar, String product) {
+      this.envVar = envVar;
+      this.product = product;
+    }
+  }
+
+  // Canonical list of known meta-harnesses, detected by presence.
+  // Keep in sync with databricks-sdk-go and databricks-sdk-py.
+  // OMNIGENT is set by the omnigent meta-harness (https://github.com/omnigent-ai/omnigent).
+  private static List<KnownMetaHarness> listKnownMetaHarnesses() {
+    return Arrays.asList(new KnownMetaHarness("OMNIGENT", "omnigent"));
+  }
+
+  // Looks up the active meta-harness by env var presence, independent of the agent.
+  private static String lookupMetaHarnessProvider(Environment env) {
+    for (KnownMetaHarness h : listKnownMetaHarnesses()) {
+      if (env.get(h.envVar) != null) {
+        return h.product;
+      }
+    }
+    return "";
+  }
+
+  // Thread-safe lazy initialization of meta-harness detection
+  private static String metaHarnessProvider() {
+    if (metaHarnessProvider == null) {
+      synchronized (UserAgent.class) {
+        if (metaHarnessProvider == null) {
+          metaHarnessProvider = lookupMetaHarnessProvider(env());
+        }
+      }
+    }
+    return metaHarnessProvider;
   }
 
   private static Environment env() {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UserAgentTest.java
@@ -18,6 +18,7 @@ public class UserAgentTest {
   private void setupAgentEnv(Map<String, String> envMap) {
     UserAgent.agentProvider = null;
     UserAgent.cicdProvider = null;
+    UserAgent.metaHarnessProvider = null;
     UserAgent.env = new Environment(envMap, new ArrayList<>(), System.getProperty("os.name"));
   }
 
@@ -25,6 +26,7 @@ public class UserAgentTest {
     UserAgent.env = null;
     UserAgent.agentProvider = null;
     UserAgent.cicdProvider = null;
+    UserAgent.metaHarnessProvider = null;
   }
 
   @Test
@@ -616,5 +618,69 @@ public class UserAgentTest {
             System.getProperty("os.name"));
     Assertions.assertTrue(UserAgent.asString().contains("agent/cursor"));
     Assertions.assertFalse(UserAgent.asString().contains("agent/claude-code"));
+  }
+
+  @Test
+  public void testMetaHarnessProviderOmnigent() {
+    setupAgentEnv(
+        new HashMap<String, String>() {
+          {
+            put("OMNIGENT", "1");
+          }
+        });
+    Assertions.assertTrue(UserAgent.asString().contains("meta-harness/omnigent"));
+  }
+
+  @Test
+  public void testMetaHarnessProviderNoHarness() {
+    setupAgentEnv(new HashMap<>());
+    Assertions.assertFalse(UserAgent.asString().contains("meta-harness/"));
+  }
+
+  @Test
+  public void testMetaHarnessProviderEmptyValueStillSet() {
+    // Empty string still counts as "set" for presence-only detection,
+    // matching the agent dimension and databricks-sdk-go semantics.
+    setupAgentEnv(
+        new HashMap<String, String>() {
+          {
+            put("OMNIGENT", "");
+          }
+        });
+    Assertions.assertTrue(UserAgent.asString().contains("meta-harness/omnigent"));
+  }
+
+  @Test
+  public void testMetaHarnessProviderIndependentOfAgent() {
+    // Under omnigent both OMNIGENT and the agent marker are set: report both
+    // dimensions, and the meta-harness must not trip the agent "multiple" logic.
+    setupAgentEnv(
+        new HashMap<String, String>() {
+          {
+            put("OMNIGENT", "1");
+            put("CLAUDECODE", "1");
+          }
+        });
+    String userAgent = UserAgent.asString();
+    Assertions.assertTrue(userAgent.contains("agent/claude-code"));
+    Assertions.assertTrue(userAgent.contains("meta-harness/omnigent"));
+    Assertions.assertFalse(userAgent.contains("agent/multiple"));
+  }
+
+  @Test
+  public void testMetaHarnessProviderCached() {
+    // Set up with omnigent.
+    setupAgentEnv(
+        new HashMap<String, String>() {
+          {
+            put("OMNIGENT", "1");
+          }
+        });
+    Assertions.assertTrue(UserAgent.asString().contains("meta-harness/omnigent"));
+
+    // Change env after caching. Cached result should persist.
+    UserAgent.env =
+        new Environment(new HashMap<>(), new ArrayList<>(), System.getProperty("os.name"));
+    Assertions.assertTrue(UserAgent.asString().contains("meta-harness/omnigent"));
   }
 }


### PR DESCRIPTION
## Why

[Omnigent](https://github.com/omnigent-ai/omnigent) is a meta-harness that orchestrates AI coding agents (Claude Code, Codex, Cursor, and others). It is not itself an agent, so it does not belong in the existing `agent/<name>` user-agent dimension. We want telemetry that surfaces both the meta-harness and the underlying agent at the same time. ("meta-harness" matches omnigent's own self-description; "harness" alone is how the field labels the underlying agents like Claude Code.)

## Changes

Before: the SDK reported only `agent/<name>` (e.g. `agent/claude-code`) for the detected AI coding agent.

Now: the SDK also reports an independent `meta-harness/<name>` dimension. When the `OMNIGENT` environment variable is present (omnigent stamps `OMNIGENT=1` into every agent process, see omnigent-ai/omnigent#656), the user agent gains a `meta-harness/omnigent` segment. Because it is a separate dimension from agent detection, running Claude Code under omnigent yields both `agent/claude-code` and `meta-harness/omnigent`, and omnigent never trips the agent "multiple" logic.

Implementation mirrors the existing agent dimension, all in `core/UserAgent.java`:

- New `metaHarnessProvider` cache field, a `KnownMetaHarness` model + `listKnownMetaHarnesses()` table, a presence-based `lookupMetaHarnessProvider()`, and a cached `metaHarnessProvider()` (double-checked locking, mirroring `agentProvider()`).
- `asString()` appends the `meta-harness/<name>` segment right after the agent segment.

## Test plan

- [x] `mvn -pl databricks-sdk-java test -Dtest=UserAgentTest` (5 new tests)
- [x] Detection tests: present / absent / empty-value-still-counts / cached
- [x] Independence test: with both `OMNIGENT` and `CLAUDECODE` set, the UA contains both `agent/claude-code` and `meta-harness/omnigent`, and does not contain `agent/multiple`
- [x] `spotless:apply` clean (no reformatting)
