### PR TITLE
fix: avoid NullPointerException in UserAgent when PATH is missing

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- Avoid NullPointerException in UserAgent when PATH is missing
+
 ### Security Vulnerabilities
 
 ### Documentation

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/UserAgent.java
@@ -411,10 +411,12 @@ public class UserAgent {
 
   private static Environment env() {
     if (env == null) {
+      String path = System.getenv("PATH");
+      String[] pathParts = path != null ? path.split(File.pathSeparator) : new String[0];
       env =
           new Environment(
               System.getenv(),
-              System.getenv("PATH").split(File.pathSeparator),
+              pathParts,
               System.getProperty("os.name"));
     }
     return env;


### PR DESCRIPTION
Closes #550. Adds a null check to the PATH environment variable in UserAgent.env() before splitting it by File.pathSeparator.