### PR TITLE
Add JDK 17 fallback to mvn-spotless-apply.sh

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,4 +14,7 @@
 
 ### Internal Changes
 
+- Added a JDK 17 fallback to `scripts/mvn-spotless-apply.sh` so `spotless:apply` still
+  formats when the default JDK is older than 17 (mirroring the `make fmt` behaviour).
+
 ### API Changes

--- a/scripts/mvn-spotless-apply.sh
+++ b/scripts/mvn-spotless-apply.sh
@@ -4,25 +4,67 @@
 # google-java-format on JDK 16+. Without these, GJF fails on JDK 17+ with either
 # IllegalAccessError or NoSuchMethodError when it reaches into com.sun.tools.javac.*.
 # On JDK <= 15 the flags are unrecognized and would break Maven startup, so we only
-# set them when detected JDK major version is >= 16.
+# set them when the detected JDK major version is >= 16.
+#
+# If that JDK can't run google-java-format (most often because it's older than JDK 17,
+# which the pinned GJF 1.27.0 requires), we retry under an explicit JDK 17 install —
+# mirroring the `make fmt` -> `make fmt-jdk17` fallback. Override the fallback location
+# with JDK17_HOME, or just point JAVA_HOME at a JDK 17+ and re-run.
 
 set -euo pipefail
 
-JDK_VERSION_OUTPUT=$(java -version 2>&1 | head -1)
-# Matches `"1.8.0_xxx"` (legacy) and `"17.0.1"` / `"25"` (modern) forms.
-JDK_MAJOR=$(echo "$JDK_VERSION_OUTPUT" | sed -E 's/.*version "([0-9]+)(\.[0-9]+)?.*/\1/')
-if [ "$JDK_MAJOR" = "1" ]; then
-  JDK_MAJOR=$(echo "$JDK_VERSION_OUTPUT" | sed -E 's/.*version "1\.([0-9]+).*/\1/')
-fi
+# Location used by the JDK 17 fallback. Override for non-Debian layouts, e.g.
+# `JDK17_HOME=$(/usr/libexec/java_home -v 17) bash scripts/mvn-spotless-apply.sh`.
+JDK17_HOME="${JDK17_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}"
 
-if [ "${JDK_MAJOR:-0}" -ge 16 ]; then
-  export MAVEN_OPTS="${MAVEN_OPTS:-} \
+# The --add-exports flags google-java-format needs to reach into com.sun.tools.javac.*
+# on JDK 16+.
+GJF_ADD_EXPORTS="\
 --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
 --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
 --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
 --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
 --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
 --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+
+# Detect the major version of the JDK Maven will actually use: $JAVA_HOME/bin/java when
+# JAVA_HOME is set, otherwise `java` from PATH. mvn resolves its JVM the same way, so the
+# add-exports gating below matches what the first attempt really runs (and re-running with
+# JAVA_HOME pointed at a JDK 17+ makes that attempt succeed without hitting the fallback).
+JAVA_BIN="java"
+if [ -n "${JAVA_HOME:-}" ] && [ -x "${JAVA_HOME}/bin/java" ]; then
+  JAVA_BIN="${JAVA_HOME}/bin/java"
 fi
 
-exec mvn spotless:apply
+JDK_VERSION_OUTPUT=$("$JAVA_BIN" -version 2>&1 | head -1)
+# Matches `"1.8.0_xxx"` (legacy) and `"17.0.1"` / `"25"` (modern) forms.
+JDK_MAJOR=$(echo "$JDK_VERSION_OUTPUT" | sed -E 's/.*version "([0-9]+)(\.[0-9]+)?.*/\1/')
+if [ "$JDK_MAJOR" = "1" ]; then
+  JDK_MAJOR=$(echo "$JDK_VERSION_OUTPUT" | sed -E 's/.*version "1\.([0-9]+).*/\1/')
+fi
+
+DEFAULT_OPTS="${MAVEN_OPTS:-}"
+if [ "${JDK_MAJOR:-0}" -ge 16 ]; then
+  DEFAULT_OPTS="$DEFAULT_OPTS $GJF_ADD_EXPORTS"
+fi
+
+# First attempt: the JDK selected above (JAVA_HOME or PATH).
+if MAVEN_OPTS="$DEFAULT_OPTS" mvn spotless:apply; then
+  exit 0
+fi
+
+echo ""
+echo "==> default JDK could not run google-java-format (likely < JDK 17). Retrying with JDK 17..."
+echo ""
+
+if [ ! -x "$JDK17_HOME/bin/java" ]; then
+  echo "error: JDK 17 not found at $JDK17_HOME" >&2
+  echo "       install it, set JDK17_HOME to a JDK 17 install, or point JAVA_HOME" >&2
+  echo "       at a JDK 17+ and re-run." >&2
+  exit 1
+fi
+
+# JDK 17 is always >= 16, so the add-exports flags are always required here.
+exec env JAVA_HOME="$JDK17_HOME" \
+  MAVEN_OPTS="${MAVEN_OPTS:-} $GJF_ADD_EXPORTS" \
+  mvn spotless:apply


### PR DESCRIPTION
## Summary

Adds a JDK 17 fallback to `scripts/mvn-spotless-apply.sh` so `mvn spotless:apply`
still formats successfully when the default JDK is older than 17, bringing the
script to parity with the existing `make fmt` → `make fmt-jdk17` behaviour.

## Why

`scripts/mvn-spotless-apply.sh` is the wrapper used to run `spotless:apply` (it is
invoked by codegen post-generation via `.codegen.json`, and by contributors who
format locally). It exported the `--add-exports` flags google-java-format needs on
JDK 16+, then `exec`'d `mvn spotless:apply` directly — with no recovery path.

The pinned google-java-format `1.27.0` requires JRE 17+. So on a machine whose
default JDK is older than 17 (e.g. JDK 11) the command fails outright with a
`PluginContainerException`, **even when a JDK 17 is installed on the box**.

`make fmt` already guards against this — it retries under JDK 17 (`make fmt-jdk17`)
when the first `spotless:apply` fails. The script had no such safety net. This PR
adds the equivalent fallback so both entry points behave the same.

## What changed

### Interface changes

None to any public API — this is an internal build script. It is still invoked the
same way (`bash scripts/mvn-spotless-apply.sh`); the only addition is an optional
`JDK17_HOME` environment override.

### Behavioral changes

- If the first `spotless:apply` attempt fails, the script now prints a clear message
  and **retries once under an explicit JDK 17 install** instead of exiting.
- Version detection now reads the JVM Maven will actually use — `$JAVA_HOME/bin/java`
  when `JAVA_HOME` is set, otherwise `java` on `PATH`. This makes the `--add-exports`
  gating match the running JDK, and means re-running with `JAVA_HOME` pointed at a
  JDK 17+ succeeds on the first attempt (no fallback needed).
- The fallback JDK 17 location is overridable via `JDK17_HOME` (defaulting to the
  same Debian/amd64 path `make fmt` uses), and the script errors clearly — pointing
  at `JDK17_HOME` / `JAVA_HOME` — when no JDK 17 is found.

### Internal changes

- Added a `NEXT_CHANGELOG.md` entry under Internal Changes.

## How is this tested?

Verified manually on a machine whose default JDK is 11 with JDK 17 installed:

- **Default run** (`bash scripts/mvn-spotless-apply.sh`): the first attempt under
  JDK 11 fails as expected (`BUILD FAILURE`), the fallback message is printed, and the
  JDK 17 retry runs `spotless:apply` to `BUILD SUCCESS` (exit 0).
- **`JAVA_HOME=<jdk17> bash scripts/mvn-spotless-apply.sh`**: succeeds on the first
  attempt with no fallback, confirming the version detection honours `JAVA_HOME`.
- `bash -n` syntax check passes.
