### PR TITLE
Add WIF group assumption integration coverage

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New Features and Improvements
 
+* Added group assumption through `group_id` / `DATABRICKS_GROUP_ID` for external-browser
+  OAuth, OAuth M2M, and Databricks workload identity federation authentication.
+
 ### Breaking Changes
 
 ### Bug Fixes

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureCliCredentialsProvider.java
@@ -81,6 +81,16 @@ public class AzureCliCredentialsProvider implements CredentialsProvider {
       return null;
     }
 
+    if (GroupAssumption.isRequested(config)) {
+      // Return null during automatic discovery so the chain can continue. If the user explicitly
+      // requested this provider, throw an actionable error explaining why it cannot be used.
+      if (authType().equals(config.getAuthType())) {
+        throw GroupAssumption.unsupportedAuth(authType());
+      }
+
+      return null;
+    }
+
     try {
       AzureUtils.ensureHostPresent(config, mapper, this::tokenSourceFor);
       String resource = config.getEffectiveAzureLoginAppId();

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureMsiCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/AzureMsiCredentialsProvider.java
@@ -42,6 +42,16 @@ public class AzureMsiCredentialsProvider implements CredentialsProvider {
       return null;
     }
 
+    if (GroupAssumption.isRequested(config)) {
+      // Return null during automatic discovery so the chain can continue. If the user explicitly
+      // requested this provider, throw an actionable error explaining why it cannot be used.
+      if (authType().equals(config.getAuthType())) {
+        throw GroupAssumption.unsupportedAuth(authType());
+      }
+
+      return null;
+    }
+
     LOG.debug("Generating AAD token via Azure MSI");
 
     AzureUtils.ensureHostPresent(config, mapper, this::tokenSourceFor);

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/BasicCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/BasicCredentialsProvider.java
@@ -22,6 +22,17 @@ public class BasicCredentialsProvider implements CredentialsProvider {
     if (username == null || password == null || host == null) {
       return null;
     }
+
+    if (GroupAssumption.isRequested(config)) {
+      // Return null during automatic discovery so the chain can continue. If the user explicitly
+      // requested this provider, throw an actionable error explaining why it cannot be used.
+      if (authType().equals(config.getAuthType())) {
+        throw GroupAssumption.unsupportedAuth(authType());
+      }
+
+      return null;
+    }
+
     byte[] bytes = String.format("%s:%s", config.getUsername(), config.getPassword()).getBytes();
     String base64 = Base64.getEncoder().encodeToString(bytes);
     Map<String, String> headers = new HashMap<>();

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksCliCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksCliCredentialsProvider.java
@@ -84,6 +84,16 @@ public class DatabricksCliCredentialsProvider implements CredentialsProvider {
       return null;
     }
 
+    if (GroupAssumption.isRequested(config)) {
+      // Return null during automatic discovery so the chain can continue. If the user explicitly
+      // requested this provider, throw an actionable error explaining why it cannot be used.
+      if (authType().equals(config.getAuthType())) {
+        throw GroupAssumption.unsupportedAuth(authType());
+      }
+
+      return null;
+    }
+
     try {
       CliTokenSource tokenSource = getDatabricksCliTokenSource(config);
       if (tokenSource == null) {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DatabricksConfig.java
@@ -41,6 +41,13 @@ public class DatabricksConfig {
   @ConfigAttribute(env = "DATABRICKS_WORKSPACE_ID")
   private String workspaceId;
 
+  /**
+   * ID of the Databricks group to assume through role-based access control (RBAC). A client uses
+   * this group for its full lifetime.
+   */
+  @ConfigAttribute(env = "DATABRICKS_GROUP_ID")
+  private String groupId;
+
   @ConfigAttribute(env = "DATABRICKS_TOKEN", auth = "pat", sensitive = true)
   private String token;
 
@@ -336,6 +343,15 @@ public class DatabricksConfig {
 
   public DatabricksConfig setWorkspaceId(String workspaceId) {
     this.workspaceId = workspaceId;
+    return this;
+  }
+
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public DatabricksConfig setGroupId(String groupId) {
+    this.groupId = groupId;
     return this;
   }
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/DefaultCredentialsProvider.java
@@ -151,6 +151,7 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
                   namedIdTokenSource.idTokenSource,
                   config.getHttpClient())
               .audience(config.getTokenAudience())
+              .groupId(config.getGroupId())
               .accountId(
                   config.getClientType() == ClientType.ACCOUNT ? config.getAccountId() : null)
               .scopes(config.getScopes())

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GoogleCredentialsCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GoogleCredentialsCredentialsProvider.java
@@ -34,6 +34,16 @@ public class GoogleCredentialsCredentialsProvider implements CredentialsProvider
       return null;
     }
 
+    if (GroupAssumption.isRequested(config)) {
+      // Return null during automatic discovery so the chain can continue. If the user explicitly
+      // requested this provider, throw an actionable error explaining why it cannot be used.
+      if (authType().equals(config.getAuthType())) {
+        throw GroupAssumption.unsupportedAuth(authType());
+      }
+
+      return null;
+    }
+
     ServiceAccountCredentials serviceAccountCredentials;
 
     try {

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GoogleIdCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GoogleIdCredentialsProvider.java
@@ -31,6 +31,16 @@ public class GoogleIdCredentialsProvider implements CredentialsProvider {
       return null;
     }
 
+    if (GroupAssumption.isRequested(config)) {
+      // Return null during automatic discovery so the chain can continue. If the user explicitly
+      // requested this provider, throw an actionable error explaining why it cannot be used.
+      if (authType().equals(config.getAuthType())) {
+        throw GroupAssumption.unsupportedAuth(authType());
+      }
+
+      return null;
+    }
+
     GoogleCredentials googleCredentials;
     try {
       googleCredentials = GoogleCredentials.getApplicationDefault();

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GroupAssumption.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/GroupAssumption.java
@@ -1,0 +1,22 @@
+package com.databricks.sdk.core;
+
+import com.databricks.sdk.support.InternalApi;
+
+/** Shared utilities for group assumption. */
+@InternalApi
+public final class GroupAssumption {
+  private GroupAssumption() {}
+
+  public static boolean isRequested(DatabricksConfig config) {
+    return config.getGroupId() != null && !config.getGroupId().isEmpty();
+  }
+
+  /** Creates an actionable error for an explicitly configured unsupported authentication type. */
+  public static DatabricksException unsupportedAuth(String authType) {
+    String message =
+        "auth type \"%s\" does not support group assumption. "
+            + "Use Databricks OAuth or workload identity federation authentication";
+
+    return new DatabricksException(String.format(message, authType));
+  }
+}

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/NotebookNativeCredentialsProvider.java
@@ -27,6 +27,16 @@ public class NotebookNativeCredentialsProvider implements CredentialsProvider {
 
   @Override
   public HeaderFactory configure(DatabricksConfig config) {
+    if (GroupAssumption.isRequested(config)) {
+      // Return null during automatic discovery so the chain can continue. If the user explicitly
+      // requested this provider, throw an actionable error explaining why it cannot be used.
+      if (authType().equals(config.getAuthType())) {
+        throw GroupAssumption.unsupportedAuth(authType());
+      }
+
+      return null;
+    }
+
     if (System.getenv("DATABRICKS_RUNTIME_VERSION") == null) {
       LOG.debug("DBR not detected, skipping runtime auth");
       return null;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/PatCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/PatCredentialsProvider.java
@@ -20,6 +20,17 @@ public class PatCredentialsProvider implements CredentialsProvider {
     if (token == null || host == null) {
       return null;
     }
+
+    if (GroupAssumption.isRequested(config)) {
+      // Return null during automatic discovery so the chain can continue. If the user explicitly
+      // requested this provider, throw an actionable error explaining why it cannot be used.
+      if (authType().equals(config.getAuthType())) {
+        throw GroupAssumption.unsupportedAuth(authType());
+      }
+
+      return null;
+    }
+
     Map<String, String> headers = new HashMap<>();
     headers.put("Authorization", String.format("Bearer %s", token));
     return () -> headers;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/AzureGithubOidcCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/AzureGithubOidcCredentialsProvider.java
@@ -33,6 +33,16 @@ public class AzureGithubOidcCredentialsProvider implements CredentialsProvider {
       return null;
     }
 
+    if (GroupAssumption.isRequested(config)) {
+      // Return null during automatic discovery so the chain can continue. If the user explicitly
+      // requested this provider, throw an actionable error explaining why it cannot be used.
+      if (authType().equals(config.getAuthType())) {
+        throw GroupAssumption.unsupportedAuth(authType());
+      }
+
+      return null;
+    }
+
     Optional<String> idToken = requestIdToken(config);
     if (!idToken.isPresent()) {
       return null;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/AzureServicePrincipalCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/AzureServicePrincipalCredentialsProvider.java
@@ -33,6 +33,16 @@ public class AzureServicePrincipalCredentialsProvider implements CredentialsProv
       return null;
     }
 
+    if (GroupAssumption.isRequested(config)) {
+      // Return null during automatic discovery so the chain can continue. If the user explicitly
+      // requested this provider, throw an actionable error explaining why it cannot be used.
+      if (authType().equals(config.getAuthType())) {
+        throw GroupAssumption.unsupportedAuth(authType());
+      }
+
+      return null;
+    }
+
     try {
       this.tenantId =
           config.getAzureTenantId() != null

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ClientCredentials.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ClientCredentials.java
@@ -17,6 +17,7 @@ public class ClientCredentials implements TokenSource {
   public static class Builder {
     private String clientId;
     private String clientSecret;
+    private String groupId;
     private String tokenUrl;
     private HttpClient hc = new CommonsHttpClient.Builder().withTimeoutSeconds(30).build();
 
@@ -34,6 +35,11 @@ public class ClientCredentials implements TokenSource {
 
     public Builder withClientSecret(String clientSecret) {
       this.clientSecret = clientSecret;
+      return this;
+    }
+
+    public Builder withGroupId(String groupId) {
+      this.groupId = groupId;
       return this;
     }
 
@@ -67,13 +73,14 @@ public class ClientCredentials implements TokenSource {
       Objects.requireNonNull(this.clientId, "clientId must be specified");
       Objects.requireNonNull(this.tokenUrl, "tokenUrl must be specified");
       return new ClientCredentials(
-          hc, clientId, clientSecret, tokenUrl, endpointParamsSupplier, scopes, position);
+          hc, clientId, clientSecret, groupId, tokenUrl, endpointParamsSupplier, scopes, position);
     }
   }
 
   private HttpClient hc;
   private String clientId;
   private String clientSecret;
+  private String groupId;
   private String tokenUrl;
   private List<String> scopes;
   private AuthParameterPosition position;
@@ -83,6 +90,7 @@ public class ClientCredentials implements TokenSource {
       HttpClient hc,
       String clientId,
       String clientSecret,
+      String groupId,
       String tokenUrl,
       Supplier<Map<String, String>> endpointParamsSupplier,
       List<String> scopes,
@@ -90,6 +98,7 @@ public class ClientCredentials implements TokenSource {
     this.hc = hc;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
+    this.groupId = groupId;
     this.tokenUrl = tokenUrl;
     this.endpointParamsSupplier = endpointParamsSupplier;
     this.scopes = scopes;
@@ -102,6 +111,9 @@ public class ClientCredentials implements TokenSource {
     params.put("grant_type", "client_credentials");
     if (scopes != null) {
       params.put("scope", String.join(" ", scopes));
+    }
+    if (groupId != null && !groupId.isEmpty()) {
+      params.put("assume_group", groupId);
     }
     if (endpointParamsSupplier != null) {
       params.putAll(endpointParamsSupplier.get());

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSource.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSource.java
@@ -43,6 +43,9 @@ public class DatabricksOAuthTokenSource implements TokenSource {
   /** Scopes to request during token exchange. */
   private final List<String> scopes;
 
+  /** Group the exchanged token assumes. */
+  private final String groupId;
+
   private static final String GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
   private static final String SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt";
   private static final String GRANT_TYPE_PARAM = "grant_type";
@@ -50,6 +53,7 @@ public class DatabricksOAuthTokenSource implements TokenSource {
   private static final String SUBJECT_TOKEN_TYPE_PARAM = "subject_token_type";
   private static final String SCOPE_PARAM = "scope";
   private static final String CLIENT_ID_PARAM = "client_id";
+  private static final String ASSUME_GROUP_PARAM = "assume_group";
 
   private DatabricksOAuthTokenSource(Builder builder) {
     this.clientId = builder.clientId;
@@ -60,6 +64,7 @@ public class DatabricksOAuthTokenSource implements TokenSource {
     this.idTokenSource = builder.idTokenSource;
     this.httpClient = builder.httpClient;
     this.scopes = builder.scopes == null ? Arrays.asList() : builder.scopes;
+    this.groupId = builder.groupId;
   }
 
   /**
@@ -75,6 +80,7 @@ public class DatabricksOAuthTokenSource implements TokenSource {
     private String accountId;
     private String audience;
     private List<String> scopes;
+    private String groupId;
 
     /**
      * Creates a new Builder with required parameters.
@@ -133,6 +139,12 @@ public class DatabricksOAuthTokenSource implements TokenSource {
       return this;
     }
 
+    /** Sets the Databricks group the exchanged token should assume. */
+    public Builder groupId(String groupId) {
+      this.groupId = groupId;
+      return this;
+    }
+
     /**
      * Builds a new DatabricksOAuthTokenSource instance.
      *
@@ -177,6 +189,9 @@ public class DatabricksOAuthTokenSource implements TokenSource {
     // perform account-wide token federation without one.
     if (!Strings.isNullOrEmpty(clientId)) {
       params.put(CLIENT_ID_PARAM, clientId);
+    }
+    if (!Strings.isNullOrEmpty(groupId)) {
+      params.put(ASSUME_GROUP_PARAM, groupId);
     }
 
     OAuthResponse response;

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProvider.java
@@ -70,7 +70,8 @@ public class ExternalBrowserCredentialsProvider implements CredentialsProvider {
       if (tokenCache == null) {
         // Create a default FileTokenCache based on config
         Path cachePath =
-            TokenCacheUtils.getCacheFilePath(config.getHost(), clientId, config.getScopes());
+            TokenCacheUtils.getCacheFilePath(
+                config.getHost(), clientId, config.getScopes(), config.getGroupId());
         tokenCache = new FileTokenCache(cachePath);
       }
 
@@ -147,6 +148,7 @@ public class ExternalBrowserCredentialsProvider implements CredentialsProvider {
             .withClientSecret(clientSecret)
             .withHost(config.getHost())
             .withAccountId(config.getAccountId())
+            .withGroupId(config.getGroupId())
             .withRedirectUrl(config.getEffectiveOAuthRedirectUrl())
             .withBrowserTimeout(config.getOAuthBrowserAuthTimeout())
             .withScopes(getScopes(config, oidcEndpoints))

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthClient.java
@@ -44,6 +44,7 @@ public class OAuthClient {
     private String clientSecret;
     private HttpClient hc;
     private String accountId;
+    private String groupId;
     private Optional<Duration> browserTimeout = Optional.empty();
     private OpenIDConnectEndpoints openIDConnectEndpoints;
 
@@ -93,6 +94,11 @@ public class OAuthClient {
       return this;
     }
 
+    public Builder withGroupId(String groupId) {
+      this.groupId = groupId;
+      return this;
+    }
+
     public Builder withBrowserTimeout(Duration browserTimeout) {
       this.browserTimeout = Optional.of(browserTimeout);
       return this;
@@ -112,6 +118,7 @@ public class OAuthClient {
   private final boolean isAzure;
   private final OpenIDConnectEndpoints openIDConnectEndpoints;
   private final Optional<Duration> browserTimeout;
+  private final String groupId;
 
   private OAuthClient(Builder b) throws IOException {
     this.clientId = Objects.requireNonNull(b.clientId);
@@ -121,7 +128,11 @@ public class OAuthClient {
     this.hc = b.hc;
 
     DatabricksConfig config =
-        new DatabricksConfig().setHost(b.host).setAccountId(b.accountId).resolve();
+        new DatabricksConfig()
+            .setHost(b.host)
+            .setAccountId(b.accountId)
+            .setHttpClient(b.hc)
+            .resolve();
     openIDConnectEndpoints = b.openIDConnectEndpoints;
     if (openIDConnectEndpoints == null) {
       throw new DatabricksException(b.host + " does not support OAuth");
@@ -133,6 +144,7 @@ public class OAuthClient {
     this.authUrl = openIDConnectEndpoints.getAuthorizationEndpoint();
     this.browserTimeout = b.browserTimeout;
     this.scopes = b.scopes;
+    this.groupId = b.groupId;
   }
 
   public String getHost() {
@@ -235,6 +247,9 @@ public class OAuthClient {
     params.put("state", state);
     params.put("code_challenge", challenge);
     params.put("code_challenge_method", "S256");
+    if (groupId != null && !groupId.isEmpty()) {
+      params.put("assume_group", groupId);
+    }
 
     String url = urlEncode(authUrl, params);
 

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthM2MServicePrincipalCredentialsProvider.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/OAuthM2MServicePrincipalCredentialsProvider.java
@@ -33,6 +33,7 @@ public class OAuthM2MServicePrincipalCredentialsProvider implements CredentialsP
               .withHttpClient(config.getHttpClient())
               .withClientId(config.getClientId())
               .withClientSecret(config.getClientSecret())
+              .withGroupId(config.getGroupId())
               .withTokenUrl(jsonResponse.getTokenEndpoint())
               .withScopes(config.getScopes())
               .withAuthParameterPosition(AuthParameterPosition.HEADER)

--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/TokenCacheUtils.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/oauth/TokenCacheUtils.java
@@ -24,6 +24,15 @@ public class TokenCacheUtils {
    * @return The path to the token cache file
    */
   public static Path getCacheFilePath(String host, String clientId, List<String> scopes) {
+    return getCacheFilePath(host, clientId, scopes, null);
+  }
+
+  /**
+   * Returns the cache path for an OAuth configuration and its fixed assumed group. The empty-group
+   * path intentionally remains byte-for-byte compatible with older SDK versions.
+   */
+  public static Path getCacheFilePath(
+      String host, String clientId, List<String> scopes, String groupId) {
     try {
       // Create SHA-256 hash of host, client_id, and scopes
       MessageDigest hash = MessageDigest.getInstance("SHA-256");
@@ -31,9 +40,24 @@ public class TokenCacheUtils {
         hash.update(chunk.getBytes(StandardCharsets.UTF_8));
       }
 
+      // Finalize the legacy cache key before including the group. Keeping this digest unchanged is
+      // important because users without a group may already have tokens stored at the path created
+      // by older SDK versions.
+      byte[] cacheKeyDigest = hash.digest();
+
+      if (groupId != null && !groupId.isEmpty()) {
+        // A token issued for one assumed group must never be reused for another group or for a
+        // non-group session. Hash the fixed-length legacy digest together with the group ID to
+        // create a separate cache namespace.
+        hash.reset();
+        hash.update(cacheKeyDigest);
+        hash.update(groupId.getBytes(StandardCharsets.UTF_8));
+        cacheKeyDigest = hash.digest();
+      }
+
       // Convert hash bytes to hexadecimal string
       StringBuilder hexString = new StringBuilder();
-      for (byte b : hash.digest()) {
+      for (byte b : cacheKeyDigest) {
         String hex = Integer.toHexString(0xff & b);
         if (hex.length() == 1) {
           hexString.append('0');

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/AuthProfilesTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/AuthProfilesTest.java
@@ -1,13 +1,15 @@
 package com.databricks.sdk.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.databricks.sdk.core.http.HttpClient;
 import com.databricks.sdk.core.http.Request;
-import com.databricks.sdk.core.http.Response;
+import com.databricks.sdk.core.oauth.Consent;
+import com.databricks.sdk.core.oauth.OAuthClient;
+import com.databricks.sdk.core.oauth.OpenIDConnectEndpoints;
 import com.databricks.sdk.core.utils.Environment;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -317,6 +319,27 @@ public class AuthProfilesTest {
     assertEquals("oauth-m2m", config.getAuthType());
   }
 
+  // Verifies that M2M sends assume_group in the token form for workspace, account, and unified
+  // hosts without changing the discovered token endpoint.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("allProfiles")
+  void oauthM2MForwardsGroupOnExistingEndpoint(HostProfile p) {
+    DatabricksConfig config =
+        profileConfig(p)
+            .setClientId("test-client")
+            .setClientSecret("test-secret")
+            .setGroupId("group-123")
+            .setAuthType("oauth-m2m");
+    MappingHttpClient client = withOidc(httpClientFor(p), p);
+    config.setHttpClient(client);
+
+    assertEquals("Bearer test-token", resolveAndAuthenticate(config, emptyEnvironment()));
+
+    Request tokenRequest = client.singleRequest("POST", p.tokenPath());
+    assertTrue(tokenRequest.getBodyString().contains("assume_group=group-123"));
+    assertFalse(tokenRequest.getUrl().contains("?o="));
+  }
+
   // ---- GitHub OIDC -----------------------------------------------------------
 
   @ParameterizedTest(name = "{0}")
@@ -350,6 +373,74 @@ public class AuthProfilesTest {
         resolveAndAuthenticate(
             config, environmentWith("DATABRICKS_OIDC_TOKEN", "test-oidc-token")));
     assertEquals("env-oidc", config.getAuthType());
+  }
+
+  // Verifies that workload identity federation sends assume_group in the token-exchange form for
+  // every host type without adding the historical o=<workspace-id> routing query parameter.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("allProfiles")
+  void envOIDCForwardsGroupOnExistingEndpoint(HostProfile p) {
+    DatabricksConfig config =
+        profileConfig(p).setClientId("test-client").setGroupId("group-123").setAuthType("env-oidc");
+    MappingHttpClient client = withOidc(httpClientFor(p), p);
+    config.setHttpClient(client);
+
+    assertEquals(
+        "Bearer test-token",
+        resolveAndAuthenticate(
+            config, environmentWith("DATABRICKS_OIDC_TOKEN", "test-oidc-token")));
+
+    Request tokenRequest = client.singleRequest("POST", p.tokenPath());
+    assertTrue(tokenRequest.getBodyString().contains("assume_group=group-123"));
+    assertFalse(tokenRequest.getUrl().contains("?o="));
+  }
+
+  // Verifies that browser OAuth on workspace, account, and unified hosts adds assume_group only to
+  // the authorization request. The discovered endpoints remain unchanged, and the authorization
+  // code exchange neither receives assume_group nor adds the historical o=<workspace-id> routing
+  // query parameter.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("allProfiles")
+  void externalBrowserForwardsGroupOnlyOnAuthorization(HostProfile p) throws IOException {
+    DatabricksConfig config =
+        profileConfig(p)
+            .setClientId("test-client")
+            .setClientSecret("test-secret")
+            .setGroupId("group-123")
+            .setAuthType("external-browser");
+    MappingHttpClient client = withOidc(httpClientFor(p), p);
+    config.setHttpClient(client);
+    config.resolve(emptyEnvironment());
+
+    OpenIDConnectEndpoints endpoints = config.getDatabricksOidcEndpoints();
+    OAuthClient oauthClient =
+        new OAuthClient.Builder()
+            .withHttpClient(client)
+            .withClientId(config.getClientId())
+            .withClientSecret(config.getClientSecret())
+            .withHost(config.getHost())
+            .withAccountId(config.getAccountId())
+            .withGroupId(config.getGroupId())
+            .withRedirectUrl(config.getEffectiveOAuthRedirectUrl())
+            .withScopes(config.getScopes())
+            .withOpenIDConnectEndpoints(endpoints)
+            .build();
+
+    Consent consent = oauthClient.initiateConsent();
+    assertEquals(p.authorizationEndpoint(), consent.getAuthUrl().split("\\?", 2)[0]);
+    assertTrue(consent.getAuthUrl().contains("assume_group=group-123"));
+    assertFalse(consent.getAuthUrl().contains("?o="));
+    assertEquals(p.tokenEndpoint(), consent.getTokenUrl());
+
+    Map<String, String> callback = new HashMap<>();
+    callback.put("code", "authorization-code");
+    callback.put("state", consent.getState());
+    consent.exchangeCallbackParameters(callback);
+
+    Request tokenRequest = client.singleRequest("POST", p.tokenPath());
+    assertTrue(tokenRequest.getBodyString().contains("grant_type=authorization_code"));
+    assertFalse(tokenRequest.getBodyString().contains("assume_group"));
+    assertFalse(tokenRequest.getUrl().contains("?o="));
   }
 
   // ---- File OIDC -------------------------------------------------------------
@@ -438,35 +529,6 @@ public class AuthProfilesTest {
     assertEquals(TEST_ACCOUNT_ID, config.getAccountId());
     if (p.kind != ProfileKind.ACCOUNT && p.kind != ProfileKind.UNIFIED) {
       assertEquals(TEST_WORKSPACE_ID, config.getWorkspaceId());
-    }
-  }
-
-  // ---- Minimal HttpClient fixture -------------------------------------------
-
-  /**
-   * Matches requests on {@code "METHOD path"} and returns a stubbed JSON body with HTTP 200. Every
-   * test must register a mapping for {@code GET /.well-known/databricks-config} (see {@link
-   * #httpClientFor(HostProfile)}); unmapped requests fail loudly with {@link IOException} so a
-   * missing fixture cannot silently fall through.
-   */
-  private static class MappingHttpClient implements HttpClient {
-    private final Map<String, String> mappings = new HashMap<>();
-
-    MappingHttpClient put(String key, String jsonBody) {
-      mappings.put(key, jsonBody);
-      return this;
-    }
-
-    @Override
-    public Response execute(Request in) throws IOException {
-      String rawUrl = in.getUrl();
-      URL url = new URL(rawUrl);
-      String key = in.getMethod() + " " + url.getPath();
-      String body = mappings.get(key);
-      if (body == null) {
-        throw new IOException("No mock for " + key + " (url=" + rawUrl + ")");
-      }
-      return new Response(body, 200, "OK", url);
     }
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/DatabricksConfigTest.java
@@ -180,6 +180,7 @@ public class DatabricksConfigTest {
             .setAuthType("oauth-m2m")
             .setClientId("my-client-id")
             .setClientSecret("my-client-secret")
+            .setGroupId("group-123")
             .setAccountId("account-id")
             .setHost("https://account.cloud.databricks.com");
     String workspaceHost = "https://workspace.cloud.databricks.com";
@@ -190,6 +191,7 @@ public class DatabricksConfigTest {
     assert newWorkspaceConfig.getAuthType().equals("oauth-m2m");
     assert newWorkspaceConfig.getClientId().equals("my-client-id");
     assert newWorkspaceConfig.getClientSecret().equals("my-client-secret");
+    assert newWorkspaceConfig.getGroupId().equals("group-123");
   }
 
   @Test
@@ -199,6 +201,7 @@ public class DatabricksConfigTest {
             .setAuthType("oauth-m2m")
             .setClientId("my-client-id")
             .setClientSecret("my-client-secret")
+            .setGroupId("group-123")
             .setAccountId("account-id")
             .setHost("https://account.cloud.databricks.com");
 
@@ -208,6 +211,7 @@ public class DatabricksConfigTest {
     assert newWorkspaceConfig.getAuthType().equals("oauth-m2m");
     assert newWorkspaceConfig.getClientId().equals("my-client-id");
     assert newWorkspaceConfig.getClientSecret().equals("my-client-secret");
+    assert newWorkspaceConfig.getGroupId().equals("group-123");
   }
 
   @Test
@@ -281,6 +285,7 @@ public class DatabricksConfigTest {
     env.put("DATABRICKS_OAUTH_BROWSER_AUTH_TIMEOUT", "30");
     env.put("DATABRICKS_DEBUG_TRUNCATE_BYTES", "100");
     env.put("DATABRICKS_RATE_LIMIT", "50");
+    env.put("DATABRICKS_GROUP_ID", "environment-group");
 
     DatabricksConfig config = new DatabricksConfig();
     config.resolve(new Environment(env, new ArrayList<>(), System.getProperty("os.name")));
@@ -288,6 +293,61 @@ public class DatabricksConfigTest {
     assertEquals(Duration.ofSeconds(30), config.getOAuthBrowserAuthTimeout());
     assertEquals(Integer.valueOf(100), config.getDebugTruncateBytes());
     assertEquals(Integer.valueOf(50), config.getRateLimit());
+    assertEquals("environment-group", config.getGroupId());
+  }
+
+  // Verifies that group ID follows the standard configuration precedence: code, environment, then
+  // profile.
+  @Test
+  public void testGroupIdCodeEnvironmentProfilePrecedence() {
+    Map<String, String> env = new HashMap<>();
+    env.put("HOME", TestOSUtils.resource("/testdata"));
+    Environment profileEnvironment =
+        new Environment(env, new ArrayList<>(), System.getProperty("os.name"));
+
+    DatabricksConfig fromProfile =
+        new DatabricksConfig()
+            .setProfile("group")
+            .setHttpClient(
+                request -> {
+                  throw new IOException("offline test");
+                });
+    fromProfile.resolve(profileEnvironment);
+    assertEquals("profile-group", fromProfile.getGroupId());
+
+    DatabricksConfig withoutGroup =
+        new DatabricksConfig()
+            .setProfile("scope-empty")
+            .setHttpClient(
+                request -> {
+                  throw new IOException("offline test");
+                });
+    withoutGroup.resolve(profileEnvironment);
+    assertNull(withoutGroup.getGroupId());
+
+    env.put("DATABRICKS_GROUP_ID", "environment-group");
+    Environment environmentOverride =
+        new Environment(env, new ArrayList<>(), System.getProperty("os.name"));
+    DatabricksConfig fromEnvironment =
+        new DatabricksConfig()
+            .setProfile("group")
+            .setHttpClient(
+                request -> {
+                  throw new IOException("offline test");
+                });
+    fromEnvironment.resolve(environmentOverride);
+    assertEquals("environment-group", fromEnvironment.getGroupId());
+
+    DatabricksConfig fromCode =
+        new DatabricksConfig()
+            .setProfile("group")
+            .setGroupId("code-group")
+            .setHttpClient(
+                request -> {
+                  throw new IOException("offline test");
+                });
+    fromCode.resolve(environmentOverride);
+    assertEquals("code-group", fromCode.getGroupId());
   }
 
   @Test

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/GroupDefaultCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/GroupDefaultCredentialsProviderTest.java
@@ -1,0 +1,45 @@
+package com.databricks.sdk.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.databricks.sdk.core.http.Request;
+import org.junit.jupiter.api.Test;
+
+class GroupDefaultCredentialsProviderTest {
+  // Verifies that the default chain skips an unsupported provider and reaches a group-aware M2M
+  // provider instead of using credentials for the unassumed identity.
+  @Test
+  void defaultChainContinuesAfterUnsupportedProvider() {
+    MappingHttpClient httpClient =
+        new MappingHttpClient()
+            .put("GET /.well-known/databricks-config", "{}")
+            .put(
+                "GET /oidc/.well-known/oauth-authorization-server",
+                "{\"token_endpoint\":\"https://workspace.example/oidc/v1/token\"}")
+            .put(
+                "POST /oidc/v1/token",
+                "{\"token_type\":\"Bearer\",\"access_token\":\"role-token\","
+                    + "\"expires_in\":3600}");
+
+    DatabricksConfig config =
+        new DatabricksConfig()
+            .setHost("https://workspace.example")
+            .setDiscoveryUrl(
+                "https://workspace.example/oidc/.well-known/oauth-authorization-server")
+            .setToken("normal-pat-must-not-be-used")
+            .setClientId("test-client")
+            .setClientSecret("test-secret")
+            .setGroupId("group-123");
+    config.setHttpClient(httpClient);
+
+    DefaultCredentialsProvider provider = new DefaultCredentialsProvider();
+    HeaderFactory headers = provider.configure(config);
+
+    assertEquals("Bearer role-token", headers.headers().get("Authorization"));
+    assertEquals("oauth-m2m", provider.authType());
+
+    Request tokenRequest = httpClient.singleRequest("POST", "/oidc/v1/token");
+    assertTrue(tokenRequest.getBodyString().contains("assume_group=group-123"));
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/MappingHttpClient.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/MappingHttpClient.java
@@ -1,0 +1,68 @@
+package com.databricks.sdk.core;
+
+import com.databricks.sdk.core.http.HttpClient;
+import com.databricks.sdk.core.http.Request;
+import com.databricks.sdk.core.http.Response;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Minimal HTTP fixture that matches requests on {@code "METHOD path"} and returns a stubbed JSON
+ * body with HTTP 200. Unmapped requests fail loudly so a missing fixture cannot silently fall
+ * through.
+ */
+class MappingHttpClient implements HttpClient {
+  private final Map<String, String> mappings = new HashMap<>();
+  private final List<Request> requests = new ArrayList<>();
+
+  MappingHttpClient put(String key, String jsonBody) {
+    mappings.put(key, jsonBody);
+    return this;
+  }
+
+  /**
+   * Returns the only recorded request with the given HTTP method and URL path. The host and query
+   * parameters are intentionally ignored so parameterized host-profile tests can inspect the
+   * request body independently of the endpoint host. Fails when no request or multiple requests
+   * match because either result would make the test assertion ambiguous.
+   */
+  Request singleRequest(String method, String path) {
+    Request match = null;
+    for (Request request : requests) {
+      try {
+        if (method.equals(request.getMethod())
+            && path.equals(new URL(request.getUrl()).getPath())) {
+          if (match != null) {
+            throw new AssertionError("Multiple requests matched " + method + " " + path);
+          }
+          match = request;
+        }
+      } catch (IOException e) {
+        throw new AssertionError("Invalid request URL", e);
+      }
+    }
+    if (match == null) {
+      throw new AssertionError("No request matched " + method + " " + path);
+    }
+    return match;
+  }
+
+  @Override
+  public Response execute(Request request) throws IOException {
+    requests.add(request);
+
+    String rawUrl = request.getUrl();
+    URL url = new URL(rawUrl);
+    String key = request.getMethod() + " " + url.getPath();
+    String body = mappings.get(key);
+    if (body == null) {
+      throw new IOException("No mock for " + key + " (url=" + rawUrl + ")");
+    }
+
+    return new Response(body, 200, "OK", url);
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UnsupportedGroupCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/UnsupportedGroupCredentialsProviderTest.java
@@ -1,0 +1,101 @@
+package com.databricks.sdk.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.databricks.sdk.core.oauth.AzureGithubOidcCredentialsProvider;
+import com.databricks.sdk.core.oauth.AzureServicePrincipalCredentialsProvider;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class UnsupportedGroupCredentialsProviderTest {
+  // Verifies that explicitly selecting an applicable provider without group support throws the
+  // existing SDK error type with an actionable message.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("unsupportedProviders")
+  void applicableUnsupportedProviderRejectsGroup(
+      String authType, CredentialsProvider provider, DatabricksConfig config) {
+    config.setGroupId("group-123").setAuthType(authType);
+
+    DatabricksException error =
+        assertThrows(DatabricksException.class, () -> provider.configure(config));
+
+    assertEquals(DatabricksException.class, error.getClass());
+    assertTrue(error.getMessage().contains(authType));
+    assertTrue(error.getMessage().contains("does not support group assumption"));
+  }
+
+  // Verifies that an applicable provider without group support returns null during automatic
+  // discovery, allowing the credential chain to continue to another provider.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("unsupportedProviders")
+  void automaticChainSkipsApplicableUnsupportedProvider(
+      String authType, CredentialsProvider provider, DatabricksConfig config) {
+    config.setGroupId("group-123").setAuthType(null);
+
+    assertNull(provider.configure(config));
+  }
+
+  private static Stream<Arguments> unsupportedProviders() {
+    String azureHost = "https://adb-123.4.azuredatabricks.net";
+    String gcpHost = "https://123.4.gcp.databricks.com";
+    return Stream.of(
+        Arguments.of(
+            "pat",
+            new PatCredentialsProvider(),
+            new DatabricksConfig()
+                .setHost("https://workspace.cloud.databricks.com")
+                .setToken("token")),
+        Arguments.of(
+            "basic",
+            new BasicCredentialsProvider(),
+            new DatabricksConfig()
+                .setHost("https://workspace.cloud.databricks.com")
+                .setUsername("user")
+                .setPassword("password")),
+        Arguments.of(
+            "databricks-cli",
+            new DatabricksCliCredentialsProvider(),
+            new DatabricksConfig()
+                .setHost("https://workspace.cloud.databricks.com")
+                .setAuthType("databricks-cli")),
+        Arguments.of(
+            "runtime",
+            new NotebookNativeCredentialsProvider(),
+            new DatabricksConfig().setAuthType("runtime")),
+        Arguments.of(
+            "azure-cli",
+            new AzureCliCredentialsProvider(),
+            new DatabricksConfig().setHost(azureHost)),
+        Arguments.of(
+            "azure-msi",
+            new AzureMsiCredentialsProvider(),
+            new DatabricksConfig().setHost(azureHost).setAzureUseMsi(true)),
+        Arguments.of(
+            "azure-client-secret",
+            new AzureServicePrincipalCredentialsProvider(),
+            new DatabricksConfig()
+                .setHost(azureHost)
+                .setAzureClientId("client")
+                .setAzureClientSecret("secret")),
+        Arguments.of(
+            "github-oidc-azure",
+            new AzureGithubOidcCredentialsProvider(),
+            new DatabricksConfig()
+                .setHost(azureHost)
+                .setAzureClientId("client")
+                .setAzureTenantId("tenant")),
+        Arguments.of(
+            "google-credentials",
+            new GoogleCredentialsCredentialsProvider(),
+            new DatabricksConfig().setHost(gcpHost).setGoogleCredentials("credentials")),
+        Arguments.of(
+            "google-id",
+            new GoogleIdCredentialsProvider(),
+            new DatabricksConfig().setHost(gcpHost).setGoogleServiceAccount("service-account")));
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSourceTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/DatabricksOAuthTokenSourceTest.java
@@ -4,17 +4,23 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.core.http.FormRequest;
 import com.databricks.sdk.core.http.HttpClient;
+import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.core.http.Response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
@@ -286,13 +292,12 @@ class DatabricksOAuthTokenSourceTest {
     }
   }
 
-  private static HttpClient createMockHttpClient(
-      FormRequest expectedRequest, int statusCode, String responseBody) {
+  private static HttpClient createMockHttpClient(FormRequest request, int status, String body) {
     try {
       HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
-      String statusMessage = statusCode == 200 ? "OK" : "Bad Request";
-      when(mockHttpClient.execute(expectedRequest))
-          .thenReturn(new Response(responseBody, statusCode, statusMessage, new URL(TEST_HOST)));
+      String statusMessage = status == 200 ? "OK" : "Bad Request";
+      when(mockHttpClient.execute(request))
+          .thenReturn(new Response(body, status, statusMessage, new URL(TEST_HOST)));
       return mockHttpClient;
     } catch (IOException e) {
       throw new RuntimeException("Failed to create mock HTTP client", e);
@@ -340,6 +345,140 @@ class DatabricksOAuthTokenSourceTest {
 
       // Verify correct audience was used
       verify(testCase.idTokenSource, atLeastOnce()).getIDToken(testCase.expectedAudience);
+    }
+  }
+
+  // Verifies that every workload identity token exchange sends the configured group to the token
+  // endpoint, rather than only the first exchange.
+  @Test
+  void everyTokenExchangeIncludesTheGroup() throws Exception {
+    RecordingClient httpClient = new RecordingClient(ignored -> tokenResponse("token"));
+
+    DatabricksOAuthTokenSource source =
+        builder(httpClient, "group-123").scopes(Collections.singletonList("all-apis")).build();
+
+    assertEquals("token", source.getToken().getAccessToken());
+    assertEquals("token", source.getToken().getAccessToken());
+    assertEquals(2, httpClient.requests.size());
+    assertAllRequestsContain(httpClient, "assume_group=group-123");
+  }
+
+  // Verifies that separate WIF clients for normal access and different groups each cache only
+  // their own access token.
+  @Test
+  void groupCachesAreIsolatedByClient() throws Exception {
+    RecordingClient httpClient =
+        new RecordingClient(
+            request -> {
+              String requestBody = request.getBodyString();
+              if (requestBody.contains("assume_group=group-a")) {
+                return tokenResponse("token-group-a");
+              }
+              if (requestBody.contains("assume_group=group-b")) {
+                return tokenResponse("token-group-b");
+              }
+              return tokenResponse("token-normal");
+            });
+
+    assertCachedToken(httpClient, null, "Bearer token-normal");
+    assertCachedToken(httpClient, "group-a", "Bearer token-group-a");
+    assertCachedToken(httpClient, "group-b", "Bearer token-group-b");
+
+    assertEquals(3, httpClient.requests.size());
+  }
+
+  // Verifies that adding a group does not wrap or otherwise change errors returned by the token
+  // endpoint.
+  @Test
+  void groupServerFailureIsReturnedNormally() throws Exception {
+    RecordingClient httpClient =
+        new RecordingClient(
+            ignored ->
+                new Response(
+                    "{\"error\":\"invalid_request\",\"error_description\":\"assume_group is not"
+                        + " supported at the account level\"}",
+                    400,
+                    "Bad Request",
+                    new URL(TEST_HOST)));
+
+    DatabricksOAuthTokenSource source = builder(httpClient, "group-123").build();
+
+    DatabricksException error = assertThrows(DatabricksException.class, source::getToken);
+    assertEquals(DatabricksException.class, error.getClass());
+    assertEquals(
+        "Token request failed with error: invalid_request - "
+            + "assume_group is not supported at the account level",
+        error.getMessage());
+    assertNull(error.getCause());
+    assertEquals(1, httpClient.requests.size());
+  }
+
+  /** Verifies that every request recorded by the client contains the expected form field. */
+  private static void assertAllRequestsContain(RecordingClient client, String field) {
+    for (Request request : client.requests) {
+      assertTrue(request.getBodyString().contains(field));
+    }
+  }
+
+  /** Creates a token source builder with the fixed WIF configuration used by these tests. */
+  private static DatabricksOAuthTokenSource.Builder builder(HttpClient client, String groupId) {
+    try {
+      OpenIDConnectEndpoints endpoints =
+          new OpenIDConnectEndpoints(TEST_TOKEN_ENDPOINT, TEST_AUTHORIZATION_ENDPOINT);
+      IDTokenSource idTokenSource = mock(IDTokenSource.class);
+      when(idTokenSource.getIDToken(any())).thenReturn(new IDToken(TEST_ID_TOKEN));
+
+      return new DatabricksOAuthTokenSource.Builder(
+              TEST_CLIENT_ID, TEST_HOST, endpoints, idTokenSource, client)
+          .groupId(groupId);
+    } catch (MalformedURLException e) {
+      throw new RuntimeException("Failed to create test OIDC endpoints", e);
+    }
+  }
+
+  /** Creates a successful OAuth response containing the requested access token. */
+  private static Response tokenResponse(String token) throws MalformedURLException {
+    return new Response(
+        String.format(
+            "{\"access_token\":\"%s\",\"token_type\":\"Bearer\",\"expires_in\":3600}", token),
+        200,
+        "OK",
+        new URL(TEST_HOST));
+  }
+
+  /** Verifies that one client fetches its expected token once and then reuses the cached token. */
+  private static void assertCachedToken(RecordingClient client, String group, String header) {
+    DatabricksOAuthTokenSource source = builder(client, group).build();
+    TokenSourceCredentialsProvider provider =
+        new TokenSourceCredentialsProvider(source, "test-oidc");
+    OAuthHeaderFactory headers =
+        provider.configure(new DatabricksConfig().setDisableAsyncTokenRefresh(true));
+
+    assertEquals(header, headers.headers().get("Authorization"));
+    assertEquals(header, headers.headers().get("Authorization"));
+  }
+
+  /** Produces an HTTP response for a recorded token request. */
+  @FunctionalInterface
+  private interface TokenResponseFactory {
+    Response create(Request request) throws IOException;
+  }
+
+  /** Records token requests and delegates response creation to a test-specific factory. */
+  private static class RecordingClient implements HttpClient {
+    private final List<Request> requests = new ArrayList<>();
+    private final TokenResponseFactory responseFactory;
+
+    /** Creates a recording client that uses the supplied factory for every response. */
+    private RecordingClient(TokenResponseFactory responseFactory) {
+      this.responseFactory = responseFactory;
+    }
+
+    /** Records the request before returning the response selected by the test. */
+    @Override
+    public Response execute(Request request) throws IOException {
+      requests.add(request);
+      return responseFactory.create(request);
     }
   }
 }

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/ExternalBrowserCredentialsProviderTest.java
@@ -41,6 +41,7 @@ public class ExternalBrowserCredentialsProviderTest {
               .setAuthType("external-browser")
               .setHost(fixtures.getUrl())
               .setClientId("test-client-id")
+              .setGroupId("group-123")
               .setHttpClient(new CommonsHttpClient.Builder().withTimeoutSeconds(30).build());
       config.resolve();
 
@@ -53,6 +54,7 @@ public class ExternalBrowserCredentialsProviderTest {
               .withClientId(config.getClientId())
               .withClientSecret(config.getClientSecret())
               .withHost(config.getHost())
+              .withGroupId(config.getGroupId())
               .withOpenIDConnectEndpoints(config.getDatabricksOidcEndpoints())
               .withRedirectUrl(config.getEffectiveOAuthRedirectUrl())
               .withScopes(config.getScopes())
@@ -68,6 +70,8 @@ public class ExternalBrowserCredentialsProviderTest {
       assertTrue(authUrl.contains("client_id=test-client-id"));
       assertTrue(authUrl.contains("redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback"));
       assertTrue(authUrl.contains("scope=all-apis"));
+      assertTrue(authUrl.contains("assume_group=group-123"));
+      assertFalse(testConsent.getTokenUrl().contains("assume_group"));
     }
   }
 
@@ -117,6 +121,9 @@ public class ExternalBrowserCredentialsProviderTest {
       assertTrue(authUrl.contains("client_id=test-client-id"));
       assertTrue(authUrl.contains("redirect_uri=http%3A%2F%2Flocalhost%3A8010"));
       assertTrue(authUrl.contains("scope=sql"));
+      // Verifies that existing browser authorization requests remain unchanged when no group is
+      // configured.
+      assertFalse(authUrl.contains("assume_group"));
     }
   }
 
@@ -420,6 +427,7 @@ public class ExternalBrowserCredentialsProviderTest {
             .setAuthType("external-browser")
             .setHost("https://test.databricks.com")
             .setClientId("test-client-id")
+            .setGroupId("group-123")
             .setHttpClient(mockHttpClient);
 
     // We need to provide OIDC endpoints for token refresh
@@ -447,7 +455,10 @@ public class ExternalBrowserCredentialsProviderTest {
     Mockito.verify(mockTokenCache, Mockito.times(1)).load();
 
     // Verify HTTP call was made to refresh the token
-    Mockito.verify(mockHttpClient, Mockito.times(1)).execute(any(Request.class));
+    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+    Mockito.verify(mockHttpClient, Mockito.times(1)).execute(requestCaptor.capture());
+    assertTrue(requestCaptor.getValue().getBodyString().contains("grant_type=refresh_token"));
+    assertFalse(requestCaptor.getValue().getBodyString().contains("assume_group"));
 
     // Verify performBrowserAuth was NOT called since refresh succeeded
     Mockito.verify(provider, Mockito.never())

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/FileTokenCacheTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/FileTokenCacheTest.java
@@ -66,6 +66,26 @@ public class FileTokenCacheTest {
         "Should throw NullPointerException for null path");
   }
 
+  // Verifies that existing non-group cache paths remain compatible while each group receives an
+  // isolated cache entry.
+  @Test
+  void testGroupCacheIsolationAndNoGroupCompatibility() {
+    Path legacyPath = TokenCacheUtils.getCacheFilePath(TEST_HOST, TEST_CLIENT_ID, TEST_SCOPES);
+    Path nullGroupPath =
+        TokenCacheUtils.getCacheFilePath(TEST_HOST, TEST_CLIENT_ID, TEST_SCOPES, null);
+    Path emptyGroupPath =
+        TokenCacheUtils.getCacheFilePath(TEST_HOST, TEST_CLIENT_ID, TEST_SCOPES, "");
+    Path groupAPath =
+        TokenCacheUtils.getCacheFilePath(TEST_HOST, TEST_CLIENT_ID, TEST_SCOPES, "group-a");
+    Path groupBPath =
+        TokenCacheUtils.getCacheFilePath(TEST_HOST, TEST_CLIENT_ID, TEST_SCOPES, "group-b");
+
+    assertEquals(legacyPath, nullGroupPath);
+    assertEquals(legacyPath, emptyGroupPath);
+    assertNotEquals(legacyPath, groupAPath);
+    assertNotEquals(groupAPath, groupBPath);
+  }
+
   @Test
   void testOverwriteToken() {
     // Given two tokens saved in sequence

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/OAuthM2MServicePrincipalCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/OAuthM2MServicePrincipalCredentialsProviderTest.java
@@ -1,0 +1,167 @@
+package com.databricks.sdk.core.oauth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.DatabricksException;
+import com.databricks.sdk.core.http.HttpClient;
+import com.databricks.sdk.core.http.Request;
+import com.databricks.sdk.core.http.Response;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OAuthM2MServicePrincipalCredentialsProviderTest {
+  // Verifies that M2M includes assume_group every time an expired client-credentials token is
+  // minted, rather than only on the initial request.
+  @Test
+  void everyTokenMintIncludesTheGroup() {
+    TokenHttpClient httpClient =
+        new TokenHttpClient(
+            (request, requestNumber) ->
+                new Response(
+                    String.format(
+                        "{\"access_token\":\"token-%d\",\"token_type\":\"Bearer\",\"expires_in\":0}",
+                        requestNumber),
+                    200,
+                    "OK",
+                    new URL(request.getUrl())));
+
+    DatabricksConfig config =
+        new DatabricksConfig()
+            .setHost("https://accounts.cloud.databricks.com")
+            .setAccountId("account-123")
+            .setDiscoveryUrl("https://accounts.cloud.databricks.com/discovery")
+            .setClientId("client-id")
+            .setClientSecret("client-secret")
+            .setGroupId("group-123")
+            .setHttpClient(httpClient)
+            .setDisableAsyncTokenRefresh(true);
+
+    OAuthHeaderFactory headers =
+        new OAuthM2MServicePrincipalCredentialsProvider().configure(config);
+
+    assertEquals("Bearer token-1", headers.headers().get("Authorization"));
+    assertEquals("Bearer token-2", headers.headers().get("Authorization"));
+    assertEquals(2, httpClient.tokenBodies.size());
+    for (String body : httpClient.tokenBodies) {
+      assertTrue(body.contains("grant_type=client_credentials"));
+      assertTrue(body.contains("assume_group=group-123"));
+      assertFalse(body.contains("refresh_token"));
+    }
+  }
+
+  // Verifies that a server rejection is returned after one grouped M2M request and is never
+  // retried without assume_group.
+  @Test
+  void groupServerRejectionDoesNotFallback() {
+    TokenHttpClient httpClient =
+        new TokenHttpClient(
+            (request, ignoredRequestNumber) ->
+                new Response(
+                    "{\"error\":\"invalid_target\"}",
+                    400,
+                    "Bad Request",
+                    new URL(request.getUrl())));
+
+    DatabricksConfig config = config(httpClient, "group-123");
+
+    OAuthHeaderFactory headers =
+        new OAuthM2MServicePrincipalCredentialsProvider().configure(config);
+
+    assertThrows(DatabricksException.class, headers::headers);
+    assertEquals(1, httpClient.tokenBodies.size());
+    assertTrue(httpClient.tokenBodies.get(0).contains("assume_group=group-123"));
+  }
+
+  // Verifies that separate M2M clients for normal access and different groups each cache only
+  // their own access token.
+  @Test
+  void cachesAreIsolatedByClient() {
+    TokenHttpClient httpClient =
+        new TokenHttpClient(
+            (request, ignoredRequestNumber) -> {
+              String body = request.getBodyString();
+              String token = "token-normal";
+
+              if (body.contains("assume_group=group-a")) {
+                token = "token-group-a";
+              } else if (body.contains("assume_group=group-b")) {
+                token = "token-group-b";
+              }
+
+              return new Response(
+                  String.format(
+                      "{\"access_token\":\"%s\",\"token_type\":\"Bearer\",\"expires_in\":3600}",
+                      token),
+                  200,
+                  "OK",
+                  new URL(request.getUrl()));
+            });
+
+    String[][] testCases = {
+      {null, "Bearer token-normal"},
+      {"group-a", "Bearer token-group-a"},
+      {"group-b", "Bearer token-group-b"}
+    };
+
+    for (String[] testCase : testCases) {
+      OAuthHeaderFactory headers =
+          new OAuthM2MServicePrincipalCredentialsProvider()
+              .configure(config(httpClient, testCase[0]));
+
+      assertEquals(testCase[1], headers.headers().get("Authorization"));
+      assertEquals(testCase[1], headers.headers().get("Authorization"));
+    }
+
+    assertEquals(testCases.length, httpClient.tokenBodies.size());
+  }
+
+  /** Creates a fixed M2M configuration using the supplied HTTP client and optional group. */
+  private static DatabricksConfig config(HttpClient httpClient, String groupId) {
+    return new DatabricksConfig()
+        .setHost("https://accounts.cloud.databricks.com")
+        .setAccountId("account-123")
+        .setDiscoveryUrl("https://accounts.cloud.databricks.com/discovery")
+        .setClientId("client-id")
+        .setClientSecret("client-secret")
+        .setGroupId(groupId)
+        .setHttpClient(httpClient)
+        .setDisableAsyncTokenRefresh(true);
+  }
+
+  /** Produces the token endpoint response for a recorded token request. */
+  @FunctionalInterface
+  private interface TokenResponder {
+    Response respond(Request request, int requestNumber) throws IOException;
+  }
+
+  /** Handles discovery uniformly while allowing each test to define token endpoint behavior. */
+  private static class TokenHttpClient implements HttpClient {
+    final List<String> tokenBodies = new ArrayList<>();
+    private final TokenResponder tokenResponder;
+
+    /** Creates a client using the supplied behavior for token endpoint requests. */
+    TokenHttpClient(TokenResponder tokenResponder) {
+      this.tokenResponder = tokenResponder;
+    }
+
+    /** Returns OIDC discovery metadata for GET requests and records every token request body. */
+    @Override
+    public Response execute(Request request) throws IOException {
+      if (request.getMethod().equals("GET")) {
+        return new Response(
+            "{\"token_endpoint\":\"https://accounts.cloud.databricks.com/oidc/accounts/account-123/v1/token\","
+                + "\"authorization_endpoint\":\"https://accounts.cloud.databricks.com/oidc/accounts/account-123/v1/authorize\"}",
+            200,
+            "OK",
+            new URL(request.getUrl()));
+      }
+
+      tokenBodies.add(request.getBodyString());
+      return tokenResponder.respond(request, tokenBodies.size());
+    }
+  }
+}

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/TokenSourceCredentialsProviderTest.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/oauth/TokenSourceCredentialsProviderTest.java
@@ -9,6 +9,7 @@ import com.databricks.sdk.core.HeaderFactory;
 import java.time.Instant;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -43,6 +44,19 @@ class TokenSourceCredentialsProviderTest {
 
     verify(mockTokenSource, atLeastOnce()).getToken();
     assertEquals(TEST_AUTH_TYPE, provider.authType());
+  }
+
+  // Verifies that configuring a group does not change how an ordinary token-source failure is
+  // handled by the credential chain.
+  @Test
+  void groupDoesNotChangeTokenFailureHandling() {
+    TokenSource tokenSource = mock(TokenSource.class);
+    when(tokenSource.getToken()).thenThrow(new DatabricksException("Token retrieval failed"));
+
+    provider = new TokenSourceCredentialsProvider(tokenSource, TEST_AUTH_TYPE);
+    DatabricksConfig config = new DatabricksConfig().setGroupId("group-123");
+
+    assertNull(provider.configure(config));
   }
 
   /** Provides test scenarios */

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/DatabricksWifIT.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/DatabricksWifIT.java
@@ -1,15 +1,27 @@
 package com.databricks.sdk.integration;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.databricks.sdk.AccountClient;
 import com.databricks.sdk.WorkspaceClient;
 import com.databricks.sdk.core.DatabricksConfig;
+import com.databricks.sdk.core.DatabricksException;
 import com.databricks.sdk.integration.framework.EnvContext;
 import com.databricks.sdk.integration.framework.EnvOrSkip;
 import com.databricks.sdk.integration.framework.EnvTest;
+import com.databricks.sdk.integration.framework.NameUtils;
+import com.databricks.sdk.integration.framework.ResourceWithCleanup;
 import com.databricks.sdk.service.iam.*;
 import com.databricks.sdk.service.oauth2.CreateServicePrincipalFederationPolicyRequest;
+import com.databricks.sdk.service.oauth2.DeleteServicePrincipalFederationPolicyRequest;
 import com.databricks.sdk.service.oauth2.FederationPolicy;
 import com.databricks.sdk.service.oauth2.OidcFederationPolicy;
+import com.databricks.sdk.service.workspace.Import;
+import com.databricks.sdk.service.workspace.ImportFormat;
+import com.databricks.sdk.service.workspace.Language;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -18,6 +30,196 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @EnvContext("ucacct")
 @ExtendWith(EnvTest.class)
 public class DatabricksWifIT {
+  /** Creates the GitHub OIDC configuration shared by the normal and group-assuming clients. */
+  private static DatabricksConfig wifConfig(String workspaceUrl, String clientId) {
+    return new DatabricksConfig()
+        .setHost(workspaceUrl)
+        .setClientId(clientId)
+        .setAuthType("github-oidc")
+        .setTokenAudience("https://github.com/databricks-eng");
+  }
+
+  // Verifies that WIF can assume a group and use permissions granted only to that group, while the
+  // same service principal without group assumption remains denied.
+  @Test
+  void workspaceGroupAssumption(
+      AccountClient a,
+      @EnvOrSkip("TEST_WORKSPACE_ID") String workspaceIdValue,
+      @EnvOrSkip("TEST_WORKSPACE_URL") String workspaceUrl,
+      @EnvOrSkip("ACTIONS_ID_TOKEN_REQUEST_URL") String ignoredOidcRequestUrl) {
+    // Use the GitHub Actions OIDC environment and an account administrator to arrange the test.
+    long workspaceId = Long.parseLong(workspaceIdValue);
+
+    // Create an administrator client for workspace resources and permissions.
+    WorkspaceClient workspaceAdmin =
+        new WorkspaceClient(new DatabricksConfig().setHost(workspaceUrl));
+
+    // Create the service principal whose normal and group-based WIF access will be tested.
+    AccountServicePrincipal servicePrincipal =
+        a.servicePrincipalsV2()
+            .create(
+                new CreateAccountServicePrincipalRequest()
+                    .setActive(true)
+                    .setDisplayName(NameUtils.uniqueName("java-sdk-wif-role-sp")));
+    long servicePrincipalId = Long.parseLong(servicePrincipal.getId());
+
+    try (ResourceWithCleanup ignoredServicePrincipal =
+        new ResourceWithCleanup(() -> a.servicePrincipalsV2().delete(servicePrincipal.getId()))) {
+      // Give the service principal basic workspace access without notebook access.
+      a.workspaceAssignment()
+          .update(
+              new UpdateWorkspaceAssignments()
+                  .setWorkspaceId(workspaceId)
+                  .setPrincipalId(servicePrincipalId)
+                  .setPermissions(Collections.singleton(WorkspacePermission.USER)));
+
+      try (ResourceWithCleanup ignoredServicePrincipalAssignment =
+          new ResourceWithCleanup(
+              () ->
+                  a.workspaceAssignment()
+                      .delete(
+                          new DeleteWorkspaceAssignmentRequest()
+                              .setWorkspaceId(workspaceId)
+                              .setPrincipalId(servicePrincipalId)))) {
+        // Create the group that represents the temporary workspace role.
+        AccountGroup group =
+            a.groupsV2()
+                .create(
+                    new CreateAccountGroupRequest()
+                        .setDisplayName(NameUtils.uniqueName("java-sdk-wif-role-group")));
+        long groupId = Long.parseLong(group.getId());
+
+        try (ResourceWithCleanup ignoredGroup =
+            new ResourceWithCleanup(() -> a.groupsV2().delete(group.getId()))) {
+          // Assign the group to the workspace so it can receive workspace permissions.
+          a.workspaceAssignment()
+              .update(
+                  new UpdateWorkspaceAssignments()
+                      .setWorkspaceId(workspaceId)
+                      .setPrincipalId(groupId)
+                      .setPermissions(Collections.singleton(WorkspacePermission.USER)));
+
+          try (ResourceWithCleanup ignoredGroupAssignment =
+              new ResourceWithCleanup(
+                  () ->
+                      a.workspaceAssignment()
+                          .delete(
+                              new DeleteWorkspaceAssignmentRequest()
+                                  .setWorkspaceId(workspaceId)
+                                  .setPrincipalId(groupId)))) {
+            // Grant the service principal permission to assume the group.
+            String ruleSetName =
+                String.format(
+                    "accounts/%s/groups/%s/ruleSets/default",
+                    a.config().getAccountId(), group.getId());
+            RuleSetResponse ruleSet = a.accessControl().getRuleSet(ruleSetName, "");
+            ArrayList<GrantRule> grantRules =
+                ruleSet.getGrantRules() == null
+                    ? new ArrayList<>()
+                    : new ArrayList<>(ruleSet.getGrantRules());
+            grantRules.add(
+                new GrantRule()
+                    .setPrincipals(
+                        Collections.singleton(
+                            "servicePrincipals/" + servicePrincipal.getApplicationId()))
+                    .setRole("roles/group.assumer"));
+            a.accessControl()
+                .updateRuleSet(
+                    new UpdateRuleSetRequest()
+                        .setName(ruleSetName)
+                        .setRuleSet(
+                            new RuleSetUpdateRequest()
+                                .setName(ruleSetName)
+                                .setEtag(ruleSet.getEtag())
+                                .setGrantRules(grantRules)));
+
+            // Trust this repository's GitHub OIDC identity to authenticate as the service
+            // principal.
+            OidcFederationPolicy oidcPolicy =
+                new OidcFederationPolicy()
+                    .setIssuer("https://token.actions.githubusercontent.com")
+                    .setSubject(
+                        "repo:databricks-eng/eng-dev-ecosystem:environment:integration-tests")
+                    .setAudiences(Collections.singleton("https://github.com/databricks-eng"));
+            FederationPolicy federationPolicy =
+                a.servicePrincipalFederationPolicy()
+                    .create(
+                        new CreateServicePrincipalFederationPolicyRequest()
+                            .setServicePrincipalId(servicePrincipalId)
+                            .setPolicy(new FederationPolicy().setOidcPolicy(oidcPolicy)));
+
+            try (ResourceWithCleanup ignoredFederationPolicy =
+                new ResourceWithCleanup(
+                    () ->
+                        a.servicePrincipalFederationPolicy()
+                            .delete(
+                                new DeleteServicePrincipalFederationPolicyRequest()
+                                    .setServicePrincipalId(servicePrincipalId)
+                                    .setPolicyId(federationPolicy.getUid())))) {
+              // Create a temporary notebook that distinguishes normal access from group access.
+              String adminUserName = workspaceAdmin.currentUser().me(new MeRequest()).getUserName();
+              String notebookPath =
+                  "/Users/"
+                      + adminUserName
+                      + "/"
+                      + NameUtils.uniqueName("java-sdk-wif-role-notebook");
+              workspaceAdmin
+                  .workspace()
+                  .importContent(
+                      new Import()
+                          .setPath(notebookPath)
+                          .setOverwrite(true)
+                          .setFormat(ImportFormat.SOURCE)
+                          .setLanguage(Language.PYTHON)
+                          .setContent(
+                              Base64.getEncoder()
+                                  .encodeToString("print(1)".getBytes(StandardCharsets.UTF_8))));
+
+              try (ResourceWithCleanup ignoredNotebook =
+                  new ResourceWithCleanup(
+                      () ->
+                          workspaceAdmin
+                              .workspace()
+                              .delete(
+                                  new com.databricks.sdk.service.workspace.Delete()
+                                      .setPath(notebookPath)))) {
+                // Give only the group permission to read the notebook.
+                Long notebookId = workspaceAdmin.workspace().getStatus(notebookPath).getObjectId();
+                workspaceAdmin
+                    .permissions()
+                    .update(
+                        new UpdateObjectPermissions()
+                            .setRequestObjectType("notebooks")
+                            .setRequestObjectId(String.valueOf(notebookId))
+                            .setAccessControlList(
+                                Collections.singleton(
+                                    new AccessControlRequest()
+                                        .setGroupName(group.getDisplayName())
+                                        .setPermissionLevel(PermissionLevel.CAN_READ))));
+
+                // Authenticate with the group and verify that its notebook permission is usable.
+                WorkspaceClient roleClient =
+                    new WorkspaceClient(
+                        wifConfig(workspaceUrl, servicePrincipal.getApplicationId())
+                            .setGroupId(group.getId()));
+                roleClient.workspace().getStatus(notebookPath);
+
+                // Authenticate normally as the same service principal and verify that access is
+                // denied.
+                WorkspaceClient normalClient =
+                    new WorkspaceClient(
+                        wifConfig(workspaceUrl, servicePrincipal.getApplicationId()));
+                assertThrows(
+                    DatabricksException.class,
+                    () -> normalClient.workspace().getStatus(notebookPath));
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   // This test cannot run on local machines. We use ACTIONS_ID_TOKEN_REQUEST_URL
   // to determine whether we are running in the GitHub Actions,
   // and we skip the test if we are not.

--- a/databricks-sdk-java/src/test/resources/testdata/.databrickscfg
+++ b/databricks-sdk-java/src/test/resources/testdata/.databrickscfg
@@ -50,3 +50,7 @@ scopes = clusters:read
 [scope-multiple]
 host = https://example.cloud.databricks.com
 scopes = clusters, jobs, pipelines, iam:read, files:read, mlflow, model-serving:read
+
+[group]
+host = https://example.cloud.databricks.com
+group_id = profile-group


### PR DESCRIPTION
## Summary

Adds an end-to-end integration test for workload identity federation group assumption.

The test creates a service principal and group, grants the service principal permission to assume the group, and verifies that:

- A WIF client using group_id can read a notebook granted only to the group.
- The same service principal without group assumption remains denied.

This is PR 3 of 3 and is stacked on #899.

## Testing

- Integration test sources compile
- Spotless and repository push checks

The integration test requires the existing CI environment and credentials to run.

NO_CHANGELOG=true